### PR TITLE
feat(AndroidLyric): 新增本地 TTML 歌词目录扫描

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     implementation "androidx.media3:media3-exoplayer:1.8.0"
     implementation "androidx.media3:media3-session:1.8.0"
     implementation "androidx.media:media:1.7.0"
+    implementation "androidx.documentfile:documentfile:1.1.0"
     implementation project(':capacitor-android')
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/android/app/src/main/java/top/imsyy/splayer/android/MainActivity.java
+++ b/android/app/src/main/java/top/imsyy/splayer/android/MainActivity.java
@@ -7,12 +7,14 @@ import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
 import com.getcapacitor.BridgeActivity;
+import top.imsyy.splayer.android.lyric.AndroidLocalLyricPlugin;
 import top.imsyy.splayer.android.playback.AndroidNativePlaybackPlugin;
 
 public class MainActivity extends BridgeActivity {
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     registerPlugin(AndroidNativePlaybackPlugin.class);
+    registerPlugin(AndroidLocalLyricPlugin.class);
     super.onCreate(savedInstanceState);
     applyImmersiveMode();
   }

--- a/android/app/src/main/java/top/imsyy/splayer/android/lyric/AndroidLocalLyricPlugin.java
+++ b/android/app/src/main/java/top/imsyy/splayer/android/lyric/AndroidLocalLyricPlugin.java
@@ -1,0 +1,317 @@
+package top.imsyy.splayer.android.lyric;
+
+import android.content.ContentResolver;
+import android.content.Intent;
+import android.net.Uri;
+import androidx.activity.result.ActivityResult;
+import androidx.annotation.Nullable;
+import androidx.documentfile.provider.DocumentFile;
+import com.getcapacitor.JSArray;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.ActivityCallback;
+import com.getcapacitor.annotation.CapacitorPlugin;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+@CapacitorPlugin(name = "AndroidLocalLyric")
+public class AndroidLocalLyricPlugin extends Plugin {
+  private static final Pattern AMLL_META_PATTERN =
+      Pattern.compile("<\\s*amll:meta\\b[^>]*>", Pattern.CASE_INSENSITIVE);
+  private static final int READ_FLAGS =
+      Intent.FLAG_GRANT_READ_URI_PERMISSION
+          | Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
+          | Intent.FLAG_GRANT_PREFIX_URI_PERMISSION;
+
+  private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+  @Override
+  protected void handleOnDestroy() {
+    executor.shutdownNow();
+  }
+
+  @PluginMethod
+  public void pickLyricDirectory(PluginCall call) {
+    if (getActivity() == null) {
+      call.reject("Activity unavailable");
+      return;
+    }
+
+    Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+    intent.addFlags(READ_FLAGS);
+    startActivityForResult(call, intent, "onPickLyricDirectoryResult");
+  }
+
+  @ActivityCallback
+  private void onPickLyricDirectoryResult(@Nullable PluginCall call, ActivityResult result) {
+    if (call == null) return;
+
+    Intent data = result.getData();
+    Uri uri = data == null ? null : data.getData();
+    if (uri == null) {
+      JSObject cancelled = new JSObject();
+      cancelled.put("cancelled", true);
+      call.resolve(cancelled);
+      return;
+    }
+
+    try {
+      int flags = data.getFlags() & Intent.FLAG_GRANT_READ_URI_PERMISSION;
+      if (flags == 0) flags = Intent.FLAG_GRANT_READ_URI_PERMISSION;
+      getContext().getContentResolver().takePersistableUriPermission(uri, flags);
+    } catch (SecurityException error) {
+      call.reject("LYRIC_DIRECTORY_PERMISSION_FAILED", error);
+      return;
+    }
+
+    DocumentFile directory = DocumentFile.fromTreeUri(getContext(), uri);
+    JSObject response = new JSObject();
+    response.put("cancelled", false);
+    response.put("uri", uri.toString());
+    response.put("name", safeName(directory, uri));
+    call.resolve(response);
+  }
+
+  @PluginMethod
+  public void scanLyricDirectories(PluginCall call) {
+    JSArray directories = call.getArray("directories");
+    if (directories == null) {
+      call.reject("directories is required");
+      return;
+    }
+
+    executor.execute(
+        () -> {
+          ScanAccumulator accumulator = new ScanAccumulator();
+          for (int i = 0; i < directories.length(); i++) {
+            try {
+              JSONObject item = directories.getJSONObject(i);
+              String uriText = item.optString("uri", "");
+              if (uriText.isEmpty()) {
+                accumulator.addFailure("", "", "EMPTY_DIRECTORY_URI", "");
+                continue;
+              }
+
+              Uri uri = Uri.parse(uriText);
+              DirectoryInfo directoryInfo = new DirectoryInfo(uriText, item.optString("name", ""));
+              DocumentFile directory = DocumentFile.fromTreeUri(getContext(), uri);
+              if (directory == null || !directory.exists() || !directory.canRead()) {
+                accumulator.addFailure(uriText, directoryInfo.name, "DIRECTORY_UNREADABLE", uriText);
+                continue;
+              }
+
+              scanDirectory(directory, directoryInfo, accumulator);
+            } catch (JSONException error) {
+              accumulator.addFailure("", "", "INVALID_DIRECTORY_PAYLOAD", "");
+            } catch (SecurityException error) {
+              accumulator.addFailure("", "", "DIRECTORY_PERMISSION_EXPIRED", "");
+            }
+          }
+          call.resolve(accumulator.toJSObject());
+        });
+  }
+
+  @PluginMethod
+  public void readLyricFile(PluginCall call) {
+    String uriText = call.getString("uri", "");
+    if (uriText.isEmpty()) {
+      call.reject("uri is required");
+      return;
+    }
+
+    executor.execute(
+        () -> {
+          try {
+            JSObject response = new JSObject();
+            response.put("content", readText(Uri.parse(uriText)));
+            call.resolve(response);
+          } catch (SecurityException error) {
+            call.reject("LYRIC_FILE_PERMISSION_EXPIRED", error);
+          } catch (Exception error) {
+            call.reject("LYRIC_FILE_READ_FAILED", error);
+          }
+        });
+  }
+
+  private void scanDirectory(
+      DocumentFile directory, DirectoryInfo directoryInfo, ScanAccumulator accumulator) {
+    DocumentFile[] children;
+    try {
+      children = directory.listFiles();
+    } catch (SecurityException error) {
+      accumulator.addFailure(
+          directory.getUri().toString(), directory.getName(), "DIRECTORY_PERMISSION_EXPIRED",
+          directoryInfo.uri);
+      return;
+    }
+
+    for (DocumentFile child : children) {
+      if (child.isDirectory()) {
+        scanDirectory(child, directoryInfo, accumulator);
+        continue;
+      }
+
+      if (!child.isFile()) continue;
+      String name = child.getName();
+      if (name == null || !name.toLowerCase().endsWith(".ttml")) continue;
+
+      accumulator.totalFiles++;
+      String fileUri = child.getUri().toString();
+      try {
+        String content = readText(child.getUri());
+        String ncmMusicId = extractNcmMusicId(content);
+        if (ncmMusicId == null || ncmMusicId.isEmpty()) continue;
+
+        accumulator.matchedFiles++;
+        accumulator.putIndex(
+            ncmMusicId,
+            new AndroidLyricIndexEntry(
+                fileUri, name, Math.max(child.lastModified(), 0L), directoryInfo.uri));
+      } catch (SecurityException error) {
+        accumulator.failedFiles++;
+        accumulator.addFailure(fileUri, name, "FILE_PERMISSION_EXPIRED", directoryInfo.uri);
+      } catch (Exception error) {
+        accumulator.failedFiles++;
+        accumulator.addFailure(fileUri, name, "FILE_READ_FAILED", directoryInfo.uri);
+      }
+    }
+  }
+
+  private String readText(Uri uri) throws IOException {
+    ContentResolver resolver = getContext().getContentResolver();
+    try (InputStream input = resolver.openInputStream(uri)) {
+      if (input == null) throw new IOException("Input stream unavailable");
+      try (BufferedReader reader =
+          new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
+        StringBuilder builder = new StringBuilder();
+        char[] buffer = new char[8192];
+        int read;
+        while ((read = reader.read(buffer)) != -1) {
+          builder.append(buffer, 0, read);
+        }
+        return builder.toString();
+      }
+    }
+  }
+
+  @Nullable
+  private String extractNcmMusicId(String ttml) {
+    Matcher metaMatcher = AMLL_META_PATTERN.matcher(ttml);
+    while (metaMatcher.find()) {
+      String tag = metaMatcher.group();
+      String key = readAttribute(tag, "key");
+      if (!"ncmMusicId".equals(key)) continue;
+      String value = readAttribute(tag, "value");
+      return value == null ? null : value.trim();
+    }
+    return null;
+  }
+
+  @Nullable
+  private String readAttribute(String tag, String name) {
+    Pattern attrPattern =
+        Pattern.compile("\\b" + Pattern.quote(name) + "\\s*=\\s*(['\"])(.*?)\\1");
+    Matcher matcher = attrPattern.matcher(tag);
+    if (!matcher.find()) return null;
+    return matcher.group(2);
+  }
+
+  private String safeName(@Nullable DocumentFile file, Uri uri) {
+    String name = file == null ? null : file.getName();
+    if (name != null && !name.isEmpty()) return name;
+    String lastPath = uri.getLastPathSegment();
+    return lastPath == null || lastPath.isEmpty() ? uri.toString() : lastPath;
+  }
+
+  private static class DirectoryInfo {
+    final String uri;
+    final String name;
+
+    DirectoryInfo(String uri, String name) {
+      this.uri = uri;
+      this.name = name;
+    }
+  }
+
+  private static class AndroidLyricIndexEntry {
+    final String uri;
+    final String name;
+    final long lastModified;
+    final String directoryUri;
+
+    AndroidLyricIndexEntry(String uri, String name, long lastModified, String directoryUri) {
+      this.uri = uri;
+      this.name = name;
+      this.lastModified = lastModified;
+      this.directoryUri = directoryUri;
+    }
+
+    JSObject toJSObject() {
+      JSObject object = new JSObject();
+      object.put("uri", uri);
+      object.put("name", name);
+      object.put("lastModified", lastModified);
+      object.put("directoryUri", directoryUri);
+      return object;
+    }
+  }
+
+  private static class ScanAccumulator {
+    int totalFiles = 0;
+    int matchedFiles = 0;
+    int duplicateIds = 0;
+    int failedFiles = 0;
+    final JSObject indexMap = new JSObject();
+    final JSArray failures = new JSArray();
+
+    void putIndex(String id, AndroidLyricIndexEntry entry) {
+      JSONObject existing = indexMap.optJSONObject(id);
+      if (existing != null) {
+        duplicateIds++;
+        long oldLastModified = existing.optLong("lastModified", 0L);
+        if (!shouldReplace(oldLastModified, entry.lastModified)) return;
+      }
+      indexMap.put(id, entry.toJSObject());
+    }
+
+    void addFailure(String uri, String name, String reason, String directoryUri) {
+      JSObject failure = new JSObject();
+      failure.put("uri", uri);
+      failure.put("name", name);
+      failure.put("reason", reason);
+      failure.put("directoryUri", directoryUri);
+      failures.put(failure);
+    }
+
+    JSObject toJSObject() {
+      JSObject response = new JSObject();
+      response.put("indexMap", indexMap);
+      response.put("totalFiles", totalFiles);
+      response.put("matchedFiles", matchedFiles);
+      response.put("duplicateIds", duplicateIds);
+      response.put("failedFiles", failedFiles);
+      response.put("failures", failures);
+      return response;
+    }
+
+    private boolean shouldReplace(long oldLastModified, long newLastModified) {
+      if (oldLastModified > 0 && newLastModified > 0) {
+        return newLastModified > oldLastModified;
+      }
+      if (oldLastModified <= 0 && newLastModified > 0) return true;
+      if (oldLastModified > 0) return false;
+      return true;
+    }
+  }
+}

--- a/src/components/Setting/components/LocalLyricDirectories.vue
+++ b/src/components/Setting/components/LocalLyricDirectories.vue
@@ -243,8 +243,13 @@ const addDirectory = async () => {
 
 .directory-list {
   margin-top: 12px;
+  overflow: hidden;
   border-radius: 8px;
   background-color: rgba(var(--primary), 0.05);
+
+  :deep(.n-list-item) {
+    padding: 10px 12px;
+  }
 }
 
 .directory-info {
@@ -252,5 +257,11 @@ const addDirectory = async () => {
   min-width: 0;
   flex: 1;
   flex-direction: column;
+
+  .name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }
 </style>

--- a/src/components/Setting/components/LocalLyricDirectories.vue
+++ b/src/components/Setting/components/LocalLyricDirectories.vue
@@ -4,6 +4,10 @@
       <div class="label">
         <n-text class="name">{{ item?.label || "本地歌词覆盖在线歌词" }}</n-text>
         <n-text class="tip" :depth="3" v-if="item?.description" v-html="item.description" />
+        <n-text class="tip" :depth="3" v-else-if="isCapacitorAndroid">
+          选择保存 TTML 的目录，扫描后会通过 metadata ncmMusicId 绑定网易云歌曲 <br />
+          仅对有网易云 ID 的歌曲生效，添加目录后会自动扫描
+        </n-text>
         <n-text class="tip" :depth="3" v-else>
           可在这些文件夹及其子文件夹内覆盖在线歌曲的歌词 <br />
           将歌词文件命名为 `歌曲ID.后缀名` 或者 `任意前缀.歌曲ID.后缀名` 即可 <br />
@@ -11,50 +15,233 @@
           （提示：可以在前缀加上歌名等信息，也可以利用子文件夹分类管理）
         </n-text>
       </div>
-      <n-button strong secondary @click="changeLocalLyricPath()">
-        <template #icon>
-          <SvgIcon name="Folder" />
-        </template>
-        添加
-      </n-button>
+      <n-flex :size="8">
+        <n-button
+          v-if="isCapacitorAndroid"
+          strong
+          secondary
+          :loading="scanLoading"
+          :disabled="!hasAndroidDirectories || picking"
+          @click="scanAndroidLyricDirectories()"
+        >
+          <template #icon>
+            <SvgIcon name="Refresh" />
+          </template>
+          重新扫描
+        </n-button>
+        <n-button strong secondary :loading="picking" :disabled="scanLoading" @click="addDirectory">
+          <template #icon>
+            <SvgIcon name="Folder" />
+          </template>
+          添加
+        </n-button>
+      </n-flex>
     </n-flex>
-    <n-collapse-transition :show="settingStore.localLyricPath.length > 0">
-      <n-card
-        v-for="(path, index) in settingStore.localLyricPath"
-        :key="index"
-        class="set-item sub-item"
-        content-style="padding: 4px 16px"
-      >
-        <n-flex justify="space-between" align="center" style="width: 100%">
-          <div class="label">
-            <n-text class="name">{{ path }}</n-text>
-          </div>
-          <n-button strong secondary @click="changeLocalLyricPath(index)">
-            <template #icon>
-              <SvgIcon name="Delete" />
-            </template>
-          </n-button>
+
+    <template v-if="isCapacitorAndroid">
+      <n-collapse-transition :show="hasAndroidScanMeta">
+        <n-flex class="scan-summary" align="center" :size="8">
+          <n-text :depth="3">最近扫描：{{ scanTimeText }}</n-text>
+          <n-tag size="small">TTML {{ androidScanMeta.totalFiles }}</n-tag>
+          <n-tag size="small" type="success">命中 {{ androidScanMeta.matchedFiles }}</n-tag>
+          <n-tag size="small" type="warning">重复 {{ androidScanMeta.duplicateIds }}</n-tag>
+          <n-tag size="small" :type="androidScanMeta.failedFiles ? 'error' : 'default'">
+            失败 {{ androidScanMeta.failedFiles }}
+          </n-tag>
         </n-flex>
-      </n-card>
-    </n-collapse-transition>
+      </n-collapse-transition>
+
+      <n-collapse-transition :show="hasAndroidDirectories">
+        <n-list class="directory-list" :bordered="false">
+          <n-list-item
+            v-for="(directory, index) in settingStore.androidLyricDirectories"
+            :key="directory.uri"
+          >
+            <n-flex justify="space-between" align="center" style="width: 100%" :wrap="false">
+              <div class="directory-info">
+                <n-text class="name">{{ directory.name }}</n-text>
+                <n-text class="directory-uri" :depth="3">{{ directory.uri }}</n-text>
+              </div>
+              <n-button
+                strong
+                secondary
+                :disabled="scanLoading || picking"
+                @click="removeAndroidLyricDirectory(index)"
+              >
+                <template #icon>
+                  <SvgIcon name="Delete" />
+                </template>
+              </n-button>
+            </n-flex>
+          </n-list-item>
+        </n-list>
+      </n-collapse-transition>
+    </template>
+
+    <template v-else>
+      <n-collapse-transition :show="settingStore.localLyricPath.length > 0">
+        <n-list class="directory-list" :bordered="false">
+          <n-list-item v-for="(path, index) in settingStore.localLyricPath" :key="path">
+            <n-flex justify="space-between" align="center" style="width: 100%" :wrap="false">
+              <div class="directory-info">
+                <n-text class="name">{{ path }}</n-text>
+              </div>
+              <n-button strong secondary @click="changeLocalLyricPath(index)">
+                <template #icon>
+                  <SvgIcon name="Delete" />
+                </template>
+              </n-button>
+            </n-flex>
+          </n-list-item>
+        </n-list>
+      </n-collapse-transition>
+    </template>
   </n-card>
 </template>
 
 <script setup lang="ts">
+import { AndroidLocalLyric, type AndroidLyricDirectory } from "@/plugins/androidLocalLyric";
 import { useSettingStore } from "@/stores";
+import type { SettingItem } from "@/types/settings";
+import { isCapacitorAndroid } from "@/utils/env";
 import { changeLocalLyricPath } from "@/utils/helper";
-import { SettingItem } from "@/types/settings";
 
 defineProps<{
   item?: SettingItem;
 }>();
 
 const settingStore = useSettingStore();
+const picking = ref(false);
+const scanLoading = ref(false);
+
+const androidScanMeta = computed(() => settingStore.androidLyricScanMeta);
+const hasAndroidDirectories = computed(() => settingStore.androidLyricDirectories.length > 0);
+const hasAndroidScanMeta = computed(
+  () =>
+    androidScanMeta.value.lastScanAt > 0 ||
+    androidScanMeta.value.totalFiles > 0 ||
+    androidScanMeta.value.matchedFiles > 0 ||
+    androidScanMeta.value.failedFiles > 0,
+);
+const scanTimeText = computed(() =>
+  androidScanMeta.value.lastScanAt
+    ? new Date(androidScanMeta.value.lastScanAt).toLocaleString()
+    : "未扫描",
+);
+
+const resetAndroidLyricIndex = () => {
+  settingStore.androidLyricIndexMap = {};
+  settingStore.androidLyricScanMeta = {
+    lastScanAt: 0,
+    totalFiles: 0,
+    matchedFiles: 0,
+    duplicateIds: 0,
+    failedFiles: 0,
+  };
+};
+
+const scanAndroidLyricDirectories = async (showSuccess = true) => {
+  if (!isCapacitorAndroid) return false;
+  if (!settingStore.androidLyricDirectories.length) {
+    resetAndroidLyricIndex();
+    return true;
+  }
+
+  scanLoading.value = true;
+  try {
+    const directories = settingStore.androidLyricDirectories.map((directory) => ({
+      uri: directory.uri,
+      name: directory.name,
+    }));
+    const summary = await AndroidLocalLyric.scanLyricDirectories({ directories });
+    settingStore.androidLyricIndexMap = summary.indexMap || {};
+    settingStore.androidLyricScanMeta = {
+      lastScanAt: Date.now(),
+      totalFiles: summary.totalFiles || 0,
+      matchedFiles: summary.matchedFiles || 0,
+      duplicateIds: summary.duplicateIds || 0,
+      failedFiles: summary.failedFiles || 0,
+    };
+
+    if (summary.failedFiles > 0) {
+      window.$message.warning(`扫描完成，${summary.failedFiles} 个文件读取失败`);
+    } else if (showSuccess) {
+      window.$message.success(`扫描完成，命中 ${summary.matchedFiles} 个 TTML 文件`);
+    }
+    return true;
+  } catch (error) {
+    console.error("扫描 Android 本地歌词目录失败:", error);
+    window.$message.error("扫描本地歌词目录失败，请重新授权目录");
+    return false;
+  } finally {
+    scanLoading.value = false;
+  }
+};
+
+const addAndroidLyricDirectory = async () => {
+  picking.value = true;
+  try {
+    const result = await AndroidLocalLyric.pickLyricDirectory();
+    if (result.cancelled || !result.uri) return;
+
+    const directory: AndroidLyricDirectory = {
+      uri: result.uri,
+      name: result.name || "歌词目录",
+    };
+    const exists = settingStore.androidLyricDirectories.some((item) => item.uri === directory.uri);
+    if (exists) {
+      window.$message.warning("该目录已添加");
+      return;
+    }
+
+    settingStore.androidLyricDirectories.push(directory);
+    const scanned = await scanAndroidLyricDirectories(false);
+    if (scanned) window.$message.success("已添加歌词目录");
+  } catch (error) {
+    console.error("添加 Android 本地歌词目录失败:", error);
+    window.$message.error("添加本地歌词目录失败");
+  } finally {
+    picking.value = false;
+  }
+};
+
+const removeAndroidLyricDirectory = async (index: number) => {
+  settingStore.androidLyricDirectories.splice(index, 1);
+  await scanAndroidLyricDirectories(false);
+  window.$message.success("已删除歌词目录");
+};
+
+const addDirectory = async () => {
+  if (isCapacitorAndroid) {
+    await addAndroidLyricDirectory();
+    return;
+  }
+  await changeLocalLyricPath();
+};
 </script>
 
 <style scoped lang="scss">
-.sub-item {
+.scan-summary {
   margin-top: 12px;
+}
+
+.directory-list {
+  margin-top: 12px;
+  border-radius: 8px;
   background-color: rgba(var(--primary), 0.05);
+}
+
+.directory-info {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.directory-uri {
+  overflow-wrap: anywhere;
+  font-size: 12px;
+  line-height: 1.4;
 }
 </style>

--- a/src/components/Setting/components/LocalLyricDirectories.vue
+++ b/src/components/Setting/components/LocalLyricDirectories.vue
@@ -59,7 +59,7 @@
           >
             <n-flex justify="space-between" align="center" style="width: 100%" :wrap="false">
               <div class="directory-info">
-                <n-text class="name">已授权目录 {{ index + 1 }}</n-text>
+                <n-text class="name">{{ getAndroidDirectoryDisplayName(directory, index) }}</n-text>
               </div>
               <n-button
                 strong
@@ -127,6 +127,23 @@ const scanTimeText = computed(() =>
     ? new Date(androidScanMeta.value.lastScanAt).toLocaleString()
     : "未扫描",
 );
+
+const getLastNameSegment = (value: string) => {
+  let name = value.trim();
+  try {
+    name = decodeURIComponent(name);
+  } catch {
+    // 保留原始名称
+  }
+  const cleanName = name.split(/[?#]/)[0];
+  const slashSegment = cleanName.split(/[\\/]/).filter(Boolean).at(-1) || cleanName;
+  return slashSegment.split(":").filter(Boolean).at(-1)?.trim() || "";
+};
+
+const getAndroidDirectoryDisplayName = (directory: AndroidLyricDirectory, index: number) => {
+  const name = getLastNameSegment(directory.name || directory.uri || "");
+  return name || `歌词目录 ${index + 1}`;
+};
 
 const resetAndroidLyricIndex = () => {
   settingStore.androidLyricIndexMap = {};

--- a/src/components/Setting/components/LocalLyricDirectories.vue
+++ b/src/components/Setting/components/LocalLyricDirectories.vue
@@ -5,8 +5,8 @@
         <n-text class="name">{{ item?.label || "本地歌词覆盖在线歌词" }}</n-text>
         <n-text class="tip" :depth="3" v-if="item?.description" v-html="item.description" />
         <n-text class="tip" :depth="3" v-else-if="isCapacitorAndroid">
-          选择保存 TTML 的目录，扫描后会通过 metadata ncmMusicId 绑定网易云歌曲 <br />
-          仅对有网易云 ID 的歌曲生效，添加目录后会自动扫描
+          选择 TTML 歌词目录，按文件元数据里的网易云 ID 匹配歌曲 <br />
+          添加后会自动扫描
         </n-text>
         <n-text class="tip" :depth="3" v-else>
           可在这些文件夹及其子文件夹内覆盖在线歌曲的歌词 <br />
@@ -59,8 +59,7 @@
           >
             <n-flex justify="space-between" align="center" style="width: 100%" :wrap="false">
               <div class="directory-info">
-                <n-text class="name">{{ directory.name }}</n-text>
-                <n-text class="directory-uri" :depth="3">{{ directory.uri }}</n-text>
+                <n-text class="name">已授权目录 {{ index + 1 }}</n-text>
               </div>
               <n-button
                 strong
@@ -236,12 +235,5 @@ const addDirectory = async () => {
   min-width: 0;
   flex: 1;
   flex-direction: column;
-  gap: 4px;
-}
-
-.directory-uri {
-  overflow-wrap: anywhere;
-  font-size: 12px;
-  line-height: 1.4;
 }
 </style>

--- a/src/components/Setting/config/local.ts
+++ b/src/components/Setting/config/local.ts
@@ -3,6 +3,7 @@ import { useCacheManager } from "@/core/resource/CacheManager";
 import { formatFileSize } from "@/utils/helper";
 import { songLevelData, getSongLevelsData, AI_AUDIO_LEVELS } from "@/utils/meta";
 import { SettingConfig } from "@/types/settings";
+import { isElectron } from "@/utils/env";
 import { openLocalMusicDirectoryModal } from "@/utils/modal";
 import { pick } from "lodash-es";
 import LocalLyricDirectories from "../components/LocalLyricDirectories.vue";
@@ -240,6 +241,7 @@ export const useLocalSettings = (): SettingConfig => {
             label: "本地歌词覆盖在线歌词",
             type: "custom",
             noWrapper: true,
+            show: isElectron,
             component: markRaw(LocalLyricDirectories),
           },
         ],

--- a/src/components/Setting/config/lyric.ts
+++ b/src/components/Setting/config/lyric.ts
@@ -11,6 +11,7 @@ import { openAMLLServer, openExcludeLyric, openFontManager } from "@/utils/modal
 import { AndroidNativePlayback } from "@/plugins/androidNativePlayback";
 import { cloneDeep, isEqual } from "lodash-es";
 import { toRef } from "vue";
+import LocalLyricDirectories from "../components/LocalLyricDirectories.vue";
 import LyricPreview from "../components/LyricPreview.vue";
 
 const ANDROID_LYRIC_CONFIG_KEY = "android-desktop-lyric-config";
@@ -192,6 +193,14 @@ export const useLyricSettings = (): SettingConfig => {
             type: "custom",
             noWrapper: true,
             component: markRaw(LyricPreview),
+          },
+          {
+            key: "androidLocalLyricPath",
+            label: "本地歌词覆盖在线歌词",
+            type: "custom",
+            noWrapper: true,
+            show: isCapacitorAndroid,
+            component: markRaw(LocalLyricDirectories),
           },
           {
             key: "lyricFontSizeMode",

--- a/src/core/player/LyricManager.ts
+++ b/src/core/player/LyricManager.ts
@@ -2,10 +2,11 @@ import { qqMusicMatch } from "@/api/qqmusic";
 import { songLyric, songLyricTTML } from "@/api/song";
 import { keywords as defaultKeywords, regexes as defaultRegexes } from "@/assets/data/exclude";
 import { useCacheManager } from "@/core/resource/CacheManager";
+import { AndroidLocalLyric } from "@/plugins/androidLocalLyric";
 import { useMusicStore, useSettingStore, useStatusStore, useStreamingStore } from "@/stores";
 import type { LyricPriority, SongLyric } from "@/types/lyric";
 import type { SongType } from "@/types/main";
-import { isElectron } from "@/utils/env";
+import { isCapacitorAndroid, isElectron } from "@/utils/env";
 import { applyBracketReplacement } from "@/utils/lyric/lyricFormat";
 import { applyProfanityUncensor } from "@/utils/lyric/lyricProfanity";
 import {
@@ -534,6 +535,40 @@ class LyricManager {
   }
 
   /**
+   * 检测 Android 索引歌词覆盖
+   * @param id 歌曲 ID
+   * @returns 歌词数据和元数据
+   */
+  private async fetchAndroidIndexedLyric(id: number): Promise<LyricFetchResult> {
+    const settingStore = useSettingStore();
+    const defaultResult: LyricFetchResult = {
+      data: { lrcData: [], yrcData: [] },
+      meta: { usingTTMLLyric: false, usingQRCLyric: false },
+    };
+
+    if (!isCapacitorAndroid) return defaultResult;
+    const entry = settingStore.androidLyricIndexMap[String(id)];
+    if (!entry?.uri) return defaultResult;
+
+    try {
+      const { content } = await AndroidLocalLyric.readLyricFile({ uri: entry.uri });
+      if (!content) return defaultResult;
+
+      const cleaned = cleanTTMLTranslations(content);
+      const lines = parseTTML(cleaned).lines || [];
+      if (!lines.length) return defaultResult;
+
+      return {
+        data: { lrcData: [], yrcData: lines },
+        meta: { usingTTMLLyric: true, usingQRCLyric: false },
+      };
+    } catch (error) {
+      console.error("读取 Android 本地歌词失败:", error);
+      return defaultResult;
+    }
+  }
+
+  /**
    * 处理歌词排除
    * @param lyricData 歌词数据
    * @param targetSong 目标歌曲
@@ -845,12 +880,20 @@ class LyricManager {
           // 对齐
           overrideResult.data.lrcData = alignLyricLines(overrideResult.data.lrcData);
           fetchResult = overrideResult;
-        } else if (song.path) {
-          // 本地文件
-          fetchResult = await this.fetchLocalLyric(song);
         } else {
-          // 在线获取
-          fetchResult = await this.fetchOnlineLyric(song);
+          const androidOverrideResult = await this.fetchAndroidIndexedLyric(song.id);
+          if (
+            !isEmpty(androidOverrideResult.data.lrcData) ||
+            !isEmpty(androidOverrideResult.data.yrcData)
+          ) {
+            fetchResult = androidOverrideResult;
+          } else if (song.path) {
+            // 本地文件
+            fetchResult = await this.fetchLocalLyric(song);
+          } else {
+            // 在线获取
+            fetchResult = await this.fetchOnlineLyric(song);
+          }
         }
       }
       // 后处理：元数据排除

--- a/src/core/player/PlayerController.ts
+++ b/src/core/player/PlayerController.ts
@@ -640,7 +640,9 @@ class PlayerController {
     }
   }
 
-  private buildAndroidTrackMetadata(song: SongType): AndroidNativeMetadataPayload & { liked?: boolean } {
+  private buildAndroidTrackMetadata(
+    song: SongType,
+  ): AndroidNativeMetadataPayload & { liked?: boolean } {
     const dataStore = useDataStore();
     const info = getPlayerInfoObj(song) || { name: song.name, artist: "", album: "" };
 
@@ -710,7 +712,8 @@ class PlayerController {
       nextUrl = nextSong.streamUrl;
     } else if (typeof nextSong.id === "number") {
       const songManager = useSongManager();
-      const prefetched = songManager.peekPrefetch(nextSong.id) ?? (await songManager.prefetchNextSong());
+      const prefetched =
+        songManager.peekPrefetch(nextSong.id) ?? (await songManager.prefetchNextSong());
       if (prefetched?.id === nextSong.id && prefetched.url) {
         nextUrl = prefetched.url;
       }
@@ -1820,7 +1823,9 @@ class PlayerController {
           window.$message.warning("请先授予悬浮窗权限");
           try {
             await AndroidNativePlayback.requestOverlayPermission();
-          } catch {}
+          } catch (error) {
+            console.warn("请求悬浮窗权限失败:", error);
+          }
           return;
         }
       }

--- a/src/plugins/androidLocalLyric.ts
+++ b/src/plugins/androidLocalLyric.ts
@@ -1,0 +1,47 @@
+import { registerPlugin } from "@capacitor/core";
+
+export interface AndroidLyricDirectory {
+  uri: string;
+  name: string;
+}
+
+export interface AndroidLyricPickResult extends Partial<AndroidLyricDirectory> {
+  cancelled: boolean;
+}
+
+export interface AndroidLyricIndexEntry {
+  uri: string;
+  name: string;
+  lastModified: number;
+  directoryUri: string;
+}
+
+export interface AndroidLyricScanMeta {
+  lastScanAt: number;
+  totalFiles: number;
+  matchedFiles: number;
+  duplicateIds: number;
+  failedFiles: number;
+}
+
+export interface AndroidLyricScanFailure {
+  uri: string;
+  name: string;
+  reason: string;
+  directoryUri: string;
+}
+
+export interface AndroidLyricScanSummary extends Omit<AndroidLyricScanMeta, "lastScanAt"> {
+  indexMap: Record<string, AndroidLyricIndexEntry>;
+  failures?: AndroidLyricScanFailure[];
+}
+
+export interface AndroidLocalLyricPlugin {
+  pickLyricDirectory(): Promise<AndroidLyricPickResult>;
+  scanLyricDirectories(options: {
+    directories: AndroidLyricDirectory[];
+  }): Promise<AndroidLyricScanSummary>;
+  readLyricFile(options: { uri: string }): Promise<{ content: string }>;
+}
+
+export const AndroidLocalLyric = registerPlugin<AndroidLocalLyricPlugin>("AndroidLocalLyric");

--- a/src/plugins/androidNativePlayback.ts
+++ b/src/plugins/androidNativePlayback.ts
@@ -54,7 +54,7 @@ export interface AndroidNativeApiContextPayload {
   cookie: string;
 }
 
-export interface AndroidNativePlaybackStateEvent extends AndroidNativePlaybackState {}
+export type AndroidNativePlaybackStateEvent = AndroidNativePlaybackState;
 
 export interface AndroidNativeProgressEvent {
   durationMs: number;
@@ -176,6 +176,5 @@ export interface AndroidNativePlaybackPlugin {
   removeAllListeners(): Promise<void>;
 }
 
-export const AndroidNativePlayback = registerPlugin<AndroidNativePlaybackPlugin>(
-  "AndroidNativePlayback",
-);
+export const AndroidNativePlayback =
+  registerPlugin<AndroidNativePlaybackPlugin>("AndroidNativePlayback");

--- a/src/stores/migrations/settingMigrations.ts
+++ b/src/stores/migrations/settingMigrations.ts
@@ -6,7 +6,7 @@ import type { SettingState } from "../setting";
 /**
  * 当前设置 Schema 版本号
  */
-export const CURRENT_SETTING_SCHEMA_VERSION = 13;
+export const CURRENT_SETTING_SCHEMA_VERSION = 14;
 
 /**
  * 迁移函数类型
@@ -200,6 +200,19 @@ export const settingMigrations: Record<number, MigrationFunction> = {
   13: () => {
     return {
       androidAllowMixWithOthers: true,
+    };
+  },
+  14: () => {
+    return {
+      androidLyricDirectories: [],
+      androidLyricIndexMap: {},
+      androidLyricScanMeta: {
+        lastScanAt: 0,
+        totalFiles: 0,
+        matchedFiles: 0,
+        duplicateIds: 0,
+        failedFiles: 0,
+      },
     };
   },
 };

--- a/src/stores/music.ts
+++ b/src/stores/music.ts
@@ -126,7 +126,9 @@ export const useMusicStore = defineStore("music", {
           try {
             const player = usePlayerController();
             player.syncFloatingLyricData();
-          } catch {}
+          } catch (error) {
+            console.warn("同步 Android 悬浮歌词失败:", error);
+          }
         });
       }
     },

--- a/src/stores/setting.ts
+++ b/src/stores/setting.ts
@@ -6,6 +6,11 @@ import { defineStore } from "pinia";
 import { CURRENT_SETTING_SCHEMA_VERSION, settingMigrations } from "./migrations/settingMigrations";
 import { ThemeColorType } from "@/types/color";
 import type { LyricPriority } from "@/types/lyric";
+import type {
+  AndroidLyricDirectory,
+  AndroidLyricIndexEntry,
+  AndroidLyricScanMeta,
+} from "@/plugins/androidLocalLyric";
 
 export interface SettingState {
   /** Schema 版本号 */
@@ -252,6 +257,12 @@ export interface SettingState {
   localFilesPath: string[];
   /** 本地歌词路径 */
   localLyricPath: string[];
+  /** Android 本地歌词目录 */
+  androidLyricDirectories: AndroidLyricDirectory[];
+  /** Android 本地歌词索引 */
+  androidLyricIndexMap: Record<string, AndroidLyricIndexEntry>;
+  /** Android 本地歌词扫描信息 */
+  androidLyricScanMeta: AndroidLyricScanMeta;
   /** 本地文件分隔符 */
   localSeparators: string[];
   /** 显示本地封面 */
@@ -606,6 +617,15 @@ export const useSettingStore = defineStore("setting", {
     excludeCommentRegexes: [],
     localFilesPath: [],
     localLyricPath: [],
+    androidLyricDirectories: [],
+    androidLyricIndexMap: {},
+    androidLyricScanMeta: {
+      lastScanAt: 0,
+      totalFiles: 0,
+      matchedFiles: 0,
+      duplicateIds: 0,
+      failedFiles: 0,
+    },
     showDefaultLocalPath: true,
     localFolderDisplayMode: "tab",
     localSeparators: ["/", "&"],

--- a/src/utils/lyric/parseTTML.ts
+++ b/src/utils/lyric/parseTTML.ts
@@ -15,6 +15,27 @@ export type TtmlBgExtractResult = {
 };
 
 /**
+ * 提取网易云歌曲 ID
+ * @param ttml TTML 文本
+ * @returns 歌曲 ID
+ */
+export const extractNcmMusicIdFromTTML = (ttml: string): string | null => {
+  const metaRegex = /<\s*amll:meta\b[^>]*>/gi;
+  const attrRegex = (name: string) => new RegExp(`\\b${name}\\s*=\\s*(['"])(.*?)\\1`, "i");
+  let match: RegExpExecArray | null;
+
+  while ((match = metaRegex.exec(ttml)) !== null) {
+    const tag = match[0];
+    const key = tag.match(attrRegex("key"))?.[2];
+    if (key !== "ncmMusicId") continue;
+    const value = tag.match(attrRegex("value"))?.[2]?.trim();
+    return value || null;
+  }
+
+  return null;
+};
+
+/**
  * 将 TTML 时间转换为毫秒
  * @param raw 原始时间字符串
  * @returns 毫秒


### PR DESCRIPTION
<!--
  感谢你为 SPlayer for Android 贡献代码！
  请认真填写下面的信息，便于 Review 与回归验证。
  标题格式建议：<type>(<scope>): <简要描述>
  例如：feat(DesktopLyric): 新增逐字描边开关
-->

## 📌 变更类型

<!-- 勾选一项或多项 -->

- [x] ✨ feat       — 新功能
- [ ] 🐞 fix        — Bug 修复
- [ ] 🎨 style      — 仅样式 / 格式，不影响逻辑
- [ ] ♻️ refactor   — 重构，不改变外部行为
- [ ] ⚡ perf       — 性能优化
- [ ] 📝 docs       — 仅文档
- [ ] 🧪 test       — 新增 / 修改测试
- [ ] 🔧 chore      — 构建 / 脚本 / 依赖
- [ ] 🚀 ci         — 仅 CI 配置
- [ ] ⏪ revert     — 回滚

## 📝 变更说明

<!-- 清晰说明 **改了什么** 与 **为什么改**，而不是逐行复述 diff -->
新增 Android 本地 TTML 歌词目录授权与扫描能力。用户可在「设置 - 歌词设置」中添加歌词目录，应用会扫描目录内 TTML 文件，并通过文件元数据中的网易云 ID 建立歌曲歌词索引。

播放歌曲时会优先读取已索引的本地 TTML 歌词，用于覆盖在线歌词。设置页支持重新扫描、删除授权目录、查看扫描统计。



## 🔗 关联 Issue

<!-- 用 Closes / Fixes 关键字关联，会在合并时自动关闭对应 Issue -->

Closes #

## 📱 影响范围

<!-- 勾选此 PR 实际影响到的模块 -->

- [ ] 🎵 播放引擎 / 音频
- [x] 📝 歌词 / 桌面歌词
- [ ] 🔔 通知栏 / MediaSession
- [ ] 🌐 在线音乐 (网易云 / Jellyfin / Navidrome / Emby / Subsonic / Last.fm)
- [ ] 🧩 内置 API (nodejs-mobile)
- [x] 🎨 UI / 主题 / 布局
- [ ] 📦 构建 / 打包 / 签名
- [x] 📱 Capacitor / 原生 Android 代码
- [ ] 📄 文档 / README

## ✅ 自检清单

- [x] 本 PR **目标分支为 `master`**
- [x] 本地已执行 `pnpm lint` 且无 warning
- [ ] 本地已执行 `pnpm typecheck` 且无报错
- [x] 已在 **至少一台真机** 上构建并验证关键路径
- [x] UI 改动已兼顾 **手机竖屏 + 平板横屏** 两种布局
- [x] 新增 / 修改的文案使用中文，与项目整体风格一致
- [x] 未引入不必要的依赖 / 大体积资源
- [x] 未修改签名密钥 / CI Secrets 相关文件

## 📸 截图 / 录屏 (UI 类 PR 必填)

<!-- 前后对比更佳，可直接拖拽图片或视频 -->

| 改动前 | 改动后 |
| :---: | :---: |
| 没有这设置 | <img width="252" height="560" alt="image" src="https://github.com/user-attachments/assets/e335409f-19a3-4177-9551-f375e4d450d0" /> |

## 🧪 测试方式

<!-- 评审者如何验证这次改动 -->

1. 安装 release APK，进入「设置 - 歌词设置 - 本地歌词覆盖在线歌词」
2. 添加包含 TTML 文件的本地目录，确认目录名称正常显示且不显示上级路径或 URI
3. 点击重新扫描，确认扫描统计正常更新
4. 播放与 TTML 元数据中网易云 ID 匹配的歌曲，确认本地 TTML 歌词优先显示
5. 删除已授权目录，确认索引会随目录变更重新扫描

## 💬 其他说明 (选填)
TTML 文件需要在元数据中包含网易云 ID 才能匹配歌曲。当前仅支持 Android 端通过系统目录授权读取本地 TTML。
<!-- 兼容性风险、已知问题、后续计划等 -->
