### PR TITLE
feat(player): 添加移动端卡片式播放器动画及手势交互

### DIFF
--- a/src/components/Player/FullPlayer.vue
+++ b/src/components/Player/FullPlayer.vue
@@ -1,6 +1,12 @@
 <template>
   <Teleport to="body">
-    <Transition :name="settingStore.playerExpandAnimation" mode="out-in">
+    <Transition
+      :name="useCompactMobilePlayer ? 'mobile-card' : settingStore.playerExpandAnimation"
+      :css="!useCompactMobilePlayer"
+      mode="out-in"
+      @enter="onMobileEnter"
+      @leave="onMobileLeave"
+    >
       <div
         v-if="statusStore.showFullPlayer"
         :style="{
@@ -102,6 +108,77 @@ const settingStore = useSettingStore();
 
 const { isPhonePortrait } = useDevice();
 const useCompactMobilePlayer = computed(() => isPhonePortrait.value);
+
+// 移动端卡片化进出场动画：兼容拖拽中的 inline transform，从当前位置平滑过渡
+const MOBILE_CARD_ENTER =
+  "transform 0.36s cubic-bezier(0.22, 1, 0.36, 1)";
+const MOBILE_CARD_LEAVE = "transform 0.32s cubic-bezier(0.4, 0, 1, 1)";
+
+const onMobileEnter = (el: Element, done: () => void) => {
+  if (!useCompactMobilePlayer.value) {
+    done();
+    return;
+  }
+  // 底栏拖拽开启模式：同步写好起始态再交给 MainPlayer 的拖拽逻辑接管，
+  // 避免出现一帧 “无 transform 全屏可见” 的裸态
+  if ((window as unknown as { __splayerDragOpen?: boolean }).__splayerDragOpen) {
+    const parent = el as HTMLElement;
+    parent.style.transformOrigin = "50% 0";
+    parent.style.willChange = "transform";
+    parent.style.transition = "none";
+    parent.style.transform = "translate3d(0, 100vh, 0) scale(0.92)";
+    parent.style.borderRadius = "28px";
+    parent.style.backfaceVisibility = "hidden";
+    done();
+    return;
+  }
+  const parent = el as HTMLElement;
+  parent.style.transformOrigin = "50% 0";
+  parent.style.willChange = "transform";
+  parent.style.transition = "none";
+  parent.style.transform = "translate3d(0, 100vh, 0) scale(0.92)";
+  parent.style.borderRadius = "28px";
+  parent.style.backfaceVisibility = "hidden";
+  parent.style.backdropFilter = "blur(48px)";
+  parent.style.contain = "paint";
+  // 强制重排，确保起始状态生效
+  parent.getBoundingClientRect();
+  requestAnimationFrame(() => {
+    parent.style.transition = MOBILE_CARD_ENTER;
+    parent.style.transform = "";
+  });
+  window.setTimeout(() => {
+    parent.style.transition = "";
+    parent.style.borderRadius = "";
+    parent.style.willChange = "";
+    parent.style.transformOrigin = "";
+    parent.style.backfaceVisibility = "";
+    parent.style.backdropFilter = "";
+    parent.style.contain = "";
+    done();
+  }, 380);
+};
+
+const onMobileLeave = (el: Element, done: () => void) => {
+  if (!useCompactMobilePlayer.value) {
+    done();
+    return;
+  }
+  const parent = el as HTMLElement;
+  parent.style.transformOrigin = "50% 0";
+  parent.style.willChange = "transform";
+  parent.style.transition = MOBILE_CARD_LEAVE;
+  parent.style.borderRadius = "28px";
+  parent.style.backfaceVisibility = "hidden";
+  parent.style.backdropFilter = "blur(48px)";
+  parent.style.contain = "paint";
+  requestAnimationFrame(() => {
+    parent.style.transform = "translate3d(0, 100vh, 0) scale(0.92)";
+  });
+  window.setTimeout(() => {
+    done();
+  }, 340);
+};
 
 /** 封面主颜色 */
 const mainCoverColor = useCssVar("--main-cover-color", document.documentElement);

--- a/src/components/Player/FullPlayerMobile.vue
+++ b/src/components/Player/FullPlayerMobile.vue
@@ -1,13 +1,21 @@
 <template>
   <div ref="mobileStart" class="full-player-mobile">
-    <div class="top-bar">
+    <div ref="topBarRef" class="top-bar">
       <div class="btn" @click.stop="statusStore.showFullPlayer = false">
         <SvgIcon name="Down" :size="26" />
       </div>
     </div>
 
+    <!-- 下拉手势捕获区：信息页覆盖顶栏 + 封面区域；歌词页仅顶栏，避免拦截歌词滚动 -->
     <div
-      :class="['mobile-content', { swiping: isSwiping }]"
+      ref="dragHandleRef"
+      class="drag-handle"
+      :style="{ height: dragHandleHeight }"
+      aria-hidden="true"
+    />
+
+    <div
+      :class="['mobile-content', { swiping: isHorizontalSwipe }]"
       :style="{ transform: contentTransform }"
       @click.stop
     >
@@ -167,7 +175,183 @@ const player = usePlayerController();
 const { timeDisplay, toggleTimeFormat } = useTimeFormat();
 
 const mobileStart = ref<HTMLElement | null>(null);
+const topBarRef = ref<HTMLElement | null>(null);
+const dragHandleRef = ref<HTMLElement | null>(null);
 const pageIndex = ref(0);
+
+// 下拉关闭手势捕获区高度：信息页仅覆盖顶栏 + 封面上半段，避免遮挡下方按钮
+// 歌词页含顶栏 + 歌曲信息条
+const dragHandleHeight = computed(() =>
+  pageIndex.value === 0
+    ? "calc(40px + var(--mobile-safe-top) + 32vh)"
+    : "calc(140px + var(--mobile-safe-top))",
+);
+
+// 顶部区域下拉关闭：整个全屏播放器（含背景蒙层）跟手下移，露出底部主页面
+let dragValue = 0;
+const CLOSE_THRESHOLD = 120;
+const REVEAL_DISTANCE = 480;
+const SPRING_TRANSITION =
+  "transform 0.32s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.32s cubic-bezier(0.22, 1, 0.36, 1)";
+
+// 缓存目标元素，避免 touchmove 每帧 DOM 查询
+let parentEl: HTMLElement | null = null;
+let mainEl: HTMLElement | null = null;
+let rafId = 0;
+let pendingDy = 0;
+
+const writeStyles = (dy: number) => {
+  if (parentEl) {
+    if (dy <= 0) {
+      parentEl.style.transform = "";
+    } else {
+      const scale = Math.max(0.92, 1 - dy / 2400);
+      parentEl.style.transform = `translate3d(0, ${dy}px, 0) scale(${scale})`;
+    }
+  }
+  if (mainEl) {
+    if (dy <= 0) {
+      mainEl.style.opacity = "";
+      mainEl.style.transform = "";
+    } else {
+      const progress = Math.min(dy / REVEAL_DISTANCE, 1);
+      mainEl.style.opacity = String(progress);
+      mainEl.style.transform = `scale(${0.9 + progress * 0.1})`;
+    }
+  }
+};
+
+// 通过 rAF 节流，避免 touchmove 高频写样式导致掉帧
+const scheduleFlush = (dy: number) => {
+  pendingDy = dy;
+  if (rafId) return;
+  rafId = requestAnimationFrame(() => {
+    rafId = 0;
+    writeStyles(pendingDy);
+  });
+};
+
+const beginDrag = () => {
+  parentEl = (mobileStart.value?.parentElement as HTMLElement | null) ?? null;
+  mainEl = document.getElementById("main");
+  // 拖动期间禁用过渡 + 提示合成层，避免每帧重排
+  if (parentEl) {
+    parentEl.style.transition = "none";
+    parentEl.style.willChange = "transform";
+    parentEl.style.transformOrigin = "50% 0";
+    parentEl.style.borderRadius = "28px";
+    parentEl.style.backfaceVisibility = "hidden";
+    parentEl.style.backdropFilter = "blur(48px)";
+    parentEl.style.contain = "paint";
+  }
+  if (mainEl) {
+    mainEl.style.transition = "none";
+    mainEl.style.willChange = "transform, opacity";
+  }
+};
+
+const clearWillChange = () => {
+  if (parentEl) parentEl.style.willChange = "";
+  if (mainEl) mainEl.style.willChange = "";
+};
+
+const resetInlineStyles = () => {
+  if (parentEl) {
+    parentEl.style.transition = "";
+    parentEl.style.transform = "";
+    parentEl.style.borderRadius = "";
+    parentEl.style.transformOrigin = "";
+    parentEl.style.willChange = "";
+    parentEl.style.backfaceVisibility = "";
+    parentEl.style.backdropFilter = "";
+    parentEl.style.contain = "";
+  }
+  if (mainEl) {
+    mainEl.style.transition = "";
+    mainEl.style.opacity = "";
+    mainEl.style.transform = "";
+    mainEl.style.willChange = "";
+  }
+};
+
+// 方向锁，避免左右翻页手势触发下拉
+let directionLock: "h" | "v" | null = null;
+let dragStarted = false;
+const DIRECTION_LOCK_TOLERANCE = 8;
+
+const { lengthX: topLengthX, lengthY: topLengthY } = useSwipe(dragHandleRef, {
+  threshold: 0,
+  onSwipeStart: () => {
+    directionLock = null;
+    dragStarted = false;
+  },
+  onSwipe: () => {
+    // 横向手势锁定后直接放行给翻页 useSwipe 处理
+    if (directionLock === "h") return;
+    if (!directionLock) {
+      const ax = Math.abs(topLengthX.value);
+      const ay = Math.abs(topLengthY.value);
+      if (Math.max(ax, ay) < DIRECTION_LOCK_TOLERANCE) return;
+      directionLock = ay > ax ? "v" : "h";
+      if (directionLock === "h") return;
+    }
+    if (!dragStarted) {
+      beginDrag();
+      dragStarted = true;
+    }
+    // useSwipe 的 lengthY = startY - currentY，下滑时为负值
+    const dy = -topLengthY.value;
+    // 仅允许向下拖动；上滑做强阻尼
+    dragValue = dy >= 0 ? dy : dy * 0.2;
+    scheduleFlush(Math.max(dragValue, 0));
+  },
+  onSwipeEnd: () => {
+    const wasDragging = dragStarted;
+    directionLock = null;
+    dragStarted = false;
+    if (!wasDragging) return;
+    if (rafId) {
+      cancelAnimationFrame(rafId);
+      rafId = 0;
+    }
+    if (dragValue > CLOSE_THRESHOLD) {
+      // 触发关闭：清掉 inline transition 让父级 @leave 钩子从当前位移继续滑出
+      if (parentEl) {
+        parentEl.style.transition = "";
+      }
+      // 同步把主页面平滑回到完全可见，避免卡片滑出过程中仍然可见拖动半透明状态
+      if (mainEl) {
+        mainEl.style.transition =
+          "opacity 0.32s ease, transform 0.32s cubic-bezier(0.22, 1, 0.36, 1)";
+        mainEl.style.opacity = "1";
+        mainEl.style.transform = "scale(1)";
+      }
+      statusStore.showFullPlayer = false;
+      window.setTimeout(() => {
+        clearWillChange();
+        resetInlineStyles();
+      }, 400);
+    } else {
+      // 取消关闭：弹簧回弹（border-radius 不参与过渡，立即清掉避免末尾突变）
+      if (parentEl) {
+        parentEl.style.transition = SPRING_TRANSITION;
+        parentEl.style.borderRadius = "";
+      }
+      if (mainEl) mainEl.style.transition = SPRING_TRANSITION;
+      writeStyles(0);
+      window.setTimeout(() => {
+        clearWillChange();
+        resetInlineStyles();
+      }, 360);
+    }
+    dragValue = 0;
+  },
+});
+
+onBeforeUnmount(() => {
+  if (rafId) cancelAnimationFrame(rafId);
+  resetInlineStyles();
+});
 
 const hasLyric = computed(() => musicStore.isHasLrc && musicStore.playSong.type !== "radio");
 
@@ -183,10 +367,12 @@ watch(hasLyric, (value) => {
   if (!value) pageIndex.value = 0;
 });
 
-const { direction, isSwiping, lengthX } = useSwipe(mobileStart, {
-  threshold: 10,
+const { direction, isSwiping, lengthX, lengthY } = useSwipe(mobileStart, {
+  threshold: 5,
   onSwipeEnd: () => {
     if (!hasLyric.value) return;
+    // 仅在主方向为水平时触发翻页，避免上下滑动歌词误触
+    if (Math.abs(lengthX.value) <= Math.abs(lengthY.value)) return;
 
     if (direction.value === "left" && lengthX.value > 100) {
       pageIndex.value = 1;
@@ -196,9 +382,14 @@ const { direction, isSwiping, lengthX } = useSwipe(mobileStart, {
   },
 });
 
+// 当前滑动是否为水平方向（用于跟手位移）
+const isHorizontalSwipe = computed(
+  () => isSwiping.value && Math.abs(lengthX.value) > Math.abs(lengthY.value),
+);
+
 const contentTransform = computed(() => {
   const baseOffset = pageIndex.value * 50;
-  if (!isSwiping.value || !hasLyric.value) {
+  if (!isHorizontalSwipe.value || !hasLyric.value) {
     return `translateX(-${baseOffset}%)`;
   }
 
@@ -224,6 +415,17 @@ const contentTransform = computed(() => {
   overflow: hidden;
   display: flex;
   flex-direction: column;
+
+  .drag-handle {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 5;
+    pointer-events: auto;
+    background: transparent;
+    touch-action: none;
+  }
 
   .top-bar {
     position: absolute;
@@ -471,6 +673,11 @@ const contentTransform = computed(() => {
       margin-bottom: 20px;
       flex-shrink: 0;
       padding-top: 8px;
+      // 喜欢按钮位于下拉手势区上方，需要抬高层级保持可点击
+      .action-btn {
+        position: relative;
+        z-index: 11;
+      }
 
       .lyric-cover {
         width: 50px;

--- a/src/components/Player/MainPlayer.vue
+++ b/src/components/Player/MainPlayer.vue
@@ -9,6 +9,10 @@
         'phone-floating': isPhone,
       },
     ]"
+    @pointerdown="onPointerDown"
+    @pointermove="onPointerMove"
+    @pointerup="onPointerEnd"
+    @pointercancel="onPointerEnd"
   >
     <!-- 进度条 -->
     <PlayerSlider />
@@ -251,7 +255,6 @@ import { useDataStore, useMusicStore, useSettingStore, useStatusStore } from "@/
 import { toLikeSong } from "@/utils/auth";
 import { useTimeFormat } from "@/composables/useTimeFormat";
 import { useDevice } from "@/composables/useDevice";
-import { useSwipe } from "@vueuse/core";
 import { copyData, coverLoaded, renderIcon, getShareUrl } from "@/utils/helper";
 import {
   openAutoClose,
@@ -280,19 +283,244 @@ const { timeDisplay, toggleTimeFormat } = useTimeFormat();
 
 const playerRef = ref<HTMLElement | null>(null);
 
-// 触摸滑动切换歌曲
-const { direction } = useSwipe(playerRef, {
-  threshold: 50,
-  onSwipeEnd: () => {
-    if (direction.value === "left") {
-      // 左滑
-      player.nextOrPrev("next");
-    } else if (direction.value === "right") {
-      // 右滑
-      player.nextOrPrev("prev");
+// 触摸滑动切换歌曲 / 上滑跟手开启全屏播放器（自实现 Pointer 事件，配合 setPointerCapture）
+let dragOpenActive = false;
+let dragOpenLocked: "h" | "v" | null = null;
+let dragOpenParent: HTMLElement | null = null;
+let dragOpenMain: HTMLElement | null = null;
+let dragOpenRaf = 0;
+let dragOpenPending = 0;
+let dragStartX = 0;
+let dragStartY = 0;
+let dragStartTop = 0; // 底栏顶部到视口顶部的距离，作为卡片起始位移
+let dragLastDy = 0;
+let dragOpenTravel = 0;
+let dragOpenResetTimer = 0;
+let dragOpenCloseTimer = 0;
+const OPEN_THRESHOLD = 100;
+
+const setDragOpenFlag = (v: boolean) => {
+  (window as unknown as { __splayerDragOpen?: boolean }).__splayerDragOpen = v;
+};
+
+// 取消上一轮手势遗留的异步清理 timer，避免清掉新手势的 inline 样式
+const cancelDragOpenTimers = () => {
+  if (dragOpenResetTimer) {
+    window.clearTimeout(dragOpenResetTimer);
+    dragOpenResetTimer = 0;
+  }
+  if (dragOpenCloseTimer) {
+    window.clearTimeout(dragOpenCloseTimer);
+    dragOpenCloseTimer = 0;
+  }
+};
+
+const writeDragOpen = (dy: number) => {
+  const progress = Math.max(0, Math.min(1, dy / dragOpenTravel));
+  const translate = (1 - progress) * dragStartTop;
+  const scale = 0.92 + 0.08 * progress;
+  if (dragOpenParent) {
+    dragOpenParent.style.transform = `translate3d(0, ${translate}px, 0) scale(${scale})`;
+  }
+  if (dragOpenMain) {
+    dragOpenMain.style.opacity = String(1 - progress);
+    dragOpenMain.style.transform = `scale(${1 - 0.1 * progress})`;
+  }
+};
+
+const scheduleDragOpenFlush = (dy: number) => {
+  dragOpenPending = dy;
+  if (dragOpenRaf) return;
+  dragOpenRaf = requestAnimationFrame(() => {
+    dragOpenRaf = 0;
+    writeDragOpen(dragOpenPending);
+  });
+};
+
+const initDragOpen = () => {
+  // 取消上一轮手势遗留的清理 timer，避免清掉本次 inline 样式
+  cancelDragOpenTimers();
+  const parent = document.querySelector(".full-player") as HTMLElement | null;
+  const main = document.getElementById("main");
+  if (parent) {
+    dragOpenParent = parent;
+    parent.style.transformOrigin = "50% 0";
+    parent.style.willChange = "transform";
+    parent.style.transition = "none";
+    // 起始放置在底栏顶部位置，让卡片从控制条向上展开
+    parent.style.transform = `translate3d(0, ${dragStartTop}px, 0) scale(0.92)`;
+    parent.style.borderRadius = "28px";
+    parent.style.backfaceVisibility = "hidden";
+    parent.style.backdropFilter = "blur(48px)";
+    parent.style.contain = "paint";
+    // 关键：让 FullPlayer 在拖拽期间不拦截触摸，事件继续命中底栏（playerRef）
+    parent.style.pointerEvents = "none";
+  }
+  if (main) {
+    dragOpenMain = main;
+    main.style.transition = "none";
+    main.style.willChange = "transform, opacity";
+    main.style.opacity = "1";
+    main.style.transform = "scale(1)";
+  }
+};
+
+const resetDragOpen = () => {
+  if (dragOpenRaf) {
+    cancelAnimationFrame(dragOpenRaf);
+    dragOpenRaf = 0;
+  }
+  if (dragOpenParent) {
+    dragOpenParent.style.transition = "";
+    dragOpenParent.style.transform = "";
+    dragOpenParent.style.borderRadius = "";
+    dragOpenParent.style.transformOrigin = "";
+    dragOpenParent.style.willChange = "";
+    dragOpenParent.style.pointerEvents = "";
+    dragOpenParent.style.backfaceVisibility = "";
+    dragOpenParent.style.backdropFilter = "";
+    dragOpenParent.style.contain = "";
+  }
+  if (dragOpenMain) {
+    dragOpenMain.style.transition = "";
+    dragOpenMain.style.transform = "";
+    dragOpenMain.style.opacity = "";
+    dragOpenMain.style.willChange = "";
+  }
+  dragOpenParent = null;
+  dragOpenMain = null;
+  dragOpenActive = false;
+  dragOpenLocked = null;
+  setDragOpenFlag(false);
+};
+
+const finishDragOpen = (dy: number) => {
+  const shouldOpen = dy > OPEN_THRESHOLD;
+  if (dragOpenRaf) {
+    cancelAnimationFrame(dragOpenRaf);
+    dragOpenRaf = 0;
+  }
+  if (shouldOpen) {
+    if (dragOpenParent) {
+      dragOpenParent.style.transition =
+        "transform 0.28s cubic-bezier(0.22, 1, 0.36, 1)";
+      dragOpenParent.style.transform = "";
     }
-  },
-});
+    if (dragOpenMain) {
+      dragOpenMain.style.transition =
+        "opacity 0.28s ease, transform 0.28s cubic-bezier(0.22, 1, 0.36, 1)";
+      dragOpenMain.style.opacity = "";
+      dragOpenMain.style.transform = "";
+    }
+    dragOpenResetTimer = window.setTimeout(() => {
+      dragOpenResetTimer = 0;
+      resetDragOpen();
+    }, 320);
+  } else {
+    if (dragOpenParent) {
+      dragOpenParent.style.transition =
+        "transform 0.24s cubic-bezier(0.4, 0, 1, 1)";
+      dragOpenParent.style.transform = `translate3d(0, ${dragStartTop}px, 0) scale(0.92)`;
+    }
+    if (dragOpenMain) {
+      dragOpenMain.style.transition =
+        "opacity 0.24s ease, transform 0.24s cubic-bezier(0.22, 1, 0.36, 1)";
+      dragOpenMain.style.opacity = "1";
+      dragOpenMain.style.transform = "scale(1)";
+    }
+    dragOpenCloseTimer = window.setTimeout(() => {
+      dragOpenCloseTimer = 0;
+      statusStore.showFullPlayer = false;
+      dragOpenResetTimer = window.setTimeout(() => {
+        dragOpenResetTimer = 0;
+        resetDragOpen();
+      }, 360);
+    }, 240);
+  }
+};
+
+let pointerId = -1;
+let pointerActiveTarget: HTMLElement | null = null;
+let horizontalSettled = false;
+let horizontalDirection: "left" | "right" | null = null;
+
+const onPointerDown = (e: PointerEvent) => {
+  if (e.pointerType === "mouse" && e.button !== 0) return;
+  // 新手势开始前取消上一轮异步清理，防止 timer 把本次样式清掉
+  cancelDragOpenTimers();
+  pointerId = e.pointerId;
+  dragStartX = e.clientX;
+  dragStartY = e.clientY;
+  dragLastDy = 0;
+  dragOpenActive = false;
+  dragOpenLocked = null;
+  horizontalSettled = false;
+  horizontalDirection = null;
+  // 仅记录目标，不立即捕获指针，避免影响子元素普通点击
+  pointerActiveTarget = e.currentTarget as HTMLElement;
+};
+
+const onPointerMove = (e: PointerEvent) => {
+  if (e.pointerId !== pointerId) return;
+  const dx = e.clientX - dragStartX;
+  const dy = dragStartY - e.clientY; // 上为正
+  dragLastDy = dy;
+  if (!isPhone.value || (statusStore.showFullPlayer && !dragOpenActive)) return;
+  const ax = Math.abs(dx);
+  const ay = Math.abs(dy);
+  if (!dragOpenLocked) {
+    if (Math.max(ax, ay) < 8) return;
+    if (ay > ax) {
+      // 向上拖拽才进入开启流程
+      if (dy <= 0) {
+        dragOpenLocked = "h";
+        return;
+      }
+      dragOpenLocked = "v";
+      // 锁定方向后再捕获指针，确保 FullPlayer 覆盖后事件仍流向底栏
+      pointerActiveTarget?.setPointerCapture?.(e.pointerId);
+      // 缓存底栏顶部坐标，作为卡片起始位移
+      const rect = playerRef.value?.getBoundingClientRect();
+      dragStartTop = rect ? rect.top : window.innerHeight - 80;
+      dragOpenTravel = Math.max(window.innerHeight * 0.55, 360);
+      setDragOpenFlag(true);
+      dragOpenActive = true;
+      statusStore.showFullPlayer = true;
+      requestAnimationFrame(() => {
+        if (!dragOpenActive) return;
+        initDragOpen();
+        writeDragOpen(Math.max(dy, 0));
+      });
+      return;
+    }
+    dragOpenLocked = "h";
+    horizontalDirection = dx > 0 ? "right" : "left";
+    return;
+  }
+  if (dragOpenLocked === "h") {
+    horizontalDirection = dx > 0 ? "right" : "left";
+    horizontalSettled = ax > 50;
+    return;
+  }
+  if (dragOpenActive) scheduleDragOpenFlush(Math.max(dy, 0));
+};
+
+const onPointerEnd = (e: PointerEvent) => {
+  if (e.pointerId !== pointerId) return;
+  pointerId = -1;
+  if (pointerActiveTarget) {
+    pointerActiveTarget.releasePointerCapture?.(e.pointerId);
+    pointerActiveTarget = null;
+  }
+  if (dragOpenActive) {
+    finishDragOpen(Math.max(dragLastDy, 0));
+    return;
+  }
+  if (dragOpenLocked === "h" && horizontalSettled && horizontalDirection) {
+    if (horizontalDirection === "left") player.nextOrPrev("next");
+    else player.nextOrPrev("prev");
+  }
+};
 
 // 歌曲更多操作
 const songMoreOptions = computed<DropdownOption[]>(() => {
@@ -450,6 +678,8 @@ const showCreatorTip = () => window.$message.info("暂不支持查看主播主�
   align-items: center;
   transition: bottom 0.3s;
   z-index: 10;
+  // 接管指针手势，避免浏览器滚动抢占垂直方向触发取消捕获
+  touch-action: pan-x;
   &.show {
     bottom: 0;
   }

--- a/src/style/animate.scss
+++ b/src/style/animate.scss
@@ -227,6 +227,19 @@
   transform: translateY(100%);
 }
 
+// mobile-card：iOS 风格的卡片化弹起 / 落下，与下拉关闭手势对称
+.mobile-card-enter-active,
+.mobile-card-leave-active {
+  transform-origin: 50% 0;
+  transition: transform 0.36s cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: transform;
+}
+.mobile-card-enter-from,
+.mobile-card-leave-to {
+  transform: translate3d(0, 100vh, 0) scale(0.92);
+  border-radius: 28px;
+}
+
 // left
 .left-enter-active,
 .left-leave-active {


### PR DESCRIPTION
## 📌 变更类型

- [x] ✨ feat — 新功能
- [x] 🐞 fix — Bug 修复
- [ ] 🎨 style — 仅样式 / 格式，不影响逻辑
- [ ] ♻️ refactor — 重构，不改变外部行为
- [x] ⚡ perf — 性能优化
- [ ] 📝 docs — 仅文档
- [ ] 🧪 test — 新增 / 修改测试
- [ ] 🔧 chore — 构建 / 脚本 / 依赖
- [ ] 🚀 ci — 仅 CI 配置
- [ ] ⏪ revert — 回滚

## 📝 变更说明

本 PR 优化了移动端播放器的卡片式展开 / 收起交互，重点解决以下问题：

- 底部播放器上滑展开全屏播放器时，卡片现在会从底部控制条区域开始，并跟随手指移动，避免动画卡在半屏。
- 新增移动端全屏播放器卡片化进出场动画，使点击展开、下拉关闭、底栏上滑展开的视觉表现更加一致。
- 优化卡片开关动画性能，减少拖拽和过渡期间的掉帧：
  - 使用 `requestAnimationFrame` 节流拖拽样式写入。
  - 动画期间主要更新 `transform` / `opacity`。
  - 避免拖拽过程中频繁修改 `border-radius`。
  - 临时设置 `will-change`、`backface-visibility`、`contain` 等属性辅助合成层优化。
  - 移动期间降低 `backdrop-filter` 模糊强度，减轻重绘压力。
- 新增顶部区域下拉关闭手势，支持全屏播放器跟手下移并露出底部主页面。
- 增加手势方向锁，避免横向翻页、歌词滚动、下拉关闭之间互相误触。
- 修复移动端全屏播放器信息页中“喜欢”和“添加到歌单”按钮被下拉手势捕获区遮挡，导致无法点击的问题。
- 修复连续快速操作时旧动画清理定时器可能影响新动画的问题。
- 修复拖拽开启时 Vue Transition 与手势动画衔接导致的一帧裸态问题。
- 修复取消下拉关闭时圆角残留导致的视觉突变。

## 🔗 关联 Issue

Closes #

## 📱 影响范围

- [ ] 🎵 播放引擎 / 音频
- [ ] 📝 歌词 / 桌面歌词
- [ ] 🔔 通知栏 / MediaSession
- [ ] 🌐 在线音乐 (网易云 / Jellyfin / Navidrome / Emby / Subsonic / Last.fm)
- [ ] 🧩 内置 API (nodejs-mobile)
- [x] 🎨 UI / 主题 / 布局
- [ ] 📦 构建 / 打包 / 签名
- [ ] 📱 Capacitor / 原生 Android 代码
- [ ] 📄 文档 / README

## ✅ 自检清单

- [x] 本 PR **目标分支为 `master`**
- [x] 本地已执行 `pnpm lint` 且无 warning
- [x] 本地已执行 `pnpm typecheck` 且无报错
- [x] 已在 **至少一台真机** 上构建并验证关键路径
- [x] UI 改动已兼顾 **手机竖屏 + 平板横屏** 两种布局
- [x] 新增 / 修改的文案使用中文，与项目整体风格一致
- [x] 未引入不必要的依赖 / 大体积资源
- [x] 未修改签名密钥 / CI Secrets 相关文件

## 📸 截图 / 录屏 (UI 类 PR 必填)

| 改动前 | 改动后 |
| :----: | :----: |
|    
<img width="3072" height="4096" alt="MEITU_20260508_165707744" src="https://github.com/user-attachments/assets/e70e036a-bc1d-4952-aa15-a2887505c497" />
    |        |

## 🧪 测试方式

1. 在移动端竖屏进入播放器页面，点击底部播放器，确认全屏播放器以卡片形式从底部展开，动画无明显闪烁。
2. 从底部播放器向上拖拽，确认全屏播放器从控制条区域开始跟随手指上滑，释放超过阈值后正常展开，未超过阈值时正常回弹。
3. 在全屏播放器顶部区域向下拖拽，确认卡片跟手下移并露出底部主页面，释放超过阈值后正常关闭，未超过阈值时正常回弹。
4. 在全屏播放器信息页点击“喜欢”和“添加到歌单”按钮，确认按钮可正常触发，不会被下拉手势区域拦截。
5. 在全屏播放器中左右滑动切换信息页 / 歌词页，确认横向翻页不会误触下拉关闭。
6. 在歌词页滚动歌词，确认纵向滚动不会误触横向翻页。
7. 快速连续执行“上滑展开 → 关闭 → 再次上滑展开”，确认动画状态不会被上一次定时器清理打断。
8. 执行 `pnpm lint`，确认无错误和 warning。

## 💬 其他说明 (选填)

本次改动主要集中在移动端播放器 UI 与手势动画层面，不涉及播放引擎、原生 Android、签名密钥或 CI Secrets。
已构建 https://github.com/Shomi-FJS/SPlayer-for-Android/actions/runs/25546938825