### PR TITLE
fix: 修复播放器交互穿透与页面响应

### DIFF
--- a/src/components/AMLL/LyricPlayer.vue
+++ b/src/components/AMLL/LyricPlayer.vue
@@ -227,7 +227,7 @@ const syncPlaybackTime = (time: number) => {
   const player = getInternalPlayer();
   if (!player) return;
 
-  const previousHotLines = new Set(player.hotLines ?? []);
+  const previousHotLines: Set<number> = new Set(player.hotLines ?? []);
   player.setCurrentTime(time, false);
   syncNewHotLineAnimations(player, previousHotLines, time);
 };
@@ -261,8 +261,35 @@ const syncSeekTime = (time: number) => {
 onMounted(() => {
   const wrapper = wrapperRef.value;
   if (wrapper) {
-    playerRef.value = new CoreLyricPlayer();
-    wrapper.appendChild(playerRef.value.getElement());
+    // AMLL 核心库在构造时注册非 passive 的 touchstart/touchmove 监听器，
+    // 产生 Chrome [Violation] 警告。临时补丁强制改为 passive，
+    // 配合 CSS touch-action: none 让浏览器不处理触摸滚动
+    const origAddEventListener = EventTarget.prototype.addEventListener;
+    EventTarget.prototype.addEventListener = function (
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | AddEventListenerOptions,
+    ) {
+      if (type === "touchstart" || type === "touchmove") {
+        const merged: AddEventListenerOptions =
+          typeof options === "object" && options !== null
+            ? { ...options, passive: true }
+            : { capture: options === true, passive: true };
+        return origAddEventListener.call(this, type, listener, merged);
+      }
+      return origAddEventListener.call(this, type, listener, options);
+    };
+
+    try {
+      playerRef.value = new CoreLyricPlayer();
+    } finally {
+      // 无论构造是否抛错，都必须还原全局原型，避免污染整个应用
+      EventTarget.prototype.addEventListener = origAddEventListener;
+    }
+
+    const el = playerRef.value.getElement();
+    el.style.touchAction = "none";
+    wrapper.appendChild(el);
     playerRef.value.addEventListener("line-click", lineClickHandler);
     playerRef.value.addEventListener("line-contextmenu", lineContextMenuHandler);
   }

--- a/src/components/List/SongList.vue
+++ b/src/components/List/SongList.vue
@@ -122,7 +122,7 @@
                       ? handlePointerDown($event, index, item.data.name || '未知曲目')
                       : undefined
                   "
-                  @touchstart="
+                  @touchstart.passive="
                     draggable
                       ? handlePointerDown($event, index, item.data.name || '未知曲目')
                       : undefined

--- a/src/components/Player/FullPlayer.vue
+++ b/src/components/Player/FullPlayer.vue
@@ -139,8 +139,6 @@ const onMobileEnter = (el: Element, done: () => void) => {
   parent.style.transform = "translate3d(0, 100vh, 0) scale(0.92)";
   parent.style.borderRadius = "28px";
   parent.style.backfaceVisibility = "hidden";
-  parent.style.backdropFilter = "blur(48px)";
-  parent.style.contain = "paint";
   // 强制重排，确保起始状态生效
   parent.getBoundingClientRect();
   requestAnimationFrame(() => {
@@ -153,8 +151,6 @@ const onMobileEnter = (el: Element, done: () => void) => {
     parent.style.willChange = "";
     parent.style.transformOrigin = "";
     parent.style.backfaceVisibility = "";
-    parent.style.backdropFilter = "";
-    parent.style.contain = "";
     done();
   }, 380);
 };
@@ -170,8 +166,6 @@ const onMobileLeave = (el: Element, done: () => void) => {
   parent.style.transition = MOBILE_CARD_LEAVE;
   parent.style.borderRadius = "28px";
   parent.style.backfaceVisibility = "hidden";
-  parent.style.backdropFilter = "blur(48px)";
-  parent.style.contain = "paint";
   requestAnimationFrame(() => {
     parent.style.transform = "translate3d(0, 100vh, 0) scale(0.92)";
   });
@@ -344,13 +338,13 @@ watch(
 onMounted(() => {
   mainCoverColor.value = statusStore.mainColor;
   if (isElectron && settingStore.preventSleep) {
-    window.electron.ipcRenderer.send("prevent-sleep", true);
+    window.electron?.ipcRenderer.send("prevent-sleep", true);
   }
 });
 
 onBeforeUnmount(() => {
   stopShow();
-  if (isElectron) window.electron.ipcRenderer.send("prevent-sleep", false);
+  if (isElectron) window.electron?.ipcRenderer.send("prevent-sleep", false);
 });
 </script>
 

--- a/src/components/Player/FullPlayerMobile.vue
+++ b/src/components/Player/FullPlayerMobile.vue
@@ -174,10 +174,12 @@ const dataStore = useDataStore();
 const player = usePlayerController();
 const { timeDisplay, toggleTimeFormat } = useTimeFormat();
 
+let savedPageIndex = 0;
+
 const mobileStart = ref<HTMLElement | null>(null);
 const topBarRef = ref<HTMLElement | null>(null);
 const dragHandleRef = ref<HTMLElement | null>(null);
-const pageIndex = ref(0);
+const pageIndex = ref(savedPageIndex);
 
 // 下拉关闭手势捕获区高度：信息页仅覆盖顶栏 + 封面上半段，避免遮挡下方按钮
 // 歌词页含顶栏 + 歌曲信息条
@@ -277,6 +279,7 @@ const resetInlineStyles = () => {
 // 方向锁，避免左右翻页手势触发下拉
 let directionLock: "h" | "v" | null = null;
 let dragStarted = false;
+let activeCloseGesture = false;
 const DIRECTION_LOCK_TOLERANCE = 8;
 
 const { lengthX: topLengthX, lengthY: topLengthY } = useSwipe(dragHandleRef, {
@@ -284,6 +287,7 @@ const { lengthX: topLengthX, lengthY: topLengthY } = useSwipe(dragHandleRef, {
   onSwipeStart: () => {
     directionLock = null;
     dragStarted = false;
+    activeCloseGesture = false;
   },
   onSwipe: () => {
     // 横向手势锁定后直接放行给翻页 useSwipe 处理
@@ -292,8 +296,10 @@ const { lengthX: topLengthX, lengthY: topLengthY } = useSwipe(dragHandleRef, {
       const ax = Math.abs(topLengthX.value);
       const ay = Math.abs(topLengthY.value);
       if (Math.max(ax, ay) < DIRECTION_LOCK_TOLERANCE) return;
-      directionLock = ay > ax ? "v" : "h";
+      // 偏向纵向触发下拉关闭，但保留略偏水平时的翻页能力（ax > ay * 1.2 视为水平）
+      directionLock = ax > ay * 1.2 ? "h" : "v";
       if (directionLock === "h") return;
+      activeCloseGesture = true;
     }
     if (!dragStarted) {
       beginDrag();
@@ -309,6 +315,14 @@ const { lengthX: topLengthX, lengthY: topLengthY } = useSwipe(dragHandleRef, {
     const wasDragging = dragStarted;
     directionLock = null;
     dragStarted = false;
+    // 兜底：本次手势结束后短暂保留 activeCloseGesture，
+    // 等 mobileStart 的 onSwipeEnd 消费后再由它清理；
+    // 若 mobileStart 没有收到（事件被中途取消），下一帧自动复位
+    if (activeCloseGesture) {
+      requestAnimationFrame(() => {
+        activeCloseGesture = false;
+      });
+    }
     if (!wasDragging) return;
     if (rafId) {
       cancelAnimationFrame(rafId);
@@ -349,6 +363,7 @@ const { lengthX: topLengthX, lengthY: topLengthY } = useSwipe(dragHandleRef, {
 });
 
 onBeforeUnmount(() => {
+  savedPageIndex = pageIndex.value;
   if (rafId) cancelAnimationFrame(rafId);
   resetInlineStyles();
 });
@@ -370,6 +385,10 @@ watch(hasLyric, (value) => {
 const { direction, isSwiping, lengthX, lengthY } = useSwipe(mobileStart, {
   threshold: 5,
   onSwipeEnd: () => {
+    if (activeCloseGesture) {
+      activeCloseGesture = false;
+      return;
+    }
     if (!hasLyric.value) return;
     // 仅在主方向为水平时触发翻页，避免上下滑动歌词误触
     if (Math.abs(lengthX.value) <= Math.abs(lengthY.value)) return;
@@ -384,7 +403,10 @@ const { direction, isSwiping, lengthX, lengthY } = useSwipe(mobileStart, {
 
 // 当前滑动是否为水平方向（用于跟手位移）
 const isHorizontalSwipe = computed(
-  () => isSwiping.value && Math.abs(lengthX.value) > Math.abs(lengthY.value),
+  () =>
+    isSwiping.value &&
+    Math.abs(lengthX.value) > Math.abs(lengthY.value) &&
+    !activeCloseGesture,
 );
 
 const contentTransform = computed(() => {

--- a/src/components/Player/MainPlayer.vue
+++ b/src/components/Player/MainPlayer.vue
@@ -303,8 +303,13 @@ const setDragOpenFlag = (v: boolean) => {
   (window as unknown as { __splayerDragOpen?: boolean }).__splayerDragOpen = v;
 };
 
+// 关闭分支的最终落实回调（settimeout 延迟 240ms 后才会把 showFullPlayer 置 false）
+// 取消 timer 时若未执行需要立即同步执行，否则 FullPlayer 会卡在起始位置
+let pendingCloseFinalize: (() => void) | null = null;
+
 // 取消上一轮手势遗留的异步清理 timer，避免清掉新手势的 inline 样式
-const cancelDragOpenTimers = () => {
+// flushClose=true 时如果有挂起的关闭动作，立即落实关闭，避免 FullPlayer 卡在起始位置
+const cancelDragOpenTimers = (flushClose = false) => {
   if (dragOpenResetTimer) {
     window.clearTimeout(dragOpenResetTimer);
     dragOpenResetTimer = 0;
@@ -312,7 +317,14 @@ const cancelDragOpenTimers = () => {
   if (dragOpenCloseTimer) {
     window.clearTimeout(dragOpenCloseTimer);
     dragOpenCloseTimer = 0;
+    if (flushClose && pendingCloseFinalize) {
+      const finalize = pendingCloseFinalize;
+      pendingCloseFinalize = null;
+      finalize();
+      return;
+    }
   }
+  if (flushClose) pendingCloseFinalize = null;
 };
 
 const writeDragOpen = (dy: number) => {
@@ -337,25 +349,24 @@ const scheduleDragOpenFlush = (dy: number) => {
   });
 };
 
-const initDragOpen = () => {
-  // 取消上一轮手势遗留的清理 timer，避免清掉本次 inline 样式
-  cancelDragOpenTimers();
-  const parent = document.querySelector(".full-player") as HTMLElement | null;
-  const main = document.getElementById("main");
-  if (parent) {
-    dragOpenParent = parent;
-    parent.style.transformOrigin = "50% 0";
-    parent.style.willChange = "transform";
-    parent.style.transition = "none";
-    // 起始放置在底栏顶部位置，让卡片从控制条向上展开
-    parent.style.transform = `translate3d(0, ${dragStartTop}px, 0) scale(0.92)`;
-    parent.style.borderRadius = "28px";
-    parent.style.backfaceVisibility = "hidden";
-    parent.style.backdropFilter = "blur(48px)";
-    parent.style.contain = "paint";
-    // 关键：让 FullPlayer 在拖拽期间不拦截触摸，事件继续命中底栏（playerRef）
-    parent.style.pointerEvents = "none";
-  }
+// .full-player 经 <Transition mode="out-in"> + Teleport 异步挂载，
+// 在 Vue 微任务流较忙或上一次离开动画未完成时可能短暂不存在，
+// 此时直接放弃会导致 FullPlayer 被 onMobileEnter 的 100vh 起始 transform 卡住，
+// 因此使用一次重试，最多 8 帧，仍找不到则放弃并复位 showFullPlayer。
+let initDragOpenRetry = 0;
+const INIT_DRAG_OPEN_MAX_RETRY = 8;
+
+const applyDragOpenInline = (parent: HTMLElement, main: HTMLElement | null) => {
+  dragOpenParent = parent;
+  parent.style.transformOrigin = "50% 0";
+  parent.style.willChange = "transform";
+  parent.style.transition = "none";
+  // 起始放置在底栏顶部位置，让卡片从控制条向上展开
+  parent.style.transform = `translate3d(0, ${dragStartTop}px, 0) scale(0.92)`;
+  parent.style.borderRadius = "28px";
+  parent.style.backfaceVisibility = "hidden";
+  // 关键：让 FullPlayer 在拖拽期间不拦截触摸，事件继续命中底栏（playerRef）
+  parent.style.pointerEvents = "none";
   if (main) {
     dragOpenMain = main;
     main.style.transition = "none";
@@ -363,6 +374,34 @@ const initDragOpen = () => {
     main.style.opacity = "1";
     main.style.transform = "scale(1)";
   }
+};
+
+const initDragOpen = () => {
+  // 取消上一轮手势遗留的清理 timer，避免清掉本次 inline 样式
+  cancelDragOpenTimers();
+  initDragOpenRetry = 0;
+  const tryAttach = () => {
+    if (!dragOpenActive) return;
+    const parent = document.querySelector(".full-player") as HTMLElement | null;
+    const main = document.getElementById("main");
+    if (parent) {
+      applyDragOpenInline(parent, main);
+      // 命中后立刻把当前 dy 写入，避免 0 dy 一帧裸态
+      writeDragOpen(Math.max(dragLastDy, 0));
+      return;
+    }
+    if (initDragOpenRetry++ < INIT_DRAG_OPEN_MAX_RETRY) {
+      requestAnimationFrame(tryAttach);
+      return;
+    }
+    // 超过重试上限，撤销开启意图，防止用户被卡在不可见的 FullPlayer 上
+    console.warn("[MainPlayer] 拖拽开启时未能找到 .full-player，回退关闭");
+    dragOpenActive = false;
+    dragOpenLocked = null;
+    setDragOpenFlag(false);
+    statusStore.showFullPlayer = false;
+  };
+  tryAttach();
 };
 
 const resetDragOpen = () => {
@@ -378,8 +417,6 @@ const resetDragOpen = () => {
     dragOpenParent.style.willChange = "";
     dragOpenParent.style.pointerEvents = "";
     dragOpenParent.style.backfaceVisibility = "";
-    dragOpenParent.style.backdropFilter = "";
-    dragOpenParent.style.contain = "";
   }
   if (dragOpenMain) {
     dragOpenMain.style.transition = "";
@@ -400,11 +437,33 @@ const finishDragOpen = (dy: number) => {
     cancelAnimationFrame(dragOpenRaf);
     dragOpenRaf = 0;
   }
+  // 兜底：若挂载阶段重试未成功捕获到 .full-player，dragOpenParent 仍为 null，
+  // 此时 onMobileEnter 已把元素定位到 100vh 离屏。无论开/关结果都必须现在重查并清掉 inline 样式，
+  // 否则 FullPlayer 会被永久卡在屏幕外（showFullPlayer 为 true 但用户什么都看不到）。
+  if (!dragOpenParent) {
+    const parent = document.querySelector(".full-player") as HTMLElement | null;
+    if (parent) {
+      dragOpenParent = parent;
+      // 清掉 onMobileEnter 留下的离屏 transform 及其它内联样式
+      parent.style.transition = "";
+      parent.style.transform = "";
+      parent.style.borderRadius = "";
+      parent.style.transformOrigin = "";
+      parent.style.willChange = "";
+      parent.style.pointerEvents = "";
+      parent.style.backfaceVisibility = "";
+    }
+    if (!dragOpenMain) {
+      dragOpenMain = document.getElementById("main");
+    }
+  }
   if (shouldOpen) {
     if (dragOpenParent) {
       dragOpenParent.style.transition =
         "transform 0.28s cubic-bezier(0.22, 1, 0.36, 1)";
       dragOpenParent.style.transform = "";
+      // 立即恢复全屏播放器的指针事件，避免开启动画期间 (~320ms) 触摸穿透到底层主页
+      dragOpenParent.style.pointerEvents = "";
     }
     if (dragOpenMain) {
       dragOpenMain.style.transition =
@@ -428,13 +487,18 @@ const finishDragOpen = (dy: number) => {
       dragOpenMain.style.opacity = "1";
       dragOpenMain.style.transform = "scale(1)";
     }
+    // 注册关闭最终落实回调，便于在新手势打断时同步执行，避免 FullPlayer 被卡在起始位置
+    pendingCloseFinalize = () => {
+      statusStore.showFullPlayer = false;
+      // 这里不再延迟 360ms reset：新手势打断的情况下需要立即清理 inline，
+      // 正常路径下 onMobileLeave 会负责接管离场动画
+      resetDragOpen();
+    };
     dragOpenCloseTimer = window.setTimeout(() => {
       dragOpenCloseTimer = 0;
-      statusStore.showFullPlayer = false;
-      dragOpenResetTimer = window.setTimeout(() => {
-        dragOpenResetTimer = 0;
-        resetDragOpen();
-      }, 360);
+      const finalize = pendingCloseFinalize;
+      pendingCloseFinalize = null;
+      if (finalize) finalize();
     }, 240);
   }
 };
@@ -446,8 +510,35 @@ let horizontalDirection: "left" | "right" | null = null;
 
 const onPointerDown = (e: PointerEvent) => {
   if (e.pointerType === "mouse" && e.button !== 0) return;
-  // 新手势开始前取消上一轮异步清理，防止 timer 把本次样式清掉
-  cancelDragOpenTimers();
+  // 新手势开始前取消上一轮异步清理，防止 timer 把本次样式清掉。
+  // flushClose=true：若上一次手势的关闭动作正在等待落实，立即执行掉，
+  // 否则会出现 showFullPlayer=true 但 FullPlayer 卡在起始位置且无法响应触摸的状态
+  cancelDragOpenTimers(true);
+  // 兜底恢复：若 FullPlayer 标记为打开但 .full-player 残留内联 transform / pointer-events:none，
+  // 说明上一次拖拽流程留下了脏状态（例如歌曲加载中竞态导致 finishDragOpen 未能落实），
+  // 此处强制清掉内联让 FullPlayer 恢复正常可交互的全屏状态
+  if (statusStore.showFullPlayer && !dragOpenActive) {
+    const stalled = document.querySelector(".full-player") as HTMLElement | null;
+    if (stalled && (stalled.style.transform || stalled.style.pointerEvents === "none")) {
+      stalled.style.transition = "";
+      stalled.style.transform = "";
+      stalled.style.borderRadius = "";
+      stalled.style.transformOrigin = "";
+      stalled.style.willChange = "";
+      stalled.style.pointerEvents = "";
+      stalled.style.backfaceVisibility = "";
+      const mainEl = document.getElementById("main");
+      if (mainEl) {
+        mainEl.style.transition = "";
+        mainEl.style.transform = "";
+        mainEl.style.opacity = "";
+        mainEl.style.willChange = "";
+      }
+      dragOpenParent = null;
+      dragOpenMain = null;
+      setDragOpenFlag(false);
+    }
+  }
   pointerId = e.pointerId;
   dragStartX = e.clientX;
   dragStartY = e.clientY;
@@ -486,10 +577,11 @@ const onPointerMove = (e: PointerEvent) => {
       setDragOpenFlag(true);
       dragOpenActive = true;
       statusStore.showFullPlayer = true;
+      // 等到下一帧再 initDragOpen，给 <Transition mode="out-in"> 留出挂载时机
+      // 实际写入由 initDragOpen 内部基于最新 dragLastDy 完成，避免使用过期 dy
       requestAnimationFrame(() => {
         if (!dragOpenActive) return;
         initDragOpen();
-        writeDragOpen(Math.max(dy, 0));
       });
       return;
     }


### PR DESCRIPTION
1. 为touchstart事件添加passive修饰符优化滚动性能
2. 移除FullPlayer多余的backdropFilter和contain样式
3. 为electron ipc调用添加可选链防止空指针
4. 修复LyricPlayer的Chrome触摸警告，全局补丁事件监听器并强制passive
5. 优化移动端播放器拖拽翻页逻辑，修复页面状态保存与手势冲突
6. 重构MainPlayer拖拽逻辑，修复竞态导致的播放器卡住问题

<!--
  感谢你为 SPlayer for Android 贡献代码！
  请认真填写下面的信息，便于 Review 与回归验证。
  标题格式建议：<type>(<scope>): <简要描述>
  例如：feat(DesktopLyric): 新增逐字描边开关
-->

## 📌 变更类型

<!-- 勾选一项或多项 -->

- [ ] ✨ feat — 新功能
- [ ] 🐞 fix — Bug 修复
- [ ] 🎨 style — 仅样式 / 格式，不影响逻辑
- [ ] ♻️ refactor — 重构，不改变外部行为
- [ ] ⚡ perf — 性能优化
- [ ] 📝 docs — 仅文档
- [ ] 🧪 test — 新增 / 修改测试
- [ ] 🔧 chore — 构建 / 脚本 / 依赖
- [ ] 🚀 ci — 仅 CI 配置
- [ ] ⏪ revert — 回滚

## 📝 变更说明

<!-- 清晰说明 **改了什么** 与 **为什么改**，而不是逐行复述 diff -->

## 🔗 关联 Issue

<!-- 用 Closes / Fixes 关键字关联，会在合并时自动关闭对应 Issue -->

Closes #

## 📱 影响范围

<!-- 勾选此 PR 实际影响到的模块 -->

- [ ] 🎵 播放引擎 / 音频
- [ ] 📝 歌词 / 桌面歌词
- [ ] 🔔 通知栏 / MediaSession
- [ ] 🌐 在线音乐 (网易云 / Jellyfin / Navidrome / Emby / Subsonic / Last.fm)
- [ ] 🧩 内置 API (nodejs-mobile)
- [ ] 🎨 UI / 主题 / 布局
- [ ] 📦 构建 / 打包 / 签名
- [ ] 📱 Capacitor / 原生 Android 代码
- [ ] 📄 文档 / README

## ✅ 自检清单

- [ ] 本 PR **目标分支为 `master`**
- [ ] 本地已执行 `pnpm lint` 且无 warning
- [ ] 本地已执行 `pnpm typecheck` 且无报错
- [ ] 已在 **至少一台真机** 上构建并验证关键路径
- [ ] UI 改动已兼顾 **手机竖屏 + 平板横屏** 两种布局
- [ ] 新增 / 修改的文案使用中文，与项目整体风格一致
- [ ] 未引入不必要的依赖 / 大体积资源
- [ ] 未修改签名密钥 / CI Secrets 相关文件

## 📸 截图 / 录屏 (UI 类 PR 必填)

<!-- 前后对比更佳，可直接拖拽图片或视频 -->

| 改动前 | 改动后 |
| :----: | :----: |
|        |        |

## 🧪 测试方式

<!-- 评审者如何验证这次改动 -->

1.
2.
3.

## 💬 其他说明 (选填)

<!-- 兼容性风险、已知问题、后续计划等 -->
