### PR TITLE
feat(android): 重构播放系统，支持移动端频谱与原生队列

### DIFF
--- a/android/app/src/main/java/top/imsyy/splayer/android/playback/AndroidNativePlaybackPlugin.java
+++ b/android/app/src/main/java/top/imsyy/splayer/android/playback/AndroidNativePlaybackPlugin.java
@@ -8,6 +8,7 @@ import android.os.Build;
 import android.preference.PreferenceManager;
 import android.provider.Settings;
 import androidx.annotation.Nullable;
+import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.PermissionState;
 import com.getcapacitor.Plugin;
@@ -16,7 +17,11 @@ import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.annotation.Permission;
 import com.getcapacitor.annotation.PermissionCallback;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Supplier;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 @CapacitorPlugin(
     name = "AndroidNativePlayback",
@@ -99,7 +104,8 @@ public class AndroidNativePlaybackPlugin extends Plugin {
   @PluginMethod
   public void updateMetadata(PluginCall call) {
     PlaybackManager.TrackMetadata metadata = new PlaybackManager.TrackMetadata();
-    metadata.songId = call.getInt("songId", 0);
+    // long：上游 songId 可超 int32 上限，用 optLong 避免溢出
+    metadata.songId = call.getData().optLong("songId", 0L);
     metadata.title = call.getString("title", "");
     metadata.artist = call.getString("artist", "");
     metadata.album = call.getString("album", "");
@@ -120,6 +126,7 @@ public class AndroidNativePlaybackPlugin extends Plugin {
     runOnMainThread(
         call,
         () -> {
+          List<PlaybackQueue.Track> windowTracks = readWindowTracks(call);
           PlaybackManager.getInstance(getContext())
               .updateQueueContext(
                   call.getBoolean("liked", false),
@@ -128,10 +135,67 @@ public class AndroidNativePlaybackPlugin extends Plugin {
                   call.getBoolean("controllerEnabled", true),
                   call.getBoolean("desktopLyricButtonEnabled", false),
                   call.getBoolean("desktopLyricEnabled", false),
-                  call.getBoolean("repeatOne", false),
-                  readTrackMetadata(call, "nextTrack", true));
+                  windowTracks,
+                  call.getInt("windowCurrentIndex", -1),
+                  call.getString("repeatMode", "off"),
+                  call.getBoolean("hasPreviousOutsideWindow", false),
+                  call.getBoolean("hasNextOutsideWindow", false),
+                  // windowRefilled：仅 refreshAndroidQueueWindow 路径置 true，
+                  // Java 端据此区分本次推送是否为「补窗响应」，避免无关 sync（liked / 桌面歌词等）误触发续播。
+                  call.getBoolean("windowRefilled", false));
           call.resolve();
         });
+  }
+
+  /**
+   * 解析 JS 端推送的 windowTracks 数组（每首带元数据 + 已解析 URL + playListIndex）。
+   *
+   * 容错策略：
+   * - JSArray 不存在或为空 → 返回空 list（PlaybackQueue 会进入空队列状态）
+   * - 单元素解析失败 → 跳过该元素继续解析其余（避免一首坏数据让整窗失效）
+   */
+  @Nullable
+  private List<PlaybackQueue.Track> readWindowTracks(PluginCall call) {
+    JSArray array = call.getArray("windowTracks");
+    if (array == null || array.length() == 0) {
+      return null;
+    }
+    List<PlaybackQueue.Track> tracks = new ArrayList<>(array.length());
+    for (int i = 0; i < array.length(); i++) {
+      try {
+        JSONObject obj = array.getJSONObject(i);
+        PlaybackQueue.Track t = new PlaybackQueue.Track();
+        t.songId = obj.optLong("songId", 0L);
+        t.title = safeOptString(obj, "title");
+        t.artist = safeOptString(obj, "artist");
+        t.album = safeOptString(obj, "album");
+        t.coverUrl = safeOptString(obj, "coverUrl");
+        t.durationMs = obj.optLong("durationMs", 0L);
+        t.canLike = obj.optBoolean("canLike", false);
+        t.liked = obj.optBoolean("liked", false);
+        t.playListIndex = obj.optInt("playListIndex", -1);
+        t.skipSong = obj.optBoolean("skipSong", false);
+        // 必须 isNull 显式判空：optString 遇 JSON null 会返回字符串 "null"，会让 ExoPlayer 拿 Uri.parse("null") → ENOENT。
+        String url = obj.isNull("url") ? null : obj.optString("url", "");
+        t.url = (url == null || url.isEmpty()) ? null : url;
+        tracks.add(t);
+      } catch (JSONException ignored) {
+        // 单首解析失败容忍，继续下一首
+      }
+    }
+    return tracks;
+  }
+
+  /**
+   * 避开 optString 遇 JSON null 返字符串 "null" 的坑，先 isNull 拦截。
+   *
+   * <p>语义约定：返回空串 "" 表示「未提供」。当前调用点（title/artist/album/coverUrl）下游
+   * 均把 "" 与 null 等价处理（参见 PlaybackManager.loadCoverBitmapAsync / refreshCurrentMediaItemMetadata），
+   * 不需要保留 null 区分。url 字段不走该 helper：见 readWindowTracks 内的特殊处理。
+   */
+  private static String safeOptString(JSONObject obj, String key) {
+    if (obj.isNull(key)) return "";
+    return obj.optString(key, "");
   }
 
   @PluginMethod
@@ -179,7 +243,10 @@ public class AndroidNativePlaybackPlugin extends Plugin {
         call,
         () -> {
           PlaybackManager.getInstance(getContext())
-              .syncApiContext(call.getString("apiBaseUrl", ""), call.getString("cookie", ""));
+              .syncApiContext(
+                  call.getString("apiBaseUrl", ""),
+                  call.getString("cookie", ""),
+                  call.getString("songLevel", "exhigh"));
           call.resolve();
         });
   }
@@ -312,6 +379,19 @@ public class AndroidNativePlaybackPlugin extends Plugin {
     call.resolve(result);
   }
 
+  // 频谱可视化 Media3 AudioProcessor 内嵌 FFT
+
+  @PluginMethod
+  public void enableVisualizer(PluginCall call) {
+    boolean enable = call.getBoolean("enable", false);
+    runOnMainThread(
+        call,
+        () -> {
+          boolean ok = PlaybackManager.getInstance(getContext()).enableVisualizer(enable);
+          call.resolve(permissionResult(ok));
+        });
+  }
+
   @PluginMethod
   public void requestOverlayPermission(PluginCall call) {
     if (Settings.canDrawOverlays(getContext())) {
@@ -371,7 +451,7 @@ public class AndroidNativePlaybackPlugin extends Plugin {
     }
 
     PlaybackManager.TrackMetadata metadata = new PlaybackManager.TrackMetadata();
-    metadata.songId = data.optInt("songId", 0);
+    metadata.songId = data.optLong("songId", 0L);
     metadata.title = data.optString("title", "");
     metadata.artist = data.optString("artist", "");
     metadata.album = data.optString("album", "");

--- a/android/app/src/main/java/top/imsyy/splayer/android/playback/FftAudioProcessor.java
+++ b/android/app/src/main/java/top/imsyy/splayer/android/playback/FftAudioProcessor.java
@@ -1,0 +1,412 @@
+package top.imsyy.splayer.android.playback;
+
+import androidx.annotation.Nullable;
+import androidx.media3.common.audio.AudioProcessor;
+import androidx.media3.common.audio.BaseAudioProcessor;
+import androidx.media3.common.util.UnstableApi;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * ExoPlayer 解码链 FFT 处理器，输出 fftBins[256] + lowFreq。
+ *
+ * <p>lowFreq 对齐 PC 端 AudioEffectManager：0–280Hz 均值→threshold=180→pow(x,2)→EMA(0.28)。
+ * fftBins 为 80–2000Hz 紧凑频谱。PCM 原样透传；除 setListener 外都在音频线程调用。
+ */
+@UnstableApi
+public final class FftAudioProcessor extends BaseAudioProcessor {
+  // FFT 参数对齐 Web Audio AnalyserNode：fftSize=2048, minDecibels=-100, maxDecibels=-30。
+  // lowFreq 语义对齐 PC 端 AudioEffectManager（0–280Hz 均值 + threshold + pow + EMA）。
+
+  /** FFT 窗口大小（必须 2 的幂）。2048 点 ~23Hz/bin@48kHz，足以分辨 低频 0–280Hz 频带。 */
+  private static final int FFT_SIZE = 2048;
+  private static final int FFT_BIN_COUNT = FFT_SIZE / 2;
+  /** STFT hop size，50% overlap。 */
+  private static final int HOP_SIZE = FFT_SIZE / 2;
+  /** 对外频谱 bin 数，保持 256 兼容前端。 */
+  private static final int OUTPUT_BIN_COUNT = 256;
+  /** 回调节流 ~33ms（30Hz），与 AnalyserNode rAF 节奏一致。 */
+  private static final long FRAME_INTERVAL_NS = 33_000_000L;
+  /** 目标等效采样率，贴近 PC AudioContext。 */
+  private static final float TARGET_EFFECTIVE_RATE = 48000f;
+
+  /** 频谱柱频段（Hz）。 */
+  private static final float SPECTRUM_FREQ_LOW = 80f;
+  private static final float SPECTRUM_FREQ_HIGH = 2000f;
+  /** AMLL 低频驱动频带上限（Hz）。起点为 bin 1（跳过 DC），对应 PC 端前 3 bin @ fftSize=512。 */
+  private static final float LOW_FREQ_BAND_END_HZ = 280f;
+
+  /** dB 归一化窗口（对齐 AnalyserNode 默认 minDecibels/maxDecibels）。 */
+  private static final float MIN_DB = -100f;
+  private static final float MAX_DB = -30f;
+
+  /** 低频底噪阈值（0–255 域）：低于此视为常态、不推动鼓点。 */
+  private static final float LOW_FREQ_THRESHOLD = 180f;
+  /** lowFreq EMA 平滑系数（对齐 PC 端 AudioEffectManager），raw 权重。 */
+  private static final float LOW_FREQ_SMOOTHING = 0.28f;
+
+  /** FFT 实例 + 蓄水池 + 工作数组。均为 thread-confined，仅音频线程访问。 */
+  private final Fft fft = new Fft(FFT_SIZE);
+  private final float[] sampleBuffer = new float[FFT_SIZE];
+  private int sampleBufferPos = 0;
+  private final float[] fftReal = new float[FFT_SIZE];
+  private final float[] fftImag = new float[FFT_SIZE];
+  /** 预计算 Hann 窗系数。 */
+  private static final float[] HANN_WINDOW = buildHannWindow(FFT_SIZE);
+
+  private static float[] buildHannWindow(int size) {
+    float[] w = new float[size];
+    for (int i = 0; i < size; i++) {
+      w[i] = 0.5f * (1f - (float) Math.cos(2.0 * Math.PI * i / (size - 1)));
+    }
+    return w;
+  }
+  /** FFT 原始 bin 强度（0-255 域），bin k 对应频率 k * effectiveRate / FFT_SIZE。 */
+  private final int[] fftBins = new int[FFT_BIN_COUNT];
+  /** 对外输出紧凑频谱：80-2000Hz bin 线性拉伸到 256；outputBins[0]=高频, [255]=低频。 */
+  private final int[] outputBins = new int[OUTPUT_BIN_COUNT];
+  /** 上次回调时间戳，用于节流。 */
+  private long lastCallbackNs = 0L;
+
+  /** 固定 stride，onConfigure 计算。 */
+  private int frameStride = 1;
+  /** 当前等效采样率。 */
+  private float effectiveRate = TARGET_EFFECTIVE_RATE;
+
+  /** 频谱柱 bin 范围。 */
+  private int spectrumBinStart = 1;
+  private int spectrumBinEnd = 1;
+  /** AMLL 低频驱动 bin 范围（0–280Hz，bin 1 起跳过 DC）。 */
+  private int lowFreqBandStart = 1;
+  private int lowFreqBandEnd = 1;
+
+  /** 低频包络平滑状态。 */
+  private float lowFreqSmoothed = 0f;
+
+  @Nullable private volatile DataListener listener;
+  /** setListener 跨线程重置令牌：主线程只置 flag，音频线程在 analyze() 入口消费，避免状态字段 race */
+  private volatile boolean pendingReset = false;
+
+  public interface DataListener {
+    /**
+     * @param fftBins 长度 256 的 0-255 频段能量（80-2000Hz 紧凑映射，bin[0]=高频, bin[255]=低频）
+     * @param lowFreq 0–280Hz 频带阈值超出量的平滑值 [0, 1]，驱动 AMLL 鼓点跳动
+     */
+    void onData(int[] fftBins, float lowFreq);
+  }
+
+  public void setListener(@Nullable DataListener listener) {
+    this.listener = listener;
+    // 仅设 flag，不从主线程直写状态字段；音频线程在下一次 analyze 入口消费。
+    pendingReset = true;
+  }
+
+  /** 重置运行时状态。 */
+  private void resetVisualState() {
+    sampleBufferPos = 0;
+    lastCallbackNs = 0L;
+    lowFreqSmoothed = 0f;
+  }
+
+  /** 根据 effectiveRate 重算 bin 下标。 */
+  private void recomputeBinRanges() {
+    float er = this.effectiveRate;
+    if (er <= 0f) return;
+    spectrumBinStart = Math.max(1, (int) Math.floor(SPECTRUM_FREQ_LOW * FFT_SIZE / er));
+    spectrumBinEnd = Math.min(FFT_BIN_COUNT - 1, (int) Math.ceil(SPECTRUM_FREQ_HIGH * FFT_SIZE / er));
+    if (spectrumBinEnd < spectrumBinStart) spectrumBinEnd = spectrumBinStart;
+    // 0–280Hz 对齐 PC 端前 3 bin@fftSize=512；bin 1 起跳过 DC 避免直流偏置污染。
+    lowFreqBandStart = 1;
+    lowFreqBandEnd = Math.min(FFT_BIN_COUNT - 1, (int) Math.ceil(LOW_FREQ_BAND_END_HZ * FFT_SIZE / er));
+    if (lowFreqBandEnd < lowFreqBandStart) lowFreqBandEnd = lowFreqBandStart;
+  }
+
+  @Override
+  protected AudioFormat onConfigure(AudioFormat inputAudioFormat) throws UnhandledAudioFormatException {
+    // 仅接受 16bit PCM，其他 encoding 交上游 ToInt16PcmAudioProcessor 转换
+    if (inputAudioFormat.encoding != androidx.media3.common.C.ENCODING_PCM_16BIT) {
+      throw new UnhandledAudioFormatException(inputAudioFormat);
+    }
+
+    // 44.1/48kHz 不降采样，高采样率才降到接近 48kHz
+    frameStride = Math.max(1, Math.round(inputAudioFormat.sampleRate / TARGET_EFFECTIVE_RATE));
+    effectiveRate = (float) inputAudioFormat.sampleRate / frameStride;
+
+    recomputeBinRanges();
+
+    // 透传上游格式
+    return inputAudioFormat;
+  }
+
+  @Override
+  public void queueInput(ByteBuffer inputBuffer) {
+    int bytesRemaining = inputBuffer.remaining();
+    if (bytesRemaining == 0) {
+      return;
+    }
+
+    // 分析 PCM
+    analyze(inputBuffer);
+
+    // 透传到下游
+    ByteBuffer output = replaceOutputBuffer(bytesRemaining);
+    output.put(inputBuffer);
+    output.flip();
+  }
+
+  /** mono 化 + 写入累积缓冲，满后触发 FFT。用 duplicate() 不影响透传。 */
+  private void analyze(ByteBuffer inputBuffer) {
+    // setListener 可能在主线程设了 pendingReset，这里是唯一由音频线程消费点，
+    // 以避免跨线程同时读写 sampleBufferPos / lastCallbackNs / lowFreqSmoothed 的 race。
+    if (pendingReset) {
+      pendingReset = false;
+      resetVisualState();
+    }
+
+    DataListener cb = listener;
+    if (cb == null) {
+      // 无消费者时跳过 FFT
+      return;
+    }
+
+    int channelCount = inputAudioFormat.channelCount;
+    if (channelCount <= 0) {
+      return;
+    }
+
+    ByteBuffer view = inputBuffer.duplicate().order(ByteOrder.nativeOrder());
+    int bytesPerFrame = channelCount * 2; // 16bit = 2 bytes/channel
+    int totalFrames = view.remaining() / bytesPerFrame;
+
+    int strideFrames = frameStride;
+
+    // 降采样时连续 stride 个采样求平均，抓高频混叠
+    for (int frame = 0; frame + strideFrames <= totalFrames; frame += strideFrames) {
+      float monoSum = 0f;
+      for (int sub = 0; sub < strideFrames; sub++) {
+        int byteOffset = (frame + sub) * bytesPerFrame;
+        int chSum = 0;
+        for (int ch = 0; ch < channelCount; ch++) {
+          chSum += view.getShort(view.position() + byteOffset + ch * 2);
+        }
+        monoSum += (float) chSum / channelCount;
+      }
+      float mono = monoSum / strideFrames;
+
+      sampleBuffer[sampleBufferPos++] = mono;
+      if (sampleBufferPos >= FFT_SIZE) {
+        // 节流前置：未达 30Hz 间隔时不进入 FFT 计算，仅走 overlap shift，
+        // 避免函数命名误导阅读者认为窗内已经做了 FFT。
+        long now = System.nanoTime();
+        if (now - lastCallbackNs >= FRAME_INTERVAL_NS) {
+          lastCallbackNs = now;
+          runFftAndCallback(cb);
+        }
+        // overlap shift：把后部 (FFT_SIZE - HOP_SIZE) 个样本移到开头，下次从 (FFT_SIZE - HOP_SIZE) 位置续写。
+        // 通用公式不再假设 HOP = FFT/2。
+        final int keepCount = FFT_SIZE - HOP_SIZE;
+        System.arraycopy(sampleBuffer, HOP_SIZE, sampleBuffer, 0, keepCount);
+        sampleBufferPos = keepCount;
+      }
+    }
+  }
+
+  private void runFftAndCallback(DataListener cb) {
+    // 节流已由调用方在 analyze() 处预筛，这里不再重复检查。
+
+    // 去 DC：避免直流偏置经 Hann 窗泄漏到低频 bin
+    float dcSum = 0f;
+    for (int i = 0; i < FFT_SIZE; i++) {
+      dcSum += sampleBuffer[i];
+    }
+    float dcMean = dcSum / FFT_SIZE;
+
+    // 去 DC + Hann 窗
+    for (int i = 0; i < FFT_SIZE; i++) {
+      fftReal[i] = (sampleBuffer[i] - dcMean) * HANN_WINDOW[i];
+      fftImag[i] = 0f;
+    }
+
+    fft.transform(fftReal, fftImag);
+
+    // 计算关心范围内的 bin，范围外置 0；FFT 自然顺序 bin k = k * effectiveRate / FFT_SIZE，无需镜像
+    final float dbRange = MAX_DB - MIN_DB;
+    int fftCalcStart = Math.min(lowFreqBandStart, spectrumBinStart);
+    int fftCalcEnd = Math.max(lowFreqBandEnd, spectrumBinEnd);
+    for (int k = 0; k < FFT_BIN_COUNT; k++) {
+      if (k < fftCalcStart || k > fftCalcEnd) {
+        fftBins[k] = 0;
+        continue;
+      }
+      float real = fftReal[k];
+      float imag = fftImag[k];
+      float mag = (float) Math.sqrt(real * real + imag * imag);
+      float normalized = mag / (FFT_SIZE / 2f) / 32768f;
+      float db = normalized <= 1e-7f ? MIN_DB : 20f * (float) Math.log10(normalized);
+      float t = (db - MIN_DB) / dbRange;
+      if (t < 0f) t = 0f;
+      else if (t > 1f) t = 1f;
+      fftBins[k] = (int) (t * 255f);
+    }
+
+    // AMLL 低频音量：对齐 PC 端 AudioEffectManager.getLowFrequencyVolume()
+    //   1) 0–280Hz 均值   2) threshold=180 过滤底噪   3) pow(x, 2) 扩展动态   4) EMA 平滑
+    int lowFreqSum = 0;
+    int lowFreqCount = 0;
+    for (int i = lowFreqBandStart; i <= lowFreqBandEnd; i++) {
+      lowFreqSum += fftBins[i];
+      lowFreqCount++;
+    }
+    float lowFreqAvg = lowFreqCount > 0 ? (float) lowFreqSum / lowFreqCount : 0f;
+    float overThreshold = (lowFreqAvg - LOW_FREQ_THRESHOLD) / (255f - LOW_FREQ_THRESHOLD);
+    if (overThreshold < 0f) overThreshold = 0f;
+    float lowFreqRaw = overThreshold * overThreshold;
+    lowFreqSmoothed += LOW_FREQ_SMOOTHING * (lowFreqRaw - lowFreqSmoothed);
+    if (lowFreqSmoothed < 0f) lowFreqSmoothed = 0f;
+    else if (lowFreqSmoothed > 1f) lowFreqSmoothed = 1f;
+
+    // 紧凑映射：80-2000Hz bin 线性插值拉伸到 outputBins
+    // 输出按 outputBins[0]=高频, [255]=低频 反转，匹配前端 SKIP_BINS 跳过高频噪声的可视化布局
+    int sourceSpan = spectrumBinEnd - spectrumBinStart;
+    if (sourceSpan <= 0) {
+      for (int k = 0; k < OUTPUT_BIN_COUNT; k++) outputBins[k] = 0;
+    } else {
+      for (int k = 0; k < OUTPUT_BIN_COUNT; k++) {
+        float srcPos = (float) k * sourceSpan / (OUTPUT_BIN_COUNT - 1);
+        int srcLow = spectrumBinStart + (int) srcPos;
+        int srcHigh = Math.min(srcLow + 1, spectrumBinEnd);
+        float frac = srcPos - (int) srcPos;
+        int interp = (int) (fftBins[srcLow] * (1f - frac) + fftBins[srcHigh] * frac);
+        if (interp < 0) interp = 0;
+        else if (interp > 255) interp = 255;
+        outputBins[OUTPUT_BIN_COUNT - 1 - k] = interp;
+      }
+    }
+
+    cb.onData(outputBins, lowFreqSmoothed);
+  }
+
+  @Override
+  protected void onFlush() {
+    // seek/flush 重置蓄水池，避免跨片段污染
+    resetVisualState();
+  }
+
+  @Override
+  protected void onReset() {
+    resetVisualState();
+    // listener 由 PlaybackManager 管理，不清
+  }
+
+  /**
+   * 原地 radix-2 Cooley-Tukey FFT。
+   *
+   * 仅支持 size 为 2 的幂；构造时预计算旋转因子（W = e^(-i*2π*k/N)）的 cos/sin 表，
+   * 避免每次 FFT 都重算三角函数。
+   *
+   * 用法：
+   * <pre>
+   *   Fft fft = new Fft(2048);
+   *   float[] real = new float[2048];
+   *   float[] imag = new float[2048]; // 全零
+   *   // ... 填入 PCM 样本到 real ...
+   *   fft.transform(real, imag);
+   *   // 频谱幅度 = sqrt(real[k]^2 + imag[k]^2)，k = 0..N/2-1
+   * </pre>
+   *
+   * 不是线程安全：调用方应在单一线程（音频处理线程）内重用。
+   */
+  private static final class Fft {
+    private final int size;
+    private final int log2Size;
+    private final float[] cosTable;
+    private final float[] sinTable;
+    private final int[] bitReverseTable;
+
+    Fft(int size) {
+      if (size <= 0 || (size & (size - 1)) != 0) {
+        throw new IllegalArgumentException("FFT size must be a power of 2, got: " + size);
+      }
+      this.size = size;
+      this.log2Size = Integer.numberOfTrailingZeros(size);
+
+      // 预计算旋转因子表（半周期足够，二象限对称由 sign 决定）
+      int half = size / 2;
+      cosTable = new float[half];
+      sinTable = new float[half];
+      for (int i = 0; i < half; i++) {
+        double angle = -2.0 * Math.PI * i / size;
+        cosTable[i] = (float) Math.cos(angle);
+        sinTable[i] = (float) Math.sin(angle);
+      }
+
+      // 预计算位反转索引表
+      bitReverseTable = new int[size];
+      for (int i = 0; i < size; i++) {
+        bitReverseTable[i] = reverseBits(i, log2Size);
+      }
+    }
+
+    public int getSize() {
+      return size;
+    }
+
+    /**
+     * 原地 FFT。real / imag 长度必须等于构造时的 size。输出位置 k 的频段对应频率 k * sampleRate / size。
+     */
+    public void transform(float[] real, float[] imag) {
+      if (real.length != size || imag.length != size) {
+        throw new IllegalArgumentException(
+            "FFT input length mismatch: expected " + size + ", got real=" + real.length
+                + ", imag=" + imag.length);
+      }
+
+      // 位反转排序：经典 Cooley-Tukey 第一步
+      for (int i = 0; i < size; i++) {
+        int j = bitReverseTable[i];
+        if (j > i) {
+          float tmpR = real[i];
+          real[i] = real[j];
+          real[j] = tmpR;
+          float tmpI = imag[i];
+          imag[i] = imag[j];
+          imag[j] = tmpI;
+        }
+      }
+
+      // 蝶形运算：从 size=2 开始倍增
+      for (int stage = 1; stage <= log2Size; stage++) {
+        int m = 1 << stage; // 当前蝶形段长度
+        int mHalf = m >> 1;
+        int twiddleStep = size / m; // 旋转因子在 cosTable/sinTable 中的步长
+
+        for (int k = 0; k < size; k += m) {
+          for (int j = 0; j < mHalf; j++) {
+            int twiddleIndex = j * twiddleStep;
+            float wR = cosTable[twiddleIndex];
+            float wI = sinTable[twiddleIndex];
+
+            int idx = k + j;
+            int idxPair = idx + mHalf;
+            float tR = wR * real[idxPair] - wI * imag[idxPair];
+            float tI = wR * imag[idxPair] + wI * real[idxPair];
+
+            real[idxPair] = real[idx] - tR;
+            imag[idxPair] = imag[idx] - tI;
+            real[idx] = real[idx] + tR;
+            imag[idx] = imag[idx] + tI;
+          }
+        }
+      }
+    }
+
+    private static int reverseBits(int x, int bits) {
+      int result = 0;
+      for (int i = 0; i < bits; i++) {
+        result = (result << 1) | (x & 1);
+        x >>>= 1;
+      }
+      return result;
+    }
+  }
+}

--- a/android/app/src/main/java/top/imsyy/splayer/android/playback/PlaybackManager.java
+++ b/android/app/src/main/java/top/imsyy/splayer/android/playback/PlaybackManager.java
@@ -32,8 +32,12 @@ import androidx.media3.common.MediaItem;
 import androidx.media3.common.MediaMetadata;
 import androidx.media3.common.PlaybackException;
 import androidx.media3.common.Player;
+import androidx.media3.common.audio.AudioProcessor;
 import androidx.media3.common.util.UnstableApi;
+import androidx.media3.exoplayer.DefaultRenderersFactory;
 import androidx.media3.exoplayer.ExoPlayer;
+import androidx.media3.exoplayer.audio.AudioSink;
+import androidx.media3.exoplayer.audio.DefaultAudioSink;
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory;
 import androidx.media3.extractor.DefaultExtractorsFactory;
 import androidx.media3.session.CommandButton;
@@ -41,6 +45,7 @@ import androidx.media3.session.MediaSession;
 import androidx.media3.session.SessionCommand;
 import androidx.media3.session.SessionCommands;
 import androidx.media3.session.SessionResult;
+import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -80,7 +85,14 @@ public final class PlaybackManager {
   private final Context appContext;
   private final Handler mainHandler = new Handler(Looper.getMainLooper());
   private final ExecutorService artworkExecutor = Executors.newSingleThreadExecutor();
+  /** 仅服务于 favorite 等非播放路径；URL 解析走 urlResolver 内部 2 线程池避免被 favorite 阻塞。 */
   private final ExecutorService networkExecutor = Executors.newSingleThreadExecutor();
+  /**
+   * URL 解析请求 token：每次 NEXT/PREV/ENDED 触发的解析自增 token，回调时若 token 已过期（用户连点
+   * 又起了一次解析）直接丢弃结果，防止旧请求覆盖播放器状态。
+   */
+  private final java.util.concurrent.atomic.AtomicLong resolveTokenCounter =
+      new java.util.concurrent.atomic.AtomicLong();
 
   private ExoPlayer player;
   /** 暴露给 MediaSession 的包装 Player：覆写 availableCommands，让系统媒体面板始终展示上一/下一首。 */
@@ -96,9 +108,18 @@ public final class PlaybackManager {
   private String currentSource = "";
   private String apiBaseUrl = "";
   private String cookie = "";
+  private String songLevel = "exhigh";
+  /** Java 端 URL 解析器：WebView 冻结时仍可自治取地址。 */
+  private final PlaybackUrlResolver urlResolver = new PlaybackUrlResolver();
   private TrackMetadata currentMetadata = new TrackMetadata();
-  private TrackMetadata queuedNextMetadata = null;
-  private String queuedNextSource = "";
+  /**
+   * Java 端自治播放队列（滑动窗口）。
+   *
+   * <p>JS 推 ±N 首窗口；ENDED / NEXT / PREVIOUS 均由 Java 自治。详见 .scratch/native-queue-design.md。
+   */
+  private final PlaybackQueue playbackQueue = new PlaybackQueue();
+  /** 即将耗尽窗口（剩 ≤ 此数）时 emit requestUrls 让 JS 补；2 给 JS 留一定缓冲。 */
+  private static final int WINDOW_REFILL_THRESHOLD = 2;
 
   private boolean controllerEnabled = true;
   private boolean desktopLyricButtonEnabled = false;
@@ -107,26 +128,18 @@ public final class PlaybackManager {
   private boolean allowMixWithOthers = true;
   private boolean canSkipPrevious = true;
   private boolean personalFmMode = false;
-  private boolean repeatOneEnabled = false;
   private boolean liked = false;
   private boolean collapsed = false;
+  /**
+   * ENDED 拦截标记：当窗口耗尽且 hasNextOutsideWindow=true 时，emit requestUrls 后置位。
+   * 下一次 updateQueueContext 收到新窗口后立即 advance + playFromQueue 续播，弥补
+   * "JS 不会主动 play"的链路缺口。
+   */
+  private boolean pendingResumeAfterRefill = false;
   private boolean favoriteRequestInFlight = false;
   private long pendingSeekPositionMs = C.TIME_UNSET;
   private long pendingSeekDeadlineMs = 0L;
   private long lastKnownPositionMs = 0L;
-  /** NEXT 快路径锁：防止 native 快切与 JS autoNext 双线抢跑。 */
-  private boolean pendingNativeNextSync = false;
-  /** 快路径锁超时释放 Runnable。 */
-  private final Runnable pendingNativeNextSyncTimeoutRunnable =
-      () -> {
-        if (pendingNativeNextSync) {
-          android.util.Log.w(
-              TAG,
-              "pendingNativeNextSync timeout (5s without updateQueueContext), force release");
-          pendingNativeNextSync = false;
-        }
-      };
-  private static final long PENDING_NATIVE_NEXT_SYNC_TIMEOUT_MS = 5_000L;
   /** 已用 ExoPlayer 真实 duration 校准过的 source URL。 */
   private String durationCalibratedForSource = "";
   /** 悬浮歌词服务实例（运行时绑定） */
@@ -138,6 +151,16 @@ public final class PlaybackManager {
   private long remoteDurationMs = 0L;
   /** Remote mode 下保持 CPU 唤醒，防止后台音频中断 */
   private PowerManager.WakeLock remoteWakeLock;
+  /**
+   * 音频频谱分析器：实现 Media3 AudioProcessor，挂在 ExoPlayer 解码链上做无权限 FFT 分析。
+   *
+   * 设计成单实例随 PlaybackManager 生命周期：当前是单 ExoPlayer 架构，FFT 处理器随之单实例；
+   * 未来 Automix 复活引入双 ExoPlayer 时，需重构为 currentProcessor / nextProcessor 双实例，
+   * listener 跟随 currentPlayer 切换（参考 memory: Android Automix 复活约束）。
+   */
+  private final FftAudioProcessor fftAudioProcessor = new FftAudioProcessor();
+  /** 频谱是否已启用（JS 端通过 enableVisualizer 控制 listener 设置） */
+  private boolean visualizerRequested = false;
   private final SessionCommand nextSessionCommand =
       new SessionCommand(PlaybackConstants.ACTION_NEXT, Bundle.EMPTY);
   private final SessionCommand previousSessionCommand =
@@ -225,10 +248,12 @@ public final class PlaybackManager {
       new Runnable() {
         @Override
         public void run() {
-          emitProgressChanged();
-
+          // 仅在真正播放时 emit；callback 链常驻，BUFFERING→READY 后下一拍立即续传
+          if (player != null && player.isPlaying()) {
+            emitProgressChanged();
+          }
           if (player != null && player.getCurrentMediaItem() != null) {
-            mainHandler.postDelayed(this, 1000L);
+            mainHandler.postDelayed(this, 250L);
           }
         }
       };
@@ -268,6 +293,9 @@ public final class PlaybackManager {
   public synchronized void detachPlugin(AndroidNativePlaybackPlugin playbackPlugin) {
     if (plugin == playbackPlugin) {
       plugin = null;
+      // plugin 销毁后 emit 没接收方，清 listener 让 FftAudioProcessor 跳过 FFT 计算节电
+      visualizerRequested = false;
+      fftAudioProcessor.setListener(null);
     }
   }
 
@@ -287,6 +315,9 @@ public final class PlaybackManager {
     currentMetadata.url = currentSource;
     clearPendingSeek();
     lastKnownPositionMs = 0L;
+    // 失效在路上的 async resolve 回调；清旧 pending 避免补窗误消费
+    resolveTokenCounter.incrementAndGet();
+    pendingResumeAfterRefill = false;
 
     // 参考 SPlayer-ROM-Compat：先 setMediaItem + prepare，再 seekTo，最后 playWhenReady
     // 不用 setMediaItem(item, startPositionMs) ——某些 ROM/容器格式下 startPositionMs
@@ -344,11 +375,11 @@ public final class PlaybackManager {
     currentSource = "";
     clearPendingSeek();
     lastKnownPositionMs = 0L;
-    queuedNextSource = "";
-    queuedNextMetadata = null;
-    pendingNativeNextSync = false;
-    mainHandler.removeCallbacks(pendingNativeNextSyncTimeoutRunnable);
+    playbackQueue.replace(null, -1, PlaybackQueue.RepeatMode.OFF, false, false, false);
     durationCalibratedForSource = "";
+    // 清 token / pending，避免旧回调搅动新状态
+    resolveTokenCounter.incrementAndGet();
+    pendingResumeAfterRefill = false;
     stopProgressUpdates();
     clearNotification();
     emitPlaybackState(true);
@@ -402,6 +433,12 @@ public final class PlaybackManager {
     emitPlaybackState(true);
   }
 
+  /**
+   * 接收 JS 推送的队列窗口。每次切歌 / 列表变化 / repeat/shuffle 变化都会调一次。
+   *
+   * @param windowTracks 当前 ±N 首（已按 shuffle 排序）
+   * @param hasPreviousOutsideWindow / hasNextOutsideWindow 提示 Java：边缘时需 emit requestUrls
+   */
   public synchronized void updateQueueContext(
       boolean likedState,
       boolean canSkipPreviousState,
@@ -409,8 +446,12 @@ public final class PlaybackManager {
       boolean controllerEnabledState,
       boolean desktopLyricButtonEnabledState,
       boolean desktopLyricEnabledState,
-      boolean repeatOneState,
-      @Nullable TrackMetadata nextTrack) {
+      @Nullable List<PlaybackQueue.Track> windowTracks,
+      int windowCurrentIndex,
+      String repeatMode,
+      boolean hasPreviousOutsideWindow,
+      boolean hasNextOutsideWindow,
+      boolean windowRefilled) {
     liked = likedState;
     currentMetadata.liked = likedState;
     canSkipPrevious = canSkipPreviousState;
@@ -418,24 +459,34 @@ public final class PlaybackManager {
     controllerEnabled = controllerEnabledState;
     desktopLyricButtonEnabled = desktopLyricButtonEnabledState;
     desktopLyricEnabled = desktopLyricEnabledState;
-    repeatOneEnabled = repeatOneState;
-    queuedNextMetadata = nextTrack == null ? null : nextTrack.copy();
-    queuedNextSource =
-        queuedNextMetadata == null || queuedNextMetadata.url == null ? "" : queuedNextMetadata.url;
-    // JS 端通过 updateQueueContext 推送新的 next 表明已经感知并处理了上一次的 autoNext，
-    // 此时清除快路径锁，让后续 ACTION_NEXT 重新可以走 native 直切。
-    pendingNativeNextSync = false;
-    mainHandler.removeCallbacks(pendingNativeNextSyncTimeoutRunnable);
+
+    playbackQueue.replace(
+        windowTracks,
+        windowCurrentIndex,
+        PlaybackQueue.RepeatMode.fromString(repeatMode),
+        hasPreviousOutsideWindow,
+        hasNextOutsideWindow,
+        personalFmModeState);
+
+    // 立即预解析前方未解析项，避免后台 ENDED 时才发现无 URL。
+    prefetchUpcomingUrls();
     updateMediaSessionButtons();
     updateNotification();
     emitPlaybackState(false);
-  }
 
-  /** 安排快路径锁超时释放，重复调用会重置计时。 */
-  private void schedulePendingNativeNextSyncTimeout() {
-    mainHandler.removeCallbacks(pendingNativeNextSyncTimeoutRunnable);
-    mainHandler.postDelayed(
-        pendingNativeNextSyncTimeoutRunnable, PENDING_NATIVE_NEXT_SYNC_TIMEOUT_MS);
+    // ENDED 续播链路：上次 ENDED 因窗口耗尽 emit 了 requestUrls，现在新窗口已到位，
+    // Java 必须主动驱动下一首；否则 ExoPlayer 停在 ENDED，用户感知"卡死"。
+    //
+    // 仅当 JS 端通过 refreshAndroidQueueWindow 路径推送（windowRefilled=true）才视为有效补窗响应。
+    // 其他无关路径（liked 切换、桌面歌词开关、本地元数据加载等）也会调 syncAndroidPlaybackContext，
+    // 若不门控会导致那些 sync 误触发续播，播错歌或播未完全 resolve 的曲目。
+    if (pendingResumeAfterRefill && windowRefilled) {
+      pendingResumeAfterRefill = false;
+      PlaybackQueue.Track resume = playbackQueue.advanceRaw(false);
+      if (resume != null) {
+        resolveAndPlayAsync(resume, "auto", true, 5);
+      }
+    }
   }
 
   public synchronized void updateNotificationPrefs(
@@ -463,9 +514,13 @@ public final class PlaybackManager {
     }
   }
 
-  public synchronized void syncApiContext(String baseUrl, String cookieValue) {
+  public synchronized void syncApiContext(String baseUrl, String cookieValue, String level) {
     apiBaseUrl = baseUrl == null ? "" : baseUrl.trim();
     cookie = cookieValue == null ? "" : cookieValue.trim();
+    if (level != null && !level.isEmpty()) {
+      songLevel = level;
+    }
+    urlResolver.updateContext(apiBaseUrl, cookie, songLevel);
   }
 
   /**
@@ -555,29 +610,34 @@ public final class PlaybackManager {
         }
         break;
       case PlaybackConstants.ACTION_NEXT:
-        // 后台时 WebView 可能被冻结、JS 响应不及；有预载则 native 直接切歌 + emit autoNext，
-        // 其余场景（personalFM、快路径锁中、无预载）回落到 emit next 由 JS 处理。
-        if (!personalFmMode
-            && !pendingNativeNextSync
-            && queuedNextSource != null
-            && !queuedNextSource.isEmpty()
-            && queuedNextMetadata != null) {
-          TrackMetadata nextMetadata = queuedNextMetadata;
-          boolean nextLiked = nextMetadata.liked;
-          int nextSongId = nextMetadata.songId;
-          startTrackFromState(queuedNextSource, nextMetadata, nextLiked, true);
-          queuedNextMetadata = null;
-          queuedNextSource = "";
-          pendingNativeNextSync = true;
-          emitCustomAction("autoNext", nextSongId, nextLiked, null, null, true, null);
-          // 5s 超时兜底：防 JS 异常路径不调 updateQueueContext 导致锁永久卡住。
-          schedulePendingNativeNextSyncTimeout();
-        } else {
-          emitCustomAction("next", null, null, null, null, true, null);
+        // 全自治：advanceRaw 取下一首（允许 url==null），resolveAndPlayAsync 补 URL。
+        if (!personalFmMode) {
+          PlaybackQueue.Track next = playbackQueue.advanceRaw(false);
+          if (next != null) {
+            resolveAndPlayAsync(next, "next", true, 5);
+            break;
+          }
+          // 窗口右缘耗尽：JS 端补窗口后续播。覆盖两种场景：
+          // 1. 还有后续歌（hasNextOutsideWindow=true）：JS 推下一页窗口
+          // 2. 已是末尾 + ALL 模式（hasPreviousOutsideWindow=true）：JS 负责 wrap 到 0
+          if (shouldRequestUrlsForwardWrap()) {
+            pendingResumeAfterRefill = true;
+            emitRequestUrls();
+            break;
+          }
         }
+        // personalFM / 队列空 / 窗口全耗尽：回退 JS
+        emitCustomAction("next", null, null, null, null, true, null);
         break;
       case PlaybackConstants.ACTION_PREVIOUS:
-        // 边界（personalFM、列表为空、playIndex 越界）全交给 JS 的 nextOrPrev("prev")。
+        // 同 ACTION_NEXT 设计：Java 自解 URL，不依赖 WebView。
+        if (!personalFmMode) {
+          PlaybackQueue.Track prev = playbackQueue.backRaw();
+          if (prev != null) {
+            resolveAndPlayAsync(prev, "previous", false, 3);
+            break;
+          }
+        }
         emitCustomAction("previous", null, null, null, null, true, null);
         break;
       case PlaybackConstants.ACTION_FAVORITE:
@@ -652,7 +712,25 @@ public final class PlaybackManager {
 
     createNotificationChannel();
 
-    player = new ExoPlayer.Builder(appContext)
+    // 自定义 RenderersFactory：override buildAudioSink 注入 FftAudioProcessor。
+    // 数组形式（虽然现在只有一个 processor）是为后续 Automix 复活时可加 GainAudioProcessor
+    // 实现淡入淡出预留扩展位。
+    DefaultRenderersFactory renderersFactory =
+        new DefaultRenderersFactory(appContext) {
+          @Override
+          protected AudioSink buildAudioSink(
+              Context context,
+              boolean enableFloatOutput,
+              boolean enableAudioTrackPlaybackParams) {
+            return new DefaultAudioSink.Builder(context)
+                .setEnableFloatOutput(enableFloatOutput)
+                .setEnableAudioTrackPlaybackParams(enableAudioTrackPlaybackParams)
+                .setAudioProcessors(new AudioProcessor[] {fftAudioProcessor})
+                .build();
+          }
+        };
+
+    player = new ExoPlayer.Builder(appContext, renderersFactory)
         .setMediaSourceFactory(
             new DefaultMediaSourceFactory(
                 appContext,
@@ -667,6 +745,9 @@ public final class PlaybackManager {
             .build(),
         !allowMixWithOthers);
     player.setHandleAudioBecomingNoisy(true);
+    // 后台播放关键：WAKE_MODE_NETWORK 同时锁 CPU + WiFi，防止 Doze 节流网络 prepare 与音频帧解码
+    // 一旦应用进入 Doze，没有 wakelock 的 ExoPlayer 会 prepare 失败或播放卡顿，导致后台 ENDED 后切下一首没声音
+    player.setWakeMode(C.WAKE_MODE_NETWORK);
     player.addListener(
         new Player.Listener() {
           @Override
@@ -690,6 +771,7 @@ public final class PlaybackManager {
 
           @Override
           public void onIsPlayingChanged(boolean isPlaying) {
+            // 不在 false 分支 stopProgressUpdates：BUFFERING/seek/stall 也是 false，停链路会卡切歌
             if (isPlaying) {
               startProgressUpdates();
             }
@@ -776,7 +858,7 @@ public final class PlaybackManager {
     coverArtworkBytes = encodeArtworkBytes(coverBitmap);
   }
 
-  /** 用 ExoPlayer 真实 duration 校准 metadata；同一 source 只走一次，偏差 ≤ 500ms 跳过。 */
+  /** 用 ExoPlayer 真实 duration 校准 metadata。允许同一 source 多次再校准（buffering 早期值可能偏差） */
   private void calibrateDurationFromPlayer() {
     if (player == null) {
       return;
@@ -784,14 +866,21 @@ public final class PlaybackManager {
     if (currentSource == null || currentSource.isEmpty()) {
       return;
     }
-    if (currentSource.equals(durationCalibratedForSource)) {
-      return;
-    }
     long realDurationMs = player.getDuration();
     if (realDurationMs == C.TIME_UNSET || realDurationMs <= 0L) {
       return;
     }
+    // 同一 source 已经做过初次校准时，仅在新值与已校准值差异 > 1s 时再次校准；
+    // 这样既避免每次 progress tick 都触发刷新（噪声），又允许 DASH/CBR 等场景在 buffering
+    // 早期取到偏差大的初值后被后续更准确的值替换。
+    final long stabilityThresholdMs = 1000L;
+    if (currentSource.equals(durationCalibratedForSource)
+        && Math.abs(realDurationMs - currentMetadata.durationMs) <= stabilityThresholdMs) {
+      return;
+    }
     durationCalibratedForSource = currentSource;
+    // 500ms 不敏感窗口：避免 ExoPlayer duration 在 buffering 后期微小抖动（±100~200ms）
+    // 反复触发 refreshCurrentMediaItemMetadata → emit trackChanged，污染 JS 进度同步。
     if (Math.abs(realDurationMs - currentMetadata.durationMs) <= 500L) {
       return;
     }
@@ -842,8 +931,16 @@ public final class PlaybackManager {
     if (currentMetadata.album != null) {
       builder.setAlbumTitle(currentMetadata.album);
     }
-    if (currentMetadata.durationMs > 0) {
-      builder.setDurationMs(currentMetadata.durationMs);
+    // 锁屏 / 通知栏 / 进度总长以 ExoPlayer 实测 ms 为权威，避免上游元数据 dt 偏差造成进度条与实际播放错位。
+    long resolvedDurationMs = currentMetadata.durationMs;
+    if (player != null) {
+      long realDurationMs = player.getDuration();
+      if (realDurationMs != C.TIME_UNSET && realDurationMs > 0L) {
+        resolvedDurationMs = realDurationMs;
+      }
+    }
+    if (resolvedDurationMs > 0L) {
+      builder.setDurationMs(resolvedDurationMs);
     }
     if (currentMetadata.coverUrl != null
         && !currentMetadata.coverUrl.isEmpty()
@@ -882,22 +979,182 @@ public final class PlaybackManager {
   }
 
   private boolean handleAutoAdvanceOnEnded() {
-    if (repeatOneEnabled && currentSource != null && !currentSource.isEmpty()) {
-      startTrackFromState(currentSource, currentMetadata, liked, false);
-      return true;
-    }
-
-    if (queuedNextSource == null || queuedNextSource.isEmpty() || queuedNextMetadata == null) {
+    if (personalFmMode) {
+      // personalFM：JS 算法决定下一首，原生层不能自治
       return false;
     }
-
-    TrackMetadata nextMetadata = queuedNextMetadata;
-    boolean nextLiked = nextMetadata.liked;
-    startTrackFromState(queuedNextSource, nextMetadata, nextLiked, true);
-    queuedNextMetadata = null;
-    queuedNextSource = "";
-    emitCustomAction("autoNext", nextMetadata.songId, nextLiked, null, null, true, null);
+    // ENDED 路径响应 repeatOne（advanceRaw(true) 单曲循环时返回当前 track）。
+    // 不再因 url==null 而 return null —— Java 自解 URL，让 resolveAndPlayAsync 接管。
+    PlaybackQueue.Track next = playbackQueue.advanceRaw(true);
+    if (next == null) {
+      // 真正窗口耗尽（不在 ALL 模式 / 没有更多歌曲）
+      if (shouldRequestUrlsForwardWrap()) {
+        // 拦截 ENDED + 置位续播标记：updateQueueContext 收到新窗口后将主动 advance+play
+        pendingResumeAfterRefill = true;
+        emitRequestUrls();
+        return true;
+      }
+      return false;
+    }
+    resolveAndPlayAsync(next, "auto", true, 5);
     return true;
+  }
+
+  /**
+   * 前进方向窗口耗尽时是否需要让 JS 端补窗口：
+   *
+   * <ul>
+   *   <li>hasNextOutsideWindow=true：还有后续歌曲（常规补窗）
+   *   <li>ALL 模式 + hasPreviousOutsideWindow=true：已是末尾，JS 负责 wrap 到 0
+   * </ul>
+   *
+   * <p>该函数不要与 {@link #requestUrlsIfWindowExhausted()} 混淆后者是「快到边」预警，
+   * 本函数是「确实边上跳不动」必须补。
+   */
+  private boolean shouldRequestUrlsForwardWrap() {
+    if (playbackQueue.hasNextOutsideWindow()) return true;
+    return playbackQueue.getRepeatMode() == PlaybackQueue.RepeatMode.ALL
+        && playbackQueue.hasPreviousOutsideWindow();
+  }
+
+  /**
+   * Java URL 自治核心：url==null 则后台解析后开播，失败则跳过继续。
+   *
+   * @param forward true=失败时 advanceRaw 跳过坏首；false=停止（previous）
+   * @param remainAttempts 连续失败限额，超过后回落 JS
+   */
+  private void resolveAndPlayAsync(
+      @Nullable PlaybackQueue.Track next,
+      String source,
+      boolean forward,
+      int remainAttempts) {
+    if (next == null) {
+      if (forward && shouldRequestUrlsForwardWrap()) {
+        // 前进方向窗口耗尽：置位续播标记，让 JS 推新窗口后自动续播
+        pendingResumeAfterRefill = true;
+        emitRequestUrls();
+      } else if (!forward) {
+        // 后退方向窗口耗尽：回落 JS prev（不应触发 requestUrls，那是右缘语义）
+        emitCustomAction("previous", null, null, null, null, true, null);
+      }
+      return;
+    }
+    if (next.playable()) {
+      playFromQueue(next, source);
+      prefetchUpcomingUrls();
+      return;
+    }
+    if (remainAttempts <= 0) {
+      // 连续失败（账号 / 解锁 / 区域屏蔽）
+      if (forward) {
+        pendingResumeAfterRefill = true;
+        emitRequestUrls();
+      } else {
+        emitCustomAction("previous", null, null, null, null, true, null);
+      }
+      return;
+    }
+    final long songId = next.songId;
+    final PlaybackQueue.Track target = next;
+    // 自增 token：用户连点 NEXT 时旧 token 失效，回调直接丢弃，防止旧 URL 覆盖新播放
+    final long myToken = resolveTokenCounter.incrementAndGet();
+    urlResolver.submitResolve(
+        songId,
+        url ->
+            mainHandler.post(
+                () -> {
+                  if (myToken != resolveTokenCounter.get()) {
+                    // 过期回调：用户已发起新一轮 NEXT/PREV，丢弃本次结果
+                    return;
+                  }
+                  if (url != null) {
+                    target.url = url;
+                    playbackQueue.updateTrackUrl(songId, url);
+                    playFromQueue(target, source);
+                    prefetchUpcomingUrls();
+                  } else if (forward) {
+                    Log.w(TAG, "resolveAndPlayAsync: songId=" + songId + " failed, skip forward");
+                    PlaybackQueue.Track again = playbackQueue.advanceRaw(false);
+                    resolveAndPlayAsync(again, source, true, remainAttempts - 1);
+                  } else {
+                    // PREVIOUS 失败：再 backRaw 跳过坏首继续后退；前缘耗尽时回落 JS prev
+                    Log.w(TAG, "resolveAndPlayAsync: songId=" + songId + " failed, skip backward");
+                    PlaybackQueue.Track again = playbackQueue.backRaw();
+                    resolveAndPlayAsync(again, source, false, remainAttempts - 1);
+                  }
+                }));
+  }
+
+  /** 预解析窗口前方 3 首，让 ENDED 时直接 playable；重复 prefetch 由 urlResolver.inFlight 去重 */
+  private void prefetchUpcomingUrls() {
+    List<PlaybackQueue.Track> upcoming = playbackQueue.peekUpcomingUnresolved(3);
+    for (PlaybackQueue.Track t : upcoming) {
+      urlResolver.prefetchAsync(t, playbackQueue, null);
+    }
+  }
+
+  /**
+   * 从队列指定 Track 切歌并 emit trackChanged。
+   *
+   * @param source "auto" (ENDED) / "next" / "previous"
+   */
+  private void playFromQueue(PlaybackQueue.Track track, String source) {
+    if (track == null || !track.playable()) {
+      return;
+    }
+    // 切歌即失效旧 async 回调 + 清 pending，防止旧 URL 覆盖 / 补窗误消费
+    resolveTokenCounter.incrementAndGet();
+    pendingResumeAfterRefill = false;
+    TrackMetadata metadata = trackToMetadata(track);
+    startTrackFromState(track.url, metadata, track.liked, true);
+
+    // 通知 JS：native 已切到这首歌，请同步 statusStore.playIndex
+    AndroidNativePlaybackPlugin currentPlugin = plugin;
+    if (currentPlugin != null) {
+      JSObject payload = new JSObject();
+      payload.put("action", "trackChanged");
+      payload.put("success", true);
+      payload.put("songId", track.songId);
+      payload.put("playListIndex", track.playListIndex);
+      payload.put("source", source);
+      payload.put("liked", track.liked);
+      currentPlugin.emitEvent("customAction", payload, true);
+    }
+
+    // 窗口边缘提前补 URL
+    requestUrlsIfWindowExhausted();
+  }
+
+  /** 转换 PlaybackQueue.Track → TrackMetadata（复用现有切歌路径） */
+  private TrackMetadata trackToMetadata(PlaybackQueue.Track track) {
+    TrackMetadata m = new TrackMetadata();
+    m.songId = track.songId;
+    m.durationMs = track.durationMs;
+    m.canLike = track.canLike;
+    m.liked = track.liked;
+    m.title = track.title;
+    m.artist = track.artist;
+    m.album = track.album;
+    m.coverUrl = track.coverUrl;
+    m.url = track.url == null ? "" : track.url;
+    return m;
+  }
+
+  /** 仅在窗口外仍有歌时主动通知 JS 推新窗口（窗口外耗尽时无意义）。 */
+  private void requestUrlsIfWindowExhausted() {
+    if (playbackQueue.playableTracksAhead() <= WINDOW_REFILL_THRESHOLD
+        && playbackQueue.hasNextOutsideWindow()) {
+      emitRequestUrls();
+    }
+  }
+
+  private void emitRequestUrls() {
+    AndroidNativePlaybackPlugin currentPlugin = plugin;
+    if (currentPlugin == null) return;
+    JSObject payload = new JSObject();
+    payload.put("action", "requestUrls");
+    payload.put("success", true);
+    currentPlugin.emitEvent("customAction", payload, true);
   }
 
   private void startTrackFromState(
@@ -1032,8 +1289,16 @@ public final class PlaybackManager {
     }
 
     Notification notification = buildNotification();
+    // 仅在「用户主动暂停」撤前台。ENDED / IDLE / BUFFERING 是过渡态，提前撤前台
+    // 会被 Android 12+ 拒 (ForegroundServiceStartNotAllowedException)，导致 NEXT 哑火。
+    boolean userPaused = !remoteMode
+        && player != null
+        && player.getPlaybackState() == Player.STATE_READY
+        && !player.getPlayWhenReady();
+    boolean remotePaused = remoteMode && !remoteIsPlaying;
+    boolean shouldStayForeground = !userPaused && !remotePaused;
     try {
-      if (isEffectivelyPlaying() || isEffectivelyBuffering()) {
+      if (shouldStayForeground) {
         service.startForeground(PlaybackConstants.NOTIFICATION_ID, notification);
       } else {
         service.stopForeground(false);
@@ -1042,6 +1307,12 @@ public final class PlaybackManager {
       }
     } catch (SecurityException error) {
       Log.w(TAG, "Failed to show playback notification", error);
+    } catch (IllegalStateException error) {
+      // Android 12+ ForegroundServiceStartNotAllowedException 继承 IllegalStateException，
+      // 在 Doze 边缘 / 系统极限场景偶发。仅记录，让通知降级为普通通知，避免崩溃。
+      Log.w(TAG, "Failed to enter foreground service from background", error);
+      NotificationManagerCompat.from(appContext)
+          .notify(PlaybackConstants.NOTIFICATION_ID, notification);
     }
   }
 
@@ -1326,7 +1597,7 @@ public final class PlaybackManager {
 
   private void emitCustomAction(
       String action,
-      @Nullable Integer songId,
+      @Nullable Long songId,
       @Nullable Boolean likedState,
       @Nullable Boolean desktopLyricEnabledState,
       @Nullable Boolean collapsedState,
@@ -1357,6 +1628,87 @@ public final class PlaybackManager {
     }
     currentPlugin.emitEvent("customAction", payload, true);
   }
+
+  // ========== 频谱可视化（基于 Media3 AudioProcessor 内嵌 FFT，无需任何权限）==========
+
+  /**
+   * JS 端开启/关闭频谱。
+   *
+   * 实现细节：FftAudioProcessor 一直挂在 ExoPlayer 解码链上，仅当 listener != null 时
+   * 才执行实际的 FFT 计算（最佳节电）。
+   */
+  public synchronized boolean enableVisualizer(boolean enable) {
+    visualizerRequested = enable;
+    updateFftListenerAttachment();
+    return true;
+  }
+
+  /** 根据频谱请求状态挂载或卸载 FFT 数据回调。 */
+  private void updateFftListenerAttachment() {
+    if (visualizerRequested) {
+      fftAudioProcessor.setListener(this::onFftData);
+    } else {
+      fftAudioProcessor.setListener(null);
+    }
+  }
+
+  /**
+   * FFT 回调（音频线程）：只写 snapshot 并请求主线程 emit，杜绝音频线程跑 base64 / bridge。
+   * coalescing：CAS 保证 mainHandler 队列同时最多 1 个 task，多余帧只覆盖 snapshot。
+   */
+  private void onFftData(int[] fftBins, float lowFreq) {
+    if (!visualizerRequested) return;
+    int len = fftBins.length;
+    synchronized (visualizerSnapshotLock) {
+      if (visualizerByteBuf == null || visualizerByteBuf.length != len) {
+        visualizerByteBuf = new byte[len];
+      }
+      for (int i = 0; i < len; i++) {
+        visualizerByteBuf[i] = (byte) fftBins[i];
+      }
+      pendingLowFreq = lowFreq;
+      hasPendingVisualizerData = true;
+    }
+    if (visualizerEmitScheduled.compareAndSet(false, true)) {
+      mainHandler.post(visualizerEmitTask);
+    }
+  }
+
+  // 频谱共享缓冲与同步原语
+  private final Object visualizerSnapshotLock = new Object();
+
+  private byte[] visualizerByteBuf;
+  private float pendingLowFreq;
+  private boolean hasPendingVisualizerData = false;
+
+  private final java.util.concurrent.atomic.AtomicBoolean visualizerEmitScheduled =
+      new java.util.concurrent.atomic.AtomicBoolean(false);
+
+  /** 主线程 emit：先释放 schedule 让新帧能再 post，clone snapshot 后 base64 推送。 */
+  private final Runnable visualizerEmitTask =
+      new Runnable() {
+        @Override
+        public void run() {
+          visualizerEmitScheduled.set(false);
+          AndroidNativePlaybackPlugin currentPlugin = plugin;
+          if (currentPlugin == null) return;
+
+          byte[] snapshot;
+          float lowFreq;
+          synchronized (visualizerSnapshotLock) {
+            if (!hasPendingVisualizerData || visualizerByteBuf == null) return;
+            snapshot = visualizerByteBuf.clone();
+            lowFreq = pendingLowFreq;
+            hasPendingVisualizerData = false;
+          }
+
+          String b64 = android.util.Base64.encodeToString(snapshot, android.util.Base64.NO_WRAP);
+          JSObject payload = new JSObject();
+          payload.put("fftB64", b64);
+          payload.put("lowFreq", lowFreq);
+          currentPlugin.emitEvent("visualizerData", payload, false);
+        }
+      };
 
   private void loadCoverBitmapAsync(String coverUrl) {
     if (coverUrl == null || coverUrl.isEmpty() || coverUrl.startsWith("blob:")) {
@@ -1427,7 +1779,7 @@ public final class PlaybackManager {
     }
 
     final boolean targetLike = !liked;
-    final int songId = currentMetadata.songId;
+    final long songId = currentMetadata.songId;
     synchronized (this) {
       if (favoriteRequestInFlight) {
         emitCustomAction("favorite", songId, liked, null, null, false, "favorite_busy");
@@ -1461,7 +1813,7 @@ public final class PlaybackManager {
         });
   }
 
-  private FavoriteRequestResult performFavoriteRequest(int songId, boolean targetLike) {
+  private FavoriteRequestResult performFavoriteRequest(long songId, boolean targetLike) {
     String likeEndpoint = apiBaseUrl.endsWith("/like") ? apiBaseUrl : apiBaseUrl + "/like";
 
     for (int attempt = 1; attempt <= FAVORITE_REQUEST_MAX_ATTEMPTS; attempt++) {
@@ -1732,7 +2084,8 @@ public final class PlaybackManager {
   }
 
   static final class TrackMetadata {
-    int songId;
+    // long：上游 songId 可能超 int32 上限，溢出会导致 liked/favorite/prefetch 全错
+    long songId;
     long durationMs;
     boolean canLike;
     boolean liked;

--- a/android/app/src/main/java/top/imsyy/splayer/android/playback/PlaybackQueue.java
+++ b/android/app/src/main/java/top/imsyy/splayer/android/playback/PlaybackQueue.java
@@ -1,0 +1,244 @@
+package top.imsyy.splayer.android.playback;
+
+import androidx.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Java 端自治的滑动窗口播放队列。WebView 冻结时仍能自主切歌。
+ *
+ * <p>JS 端推 ±N 首窗口（{@code updateQueueContext}），Java 端窗口耗尽时 emit
+ * {@code requestUrls} 让 JS 补。不线程安全，依赖 PlaybackManager 的 synchronized。
+ *
+ * <p>详见 .scratch/native-queue-design.md。
+ */
+public final class PlaybackQueue {
+  /** 当前窗口（已按 shuffleMode 排过序） */
+  private List<Track> windowTracks = Collections.emptyList();
+  /** 当前正在播的曲目在 windowTracks 中的索引；-1 表示队列空 */
+  private int windowCurrentIndex = -1;
+  /** 循环模式：跨歌曲行为由此决定 */
+  private RepeatMode repeatMode = RepeatMode.OFF;
+  /** 全局是否还有上一首 / 下一首（窗口外信息，由 JS 端计算后传入） */
+  private boolean hasPreviousOutsideWindow = false;
+  private boolean hasNextOutsideWindow = false;
+  /** personalFM 模式：单首推进，不预解析多首 */
+  private boolean personalFmMode = false;
+
+  public enum RepeatMode {
+    OFF,
+    ALL,
+    ONE;
+
+    public static RepeatMode fromString(@Nullable String value) {
+      if (value == null) return OFF;
+      switch (value) {
+        case "all":
+          return ALL;
+        case "one":
+          return ONE;
+        default:
+          return OFF;
+      }
+    }
+  }
+
+  /** 单首曲目元数据 + 已解析 URL。 */
+  public static final class Track {
+    /** 网易云 songId。必须 long：2024+ 部分 ID 超过 Integer.MAX_VALUE，int 会溢出为负。 */
+    public long songId;
+    public long durationMs;
+    public boolean canLike;
+    public boolean liked;
+    public String title = "";
+    public String artist = "";
+    public String album = "";
+    public String coverUrl = "";
+    /** 已解析的播放 URL；null 表示尚未解析（Java 端会按需通过 UrlResolver 补齐）。 */
+    @Nullable public String url;
+    /** 该曲目在 JS 端 playList 中的实际索引，回调时让 JS 直接定位 */
+    public int playListIndex = -1;
+    /**
+     * 显式跳过标志：JS 端 shouldSkipSong（Fuck DJ Mode）置 true。
+     *
+     * <p>语义与 url==null 严格区分：
+     * <ul>
+     *   <li>url==null + skipSong=false → 还没 prefetch，Java 应主动解析后播放
+     *   <li>skipSong=true → 用户屏蔽，Java 在 advance/back/peek 时直接跳过，不调上游解析接口
+     * </ul>
+     */
+    public boolean skipSong = false;
+
+    public Track copy() {
+      Track c = new Track();
+      c.songId = songId;
+      c.durationMs = durationMs;
+      c.canLike = canLike;
+      c.liked = liked;
+      c.title = title;
+      c.artist = artist;
+      c.album = album;
+      c.coverUrl = coverUrl;
+      c.url = url;
+      c.playListIndex = playListIndex;
+      c.skipSong = skipSong;
+      return c;
+    }
+
+    public boolean playable() {
+      return url != null && !url.isEmpty();
+    }
+  }
+
+  /** 替换整个窗口（来自 JS 端 updateQueueContext）。 */
+  public synchronized void replace(
+      List<Track> tracks,
+      int currentIndex,
+      RepeatMode mode,
+      boolean prevOutside,
+      boolean nextOutside,
+      boolean personalFm) {
+    // 拷贝传入列表防御性隔离，避免外部 mutation 影响内部状态
+    if (tracks == null || tracks.isEmpty()) {
+      windowTracks = Collections.emptyList();
+      windowCurrentIndex = -1;
+    } else {
+      List<Track> copy = new ArrayList<>(tracks.size());
+      for (Track t : tracks) {
+        if (t != null) copy.add(t.copy());
+      }
+      windowTracks = copy;
+      // -1 透传：表示 JS 端尚未确定 current（如列表瞬时清空），不强制视为 0；
+      // 否则 favorite/同步等会作用在错误的"窗口首曲"上。
+      if (currentIndex < 0) {
+        windowCurrentIndex = -1;
+      } else if (currentIndex >= copy.size()) {
+        windowCurrentIndex = copy.size() - 1;
+      } else {
+        windowCurrentIndex = currentIndex;
+      }
+    }
+    repeatMode = mode == null ? RepeatMode.OFF : mode;
+    hasPreviousOutsideWindow = prevOutside;
+    hasNextOutsideWindow = nextOutside;
+    personalFmMode = personalFm;
+  }
+
+  /** 当前曲目（可能为 null：队列空 / index 越界）。 */
+  @Nullable
+  public synchronized Track current() {
+    if (windowCurrentIndex < 0 || windowCurrentIndex >= windowTracks.size()) return null;
+    return windowTracks.get(windowCurrentIndex);
+  }
+
+  /** 当前 index 距窗口右边缘的非 skipSong 剩余首数，<= edgeThreshold 时调用方应 emit requestUrls。 */
+  public synchronized int playableTracksAhead() {
+    if (windowTracks.isEmpty() || windowCurrentIndex < 0) return 0;
+    int count = 0;
+    for (int i = windowCurrentIndex + 1; i < windowTracks.size(); i++) {
+      if (!windowTracks.get(i).skipSong) count++;
+    }
+    return count;
+  }
+
+  public synchronized boolean hasPreviousOutsideWindow() {
+    return hasPreviousOutsideWindow;
+  }
+
+  public synchronized boolean hasNextOutsideWindow() {
+    return hasNextOutsideWindow;
+  }
+
+  /**
+   * 推进下一首；跳过 skipSong=true 的曲目（Fuck DJ 等用户级屏蔽），
+   * 但不跳过 url==null（让 UrlResolver 后台解析）。
+   *
+   * @param respectRepeatOne ENDED 调用传 true（响应单曲循环），用户 NEXT 传 false
+   */
+  @Nullable
+  public synchronized Track advanceRaw(boolean respectRepeatOne) {
+    if (windowTracks.isEmpty()) return null;
+    if (respectRepeatOne && repeatMode == RepeatMode.ONE) {
+      return current();
+    }
+    int probe = windowCurrentIndex + 1;
+    while (probe < windowTracks.size()) {
+      Track t = windowTracks.get(probe);
+      if (!t.skipSong) {
+        windowCurrentIndex = probe;
+        return t;
+      }
+      probe++;
+    }
+    // 窗口右缘：仅当窗口完整覆盖全局列表（前后均无外部歌曲）时，ALL 模式才可在窗口内 wrap。
+    // 若 hasNextOutsideWindow=true 或 hasPreviousOutsideWindow=true，必须返 null 让上层 emit
+    // requestUrls 让 JS 重新构造窗口（含 wrap 到 0 的语义），否则会跳过窗口外所有曲目错误回到
+    // windowTracks[0]。
+    if (repeatMode == RepeatMode.ALL
+        && !hasPreviousOutsideWindow
+        && !hasNextOutsideWindow
+        && !windowTracks.isEmpty()) {
+      // 窗口完整覆盖全局：从头扫描第一个非 skip 曲目
+      for (int i = 0; i < windowTracks.size(); i++) {
+        Track t = windowTracks.get(i);
+        if (!t.skipSong) {
+          windowCurrentIndex = i;
+          return t;
+        }
+      }
+    }
+    return null;
+  }
+
+  /** 后退一首；同样跳过 skipSong=true 的曲目。窗口前缘耗尽返回 null。 */
+  @Nullable
+  public synchronized Track backRaw() {
+    if (windowTracks.isEmpty()) return null;
+    int probe = windowCurrentIndex - 1;
+    while (probe >= 0) {
+      Track t = windowTracks.get(probe);
+      if (!t.skipSong) {
+        windowCurrentIndex = probe;
+        return t;
+      }
+      probe--;
+    }
+    return null;
+  }
+
+  /** 从当前 index 之后取 N 首 url==null 且 !skipSong 的曲目；UrlResolver 据此后台批量预解析。 */
+  public synchronized List<Track> peekUpcomingUnresolved(int count) {
+    List<Track> out = new ArrayList<>(count);
+    if (windowTracks.isEmpty() || windowCurrentIndex < 0) return out;
+    for (int i = windowCurrentIndex + 1; i < windowTracks.size() && out.size() < count; i++) {
+      Track t = windowTracks.get(i);
+      if (t.url == null && !t.skipSong) out.add(t);
+    }
+    return out;
+  }
+
+  /** 用 songId 在窗口里查找 Track 并就地写回 url（UrlResolver 解析完成回调用）。 */
+  public synchronized boolean updateTrackUrl(long songId, @Nullable String url) {
+    if (url == null || url.isEmpty()) return false;
+    for (Track t : windowTracks) {
+      if (t.songId == songId) {
+        t.url = url;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public synchronized boolean isPersonalFm() {
+    return personalFmMode;
+  }
+
+  public synchronized RepeatMode getRepeatMode() {
+    return repeatMode;
+  }
+
+  public synchronized boolean isEmpty() {
+    return windowTracks.isEmpty();
+  }
+}

--- a/android/app/src/main/java/top/imsyy/splayer/android/playback/PlaybackUrlResolver.java
+++ b/android/app/src/main/java/top/imsyy/splayer/android/playback/PlaybackUrlResolver.java
@@ -1,0 +1,268 @@
+package top.imsyy.splayer.android.playback;
+
+import android.util.Log;
+import androidx.annotation.Nullable;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * Java 端 URL 解析器。WebView 冻结时仍可通过本地 embedded API（127.0.0.1:1145）拿到播放地址。
+ *
+ * <p>{@link #resolveSync} 阻塞调 /song/url/v1；{@link #prefetchAsync} 后台解析并写回
+ * track.url。内置 64 项 LRU 缓存，2 线程并发。
+ */
+public final class PlaybackUrlResolver {
+  private static final String TAG = "UrlResolver";
+  private static final int CONNECT_TIMEOUT_MS = 8000;
+  private static final int READ_TIMEOUT_MS = 8000;
+  private static final int CACHE_SIZE = 64;
+  /** 失败 songId 短期负缓存窗口（毫秒）：跨多次 prefetch 周期同一首失败时避免持续打上游 /song/url 接口。 */
+  private static final long NEGATIVE_CACHE_TTL_MS = 30_000L;
+
+  /** 2 线程：避免「播放刚起 + 用户立刻 NEXT」被串行。上游接口有节流，不宜调高。 */
+  private final ExecutorService executor = Executors.newFixedThreadPool(2);
+
+  /** cacheKey("songId:level") → URL。level 不同 → 文件/码率/endpoint 都可能不同，必须分键。 */
+  private final LinkedHashMap<String, String> cache =
+      new LinkedHashMap<String, String>(16, 0.75f, true) {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<String, String> eldest) {
+          return size() > CACHE_SIZE;
+        }
+      };
+
+  /** 正在解析的 songId 去重（LinkedHashMap 充当 set）。 */
+  private final LinkedHashMap<Long, AtomicBoolean> inFlight = new LinkedHashMap<>();
+
+  /** cacheKey("songId:level") → 失败时间戳；TTL 内重复请求直接返 null，避免 API 打风暴。 */
+  private final LinkedHashMap<String, Long> negativeCache =
+      new LinkedHashMap<String, Long>(16, 0.75f, true) {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<String, Long> eldest) {
+          return size() > CACHE_SIZE;
+        }
+      };
+
+  private volatile String apiBaseUrl = "";
+  private volatile String cookie = "";
+  private volatile String songLevel = "exhigh";
+
+  public synchronized void updateContext(
+      @Nullable String baseUrl, @Nullable String cookieValue, @Nullable String level) {
+    String newBaseUrl = baseUrl == null ? "" : baseUrl.trim();
+    String newCookie = cookieValue == null ? "" : cookieValue.trim();
+    String newLevel = level != null && !level.isEmpty() ? level : this.songLevel;
+
+    // 任一上下文变化都要清缓存：
+    // - level 变 → URL 文件/码率/endpoint 不同
+    // - cookie 变 → 换账号，旧账号缓存的 VIP URL / 失败记录都不再适用
+    // - baseUrl 变 → embedded API 地址变更（极罕见），缓存失效
+    boolean contextChanged =
+        !newBaseUrl.equals(this.apiBaseUrl)
+            || !newCookie.equals(this.cookie)
+            || !newLevel.equals(this.songLevel);
+
+    this.apiBaseUrl = newBaseUrl;
+    this.cookie = newCookie;
+    this.songLevel = newLevel;
+
+    if (contextChanged) {
+      synchronized (cache) {
+        cache.clear();
+      }
+      synchronized (negativeCache) {
+        negativeCache.clear();
+      }
+    }
+  }
+
+  /** 阻塞解析 songId 的 URL；命中缓存 / 失败 / 未配置返 null。 */
+  @Nullable
+  public String resolveSync(long songId) {
+    if (songId <= 0) return null;
+    String level = songLevel;
+    // 缓存键：songId + level。level 差异 → URL 不同文件/码率/endpoint，不能合并。
+    String cacheKey = songId + ":" + level;
+    synchronized (cache) {
+      String hit = cache.get(cacheKey);
+      if (hit != null) return hit;
+    }
+    // 负缓存命中：TTL 内跳过重复网络调用。仅业务层“无可播 URL”入负缓存，
+    // 网络异常/超时/HTTP 非 200 不入负缓存，以免临时故障吃掉后续 retry 机会。
+    synchronized (negativeCache) {
+      Long failedAt = negativeCache.get(cacheKey);
+      if (failedAt != null) {
+        if (System.currentTimeMillis() - failedAt < NEGATIVE_CACHE_TTL_MS) {
+          return null;
+        }
+        negativeCache.remove(cacheKey);
+      }
+    }
+    String baseUrl = apiBaseUrl;
+    String cookieValue = cookie;
+    if (baseUrl.isEmpty()) {
+      Log.w(TAG, "resolveSync skipped: apiBaseUrl empty");
+      return null;
+    }
+
+    HttpURLConnection connection = null;
+    String resolvedUrl = null;
+    boolean networkFailure = false;
+    try {
+      // dolby 走旧版接口，其余走 /song/url/v1
+      String endpoint;
+      if ("dolby".equals(level)) {
+        endpoint =
+            baseUrl
+                + "/song/url?id="
+                + songId
+                + "&br=999000&immerseType=c51&timestamp="
+                + System.currentTimeMillis();
+      } else {
+        endpoint =
+            baseUrl
+                + "/song/url/v1?id="
+                + songId
+                + "&level="
+                + URLEncoder.encode(level, StandardCharsets.UTF_8.name())
+                + "&timestamp="
+                + System.currentTimeMillis();
+      }
+      if (!cookieValue.isEmpty()) {
+        endpoint += "&cookie=" + URLEncoder.encode(cookieValue, StandardCharsets.UTF_8.name());
+      }
+
+      connection = (HttpURLConnection) new URL(endpoint).openConnection();
+      connection.setRequestMethod("GET");
+      connection.setConnectTimeout(CONNECT_TIMEOUT_MS);
+      connection.setReadTimeout(READ_TIMEOUT_MS);
+      connection.setRequestProperty("Accept", "application/json");
+      if (!cookieValue.isEmpty()) {
+        connection.setRequestProperty("Cookie", cookieValue);
+      }
+      connection.connect();
+
+      int httpCode = connection.getResponseCode();
+      if (httpCode != HttpURLConnection.HTTP_OK) {
+        Log.w(TAG, "resolveSync songId=" + songId + " http=" + httpCode);
+        networkFailure = true;
+      } else {
+        String body = readBody(connection);
+        JSONObject root = new JSONObject(body);
+        JSONArray data = root.optJSONArray("data");
+        if (data != null && data.length() > 0) {
+          JSONObject first = data.optJSONObject(0);
+          if (first != null) {
+            String url = first.optString("url", "");
+            if (!url.isEmpty() && !"null".equals(url)) {
+              resolvedUrl = url;
+            }
+          }
+        }
+      }
+    } catch (Exception e) {
+      Log.w(TAG, "resolveSync failed songId=" + songId, e);
+      networkFailure = true;
+    } finally {
+      if (connection != null) connection.disconnect();
+    }
+
+    if (resolvedUrl != null) {
+      synchronized (cache) {
+        cache.put(cacheKey, resolvedUrl);
+      }
+      // 成功：清负缓存（防止之前临时失败后错过重试窗口）
+      synchronized (negativeCache) {
+        negativeCache.remove(cacheKey);
+      }
+      return resolvedUrl;
+    }
+    // 仅业务层“无可播 URL”（HTTP 200 但 data 为空）入负缓存；网络异常不入，让上层可重试。
+    if (!networkFailure) {
+      synchronized (negativeCache) {
+        negativeCache.put(cacheKey, System.currentTimeMillis());
+      }
+    }
+    return null;
+  }
+
+  /**
+   * 在内部线程池上异步解析 songId 的播放 URL，结果通过回调返回（运行在池线程，调用方自行 post 主线程）。
+   *
+   * <p>用于 NEXT/PREV 等需要立即播放的场景，避免共享 PlaybackManager 单线程 networkExecutor 与
+   * favorite 请求互锁，同时享用 inFlight 去重 + cache 命中。
+   *
+   * @param songId 待解析的 songId
+   * @param callback 解析回调（参数为 URL 或 null）
+   */
+  public void submitResolve(long songId, @Nullable java.util.function.Consumer<String> callback) {
+    if (songId <= 0) {
+      if (callback != null) callback.accept(null);
+      return;
+    }
+    executor.submit(
+        () -> {
+          String url = resolveSync(songId);
+          if (callback != null) callback.accept(url);
+        });
+  }
+
+  /**
+   * 后台解析 track.url，成功同步写回队列。
+   *
+   * @param onResolved 解析完成回调（运行在池线程，需自行 post 到主线程）
+   */
+  public void prefetchAsync(
+      PlaybackQueue.Track track,
+      PlaybackQueue queue,
+      @Nullable Runnable onResolved) {
+    if (track == null || track.songId <= 0 || track.playable()) return;
+    long songId = track.songId;
+    AtomicBoolean flag;
+    synchronized (inFlight) {
+      flag = inFlight.get(songId);
+      if (flag != null && flag.get()) return; // 已有进行中的 task
+      flag = new AtomicBoolean(true);
+      inFlight.put(songId, flag);
+    }
+    final AtomicBoolean flagRef = flag;
+    executor.submit(
+        () -> {
+          try {
+            String url = resolveSync(songId);
+            if (url != null) {
+              track.url = url;
+              if (queue != null) queue.updateTrackUrl(songId, url);
+            }
+            if (onResolved != null) onResolved.run();
+          } finally {
+            flagRef.set(false);
+            synchronized (inFlight) {
+              inFlight.remove(songId);
+            }
+          }
+        });
+  }
+
+  private static String readBody(HttpURLConnection connection) throws Exception {
+    try (BufferedReader reader =
+        new BufferedReader(
+            new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8))) {
+      StringBuilder sb = new StringBuilder();
+      String line;
+      while ((line = reader.readLine()) != null) sb.append(line);
+      return sb.toString();
+    }
+  }
+}

--- a/src/components/Player/FullPlayer.vue
+++ b/src/components/Player/FullPlayer.vue
@@ -80,7 +80,7 @@
           />
           <!-- 控制中心 -->
           <PlayerControl @mouseenter.stop="stopHide" @mouseleave.stop="resumeHide" />
-          <!-- 音乐频谱 -->
+          <!-- 桌面端频谱（移动端在 FullPlayerMobile 内渲染，避免 z-index 冲突） -->
           <PlayerSpectrum
             v-if="settingStore.showSpectrums"
             :color="statusStore.mainColor ? `rgb(${statusStore.mainColor})` : 'rgb(239 239 239)'"

--- a/src/components/Player/FullPlayerMobile.vue
+++ b/src/components/Player/FullPlayerMobile.vue
@@ -163,6 +163,15 @@ let savedPageIndex = 0;
         @click="pageIndex = i - 1"
       />
     </div>
+
+    <!-- 移动端竖屏频谱：贴底浮层，与封面/歌词页共享展示 -->
+    <PlayerSpectrum
+      v-if="settingStore.showSpectrums"
+      class="mobile-spectrum"
+      :color="statusStore.mainColor ? `rgb(${statusStore.mainColor})` : 'rgb(239 239 239)'"
+      :show="true"
+      :height="56"
+    />
   </div>
 </template>
 
@@ -438,6 +447,13 @@ const contentTransform = computed(() => {
   overflow: hidden;
   display: flex;
   flex-direction: column;
+
+  // 频谱贴底浮层：absolute 锚定容器底部，避开 PlayerSpectrum 默认 fixed + z-index:-1
+  :deep(.mobile-spectrum) {
+    position: absolute;
+    z-index: 1;
+    opacity: 0.45 !important;
+  }
 
   .drag-handle {
     position: absolute;

--- a/src/components/Player/PlayerComponents/PlayerSpectrum.vue
+++ b/src/components/Player/PlayerComponents/PlayerSpectrum.vue
@@ -20,63 +20,76 @@ const player = usePlayerController();
 const canvasRef = ref<HTMLCanvasElement | null>(null);
 const isKeepDrawing = ref<boolean>(true);
 
-/**
- * 绘制音乐频谱图
- */
-const drawSpectrum = () => {
-  const spectrumData = player.getSpectrumData();
+const SKIP_BINS = 10;
+const SPECTRUM_GAIN = 0.8;
+let cachedCanvasWidth = 0;
+let cachedCanvasHeight = 0;
+let cachedPixelRatio = 0;
+let ctx: CanvasRenderingContext2D | null = null;
 
-  if (!spectrumData) return;
-  // 转换为普通数组并处理
-  const data = Array.from(spectrumData).slice(10);
-  if (!isKeepDrawing.value || !canvasRef.value) return;
-  // 设置画布宽度，最大为 1600
-  canvasRef.value.width = document.body.clientWidth >= 1600 ? 1600 : document.body.clientWidth;
-  // 设置画布高度
-  canvasRef.value.height = props.height || 80;
-  // 获取2D上下文
-  const ctx: CanvasRenderingContext2D | null = canvasRef.value.getContext("2d");
-  // 画布宽高
-  const canvasWidth = canvasRef.value.width;
-  const canvasHeight = canvasRef.value.height;
-  // 频谱数量
-  const numBars = data.length / 2.5;
-  // 圆角半径
-  const cornerRadius = props.radius || 2.5;
-  // 柱形宽度
-  const barWidth = canvasWidth / numBars / 2;
-  if (!ctx) return;
-  // 清除画布
-  ctx.clearRect(0, 0, canvasWidth, canvasHeight);
-  // 遍历音频频谱数据
-  for (let i = 0; i < numBars; i++) {
-    // 计算柱形高度
-    const barHeight = (data[i] / 255) * canvasHeight;
-    // 计算柱形的 x 和 y 坐标
-    const x1 = i * barWidth + canvasWidth / 2;
-    const x2 = canvasWidth / 2 - (i + 1) * barWidth;
-    const y = canvasHeight - barHeight;
-    // 设置柱形颜色，如果未设置则使用默认颜色
-    ctx.fillStyle = props.color || "#efefef";
-    // 检查柱形高度是否大于0，避免绘制高度为0的柱形
-    if (barHeight > 0) {
-      // 调用绘制圆角矩形的函数
-      roundRect(ctx, x1, y, barWidth - 3, barHeight, cornerRadius);
-      roundRect(ctx, x2, y, barWidth - 3, barHeight, cornerRadius);
-    }
+// 仅尺寸变化时重设 canvas
+const updateCanvasSize = () => {
+  if (!canvasRef.value) return;
+  const targetWidth = Math.min(document.body.clientWidth, 1600);
+  const targetHeight = props.height || 80;
+  const targetPixelRatio = window.devicePixelRatio || 1;
+  if (
+    targetWidth !== cachedCanvasWidth ||
+    targetHeight !== cachedCanvasHeight ||
+    targetPixelRatio !== cachedPixelRatio
+  ) {
+    canvasRef.value.width = Math.round(targetWidth * targetPixelRatio);
+    canvasRef.value.height = Math.round(targetHeight * targetPixelRatio);
+    canvasRef.value.style.width = `${targetWidth}px`;
+    canvasRef.value.style.height = `${targetHeight}px`;
+    cachedCanvasWidth = targetWidth;
+    cachedCanvasHeight = targetHeight;
+    cachedPixelRatio = targetPixelRatio;
+    ctx = canvasRef.value.getContext("2d");
+    ctx?.setTransform(targetPixelRatio, 0, 0, targetPixelRatio, 0, 0);
   }
 };
 
-/**
- * 绘制圆角矩形
- * @param {CanvasRenderingContext2D} ctx - 2D上下文
- * @param {number} x - 矩形左上角 x 坐标
- * @param {number} y - 矩形左上角 y 坐标
- * @param {number} width - 矩形宽度
- * @param {number} height - 矩形高度
- * @param {number} radius - 圆角半径
- */
-const roundRect = (
+// 数据源 30Hz，锁 ~30Hz 重绘与数据更新同步
+const DRAW_INTERVAL_MS = 33;
+let lastDrawTime = 0;
+
+const drawSpectrum = () => {
+  if (!isKeepDrawing.value || !ctx) return;
+  const now = performance.now();
+  if (now - lastDrawTime < DRAW_INTERVAL_MS) return;
+  lastDrawTime = now;
+  const spectrumData = player.getSpectrumData();
+  if (!spectrumData) return;
+  const dataLen = spectrumData.length - SKIP_BINS;
+  if (dataLen <= 0) return;
+  const numBars = Math.floor(dataLen / 2.5);
+  if (numBars <= 0) return;
+  const canvasWidth = cachedCanvasWidth;
+  const canvasHeight = cachedCanvasHeight;
+  const cornerRadius = props.radius || 2.5;
+  const barWidth = canvasWidth / numBars / 2;
+  const halfWidth = canvasWidth / 2;
+  const drawWidth = barWidth - 3;
+  ctx.clearRect(0, 0, canvasWidth, canvasHeight);
+  ctx.fillStyle = props.color || "#efefef";
+
+  // 累积所有柱到单 Path 后一次 fill，减少 GPU 状态切换
+  ctx.beginPath();
+  for (let i = 0; i < numBars; i++) {
+    const barHeight = (spectrumData[i + SKIP_BINS] / 255) * canvasHeight * SPECTRUM_GAIN;
+    if (barHeight <= 0) continue;
+    const x1 = i * barWidth + halfWidth;
+    const x2 = halfWidth - (i + 1) * barWidth;
+    const y = canvasHeight - barHeight;
+    addRoundRectPath(ctx, x1, y, drawWidth, barHeight, cornerRadius);
+    addRoundRectPath(ctx, x2, y, drawWidth, barHeight, cornerRadius);
+  }
+  ctx.fill();
+};
+
+// 追加圆角矩形 sub-path；外层负责 beginPath + fill 批处理
+const addRoundRectPath = (
   ctx: CanvasRenderingContext2D,
   x: number,
   y: number,
@@ -84,7 +97,6 @@ const roundRect = (
   height: number,
   radius: number,
 ) => {
-  ctx.beginPath();
   ctx.moveTo(x + radius, y);
   ctx.lineTo(x + width - radius, y);
   ctx.quadraticCurveTo(x + width, y, x + width, y + radius);
@@ -95,7 +107,6 @@ const roundRect = (
   ctx.lineTo(x, y + radius);
   ctx.quadraticCurveTo(x, y, x + radius, y);
   ctx.closePath();
-  ctx.fill();
 };
 
 // 开始绘制频谱
@@ -106,14 +117,54 @@ const { pause: pauseDraw, resume: resumeDraw } = useRafFn(
   { immediate: false },
 );
 
+const onResize = () => updateCanvasSize();
+
+// 避免重复 acquire/release 撕裂 Java visualizerRefCount
+let visualizerHeld = false;
+const acquireVis = () => {
+  if (visualizerHeld) return;
+  visualizerHeld = true;
+  void player.acquireVisualizer();
+};
+const releaseVis = () => {
+  if (!visualizerHeld) return;
+  visualizerHeld = false;
+  player.releaseVisualizer();
+};
+
+// 仅 visibility 切换驱动 acquire/release；props.show 只控 CSS opacity，
+// 不接入避免 playerMetaShow 高频 toggle 让原生 enableVisualizer 队列堆积导致 flag 错位锁死
+const onVisibility = () => {
+  if (typeof document === "undefined") return;
+  if (document.visibilityState === "visible") {
+    if (!isKeepDrawing.value) return;
+    acquireVis();
+    resumeDraw();
+  } else {
+    pauseDraw();
+    releaseVis();
+  }
+};
+
 onMounted(() => {
   isKeepDrawing.value = true;
-  resumeDraw();
+  updateCanvasSize();
+  window.addEventListener("resize", onResize);
+  document.addEventListener("visibilitychange", onVisibility);
+  if (typeof document === "undefined" || document.visibilityState === "visible") {
+    acquireVis();
+    resumeDraw();
+  }
 });
+
+watch(() => props.height, () => updateCanvasSize());
 
 onBeforeUnmount(() => {
   isKeepDrawing.value = false;
   pauseDraw();
+  window.removeEventListener("resize", onResize);
+  document.removeEventListener("visibilitychange", onVisibility);
+  releaseVis();
 });
 </script>
 

--- a/src/components/Player/PlayerLyric/index.vue
+++ b/src/components/Player/PlayerLyric/index.vue
@@ -107,12 +107,42 @@ const currentSongId = computed(() => musicStore.playSong?.id as number | undefin
 // 实时播放进度
 const playSeek = ref<number>(player.getSeek() + statusStore.getSongOffset(musicStore.playSong?.id));
 
-// 实时更新播放进度
-const { pause: pauseSeek, resume: resumeSeek } = useRafFn(() => {
+// 立即同步真实播放位置（不等下帧 rAF）
+const syncPlaySeek = () => {
   const songId = musicStore.playSong?.id;
   const offsetTime = statusStore.getSongOffset(songId);
   playSeek.value = player.getSeek() + offsetTime;
+};
+
+// 实时更新播放进度
+const { pause: pauseSeek, resume: resumeSeek } = useRafFn(syncPlaySeek, { immediate: false });
+
+// 仅播放中 + 可见时跑 60Hz rAF，暂停/后台时全零避免手机发热
+const updateSeekRunning = () => {
+  const visible = typeof document === "undefined" || document.visibilityState === "visible";
+  if (statusStore.playStatus && visible) {
+    resumeSeek();
+  } else {
+    pauseSeek();
+    syncPlaySeek();
+  }
+};
+
+const onVisibility = () => {
+  if (document.visibilityState === "visible") syncPlaySeek();
+  updateSeekRunning();
+};
+// 切曲 player seek 尚未重置，先归零等 tick 稳定后再同步
+watch(currentSongId, async () => {
+  playSeek.value = statusStore.getSongOffset(musicStore.playSong?.id);
+  await nextTick();
+  syncPlaySeek();
 });
+watch(
+  () => statusStore.getSongOffset(currentSongId.value),
+  () => syncPlaySeek(),
+);
+watch(() => statusStore.playStatus, updateSeekRunning);
 
 /**
  * 当前进度偏移值
@@ -153,11 +183,13 @@ const resetOffset = () => {
 };
 
 onMounted(() => {
-  resumeSeek();
+  updateSeekRunning();
+  document.addEventListener("visibilitychange", onVisibility);
 });
 
 onBeforeUnmount(() => {
   pauseSeek();
+  document.removeEventListener("visibilitychange", onVisibility);
 });
 </script>
 

--- a/src/components/Player/PlayerMeta/PlayerBackground.vue
+++ b/src/components/Player/PlayerMeta/PlayerBackground.vue
@@ -40,13 +40,26 @@ const player = usePlayerController();
 
 // 低频音量
 const lowFreqVolume = ref(1.0);
+let smoothedLowFreqVolume = 0;
+
+const LOW_FREQ_GAIN = 1.85;
+const LOW_FREQ_ATTACK = 0.38;
+const LOW_FREQ_RELEASE = 0.045;
+const LOW_FREQ_DEAD_ZONE = 0.015;
+
+// 文档可见性：后台/锁屏时全链路降耗。前台启动默认 visible（SSR/无 document 兜底为 true）
+const documentVisible = ref(typeof document === "undefined" || document.visibilityState === "visible");
+const onVisibility = () => {
+  documentVisible.value = document.visibilityState === "visible";
+};
 
 const flowSpeed = computed(() => {
+  if (!documentVisible.value) return 0;
   if (!statusStore.playStatus && settingStore.playerBackgroundPause) return 0;
   else return settingStore.playerBackgroundFlowSpeed ?? 4;
 });
 
-// 更新低频音量
+// AMLL Core 背景动效驱动值：80-120Hz 低频限幅平滑到 [0,1]，未启用时回落 1.0
 const { pause: pauseRaf, resume: resumeRaf } = useRafFn(
   () => {
     if (
@@ -54,32 +67,64 @@ const { pause: pauseRaf, resume: resumeRaf } = useRafFn(
       settingStore.playerBackgroundType === "animation" &&
       statusStore.playStatus
     ) {
-      lowFreqVolume.value = player.getLowFrequencyVolume();
+      const rawValue = Math.max(0, Math.min(1, player.getLowFrequencyVolume()));
+      const targetValue = rawValue <= LOW_FREQ_DEAD_ZONE ? 0 : rawValue * LOW_FREQ_GAIN;
+      const smoothFactor = targetValue > smoothedLowFreqVolume ? LOW_FREQ_ATTACK : LOW_FREQ_RELEASE;
+      smoothedLowFreqVolume += smoothFactor * (targetValue - smoothedLowFreqVolume);
+      lowFreqVolume.value = smoothedLowFreqVolume;
     }
   },
   { immediate: false },
 );
 
-// 启动或暂停 RAF
+// 避免重复 acquire/release
+let visualizerHeld = false;
+const acquireFreq = () => {
+  if (visualizerHeld) return;
+  visualizerHeld = true;
+  void player.acquireVisualizer();
+};
+const releaseFreq = () => {
+  if (!visualizerHeld) return;
+  visualizerHeld = false;
+  player.releaseVisualizer();
+};
+
+// RAF 启停 + 频谱采集 acquire/release（仅 Android 原生有效）；后台立即全释放
 watch(
   () => [
     settingStore.playerBackgroundLowFreqVolume,
     settingStore.playerBackgroundType,
     statusStore.playStatus,
+    documentVisible.value,
   ],
-  ([enabled, bgType, playing]) => {
-    if (enabled && bgType === "animation") {
+  ([enabled, bgType, playing, visible]) => {
+    const needFreq = enabled && bgType === "animation" && visible;
+    if (needFreq) {
+      acquireFreq();
       playing ? resumeRaf() : pauseRaf();
     } else {
       pauseRaf();
+      smoothedLowFreqVolume = 0;
       lowFreqVolume.value = 1.0;
+      releaseFreq();
     }
   },
   { immediate: true },
 );
 
+onMounted(() => {
+  if (typeof document !== "undefined") {
+    document.addEventListener("visibilitychange", onVisibility);
+  }
+});
+
 onBeforeUnmount(() => {
   pauseRaf();
+  releaseFreq();
+  if (typeof document !== "undefined") {
+    document.removeEventListener("visibilitychange", onVisibility);
+  }
 });
 </script>
 

--- a/src/components/Player/PlayerMeta/PlayerCover.vue
+++ b/src/components/Player/PlayerMeta/PlayerCover.vue
@@ -40,11 +40,17 @@
         v-if="dynamicCover && settingStore.dynamicCover && settingStore.playerType === 'cover'"
         ref="videoRef"
         :src="dynamicCover"
+        :poster="getCoverUrl('l')"
         :class="['dynamic-cover', { loaded: dynamicCoverLoaded }]"
         muted
         autoplay
+        playsinline
+        preload="auto"
+        disablepictureinpicture
         @loadeddata="dynamicCoverLoaded = true"
         @ended="dynamicCoverEnded"
+        @error="onDynamicCoverError"
+        @stalled="onDynamicCoverError"
       />
     </Transition>
   </div>
@@ -115,10 +121,10 @@ const getLocalCover = async () => {
     return;
   }
   try {
-    const coverData = await window.electron.ipcRenderer.invoke(
+    const coverData = (await window.electron.ipcRenderer.invoke(
       "get-music-cover",
       musicStore.playSong.path,
-    );
+    )) as { data: ArrayBuffer; format: string } | null;
     if (coverData) {
       // 使用 Data URL，确保跨窗口可用
       const blob = new Blob([coverData.data], { type: coverData.format });
@@ -153,7 +159,8 @@ const getDynamicCover = async () => {
   dynamicCoverLoaded.value = false;
   const result = await songDynamicCover(musicStore.playSong.id);
   if (!isEmpty(result.data) && result?.data?.videoPlayUrl) {
-    dynamicCover.value = result.data.videoPlayUrl;
+    // 升级 https 避免 HTTPS 页面 Mixed Content 拦截
+    dynamicCover.value = String(result.data.videoPlayUrl).replace(/^http:\/\//i, "https://");
   } else {
     dynamicCover.value = "";
   }
@@ -163,6 +170,12 @@ const getDynamicCover = async () => {
 const dynamicCoverEnded = () => {
   dynamicCoverLoaded.value = false;
   dynamicCoverStart();
+};
+
+// 加载/解码失败兜底：清 src 让 v-if 卸载，避免原生播放按钮占位或花屏残帧
+const onDynamicCoverError = () => {
+  cleanupDynamicCover();
+  dynamicCoverStop();
 };
 
 // 获取封面 URL

--- a/src/components/Setting/config/appearance.ts
+++ b/src/components/Setting/config/appearance.ts
@@ -1,5 +1,5 @@
 import { useSettingStore, useStatusStore } from "@/stores";
-import { isElectron } from "@/utils/env";
+import { isCapacitorAndroid, isElectron } from "@/utils/env";
 import {
   openFontManager,
   openCustomCode,
@@ -430,8 +430,8 @@ export const useAppearanceSettings = (): SettingConfig => {
             key: "showSpectrums",
             label: "音乐频谱",
             type: "switch",
-            show: isElectron,
-            description: "开启音乐频谱会影响性能或增加内存占用，如遇问题请关闭",
+            show: isElectron || isCapacitorAndroid,
+            description: "在播放界面底栏显示随节奏跳动的频谱柱状图，会增加少量性能开销",
             value: computed({
               get: () => settingStore.showSpectrums,
               set: (v) => (settingStore.showSpectrums = v),

--- a/src/core/audio-player/AndroidNativeAudioPlayer.ts
+++ b/src/core/audio-player/AndroidNativeAudioPlayer.ts
@@ -18,21 +18,20 @@ import { AUDIO_EVENTS } from "./BaseAudioPlayer";
 /**
  * Android 原生播放器（参照 SPlayer-ROM-Compat 实现）
  *
- * 核心设计原则：
- * 1. **TS 全权拥有 currentTime**：用 performance.now() 插值估算，不接收原生周期性位置上报
- *    - 缓冲期 ExoPlayer 经常短暂上报 positionMs=0，强行更新会导致 UI 进度回退
- *    - 插值方案对短暂卡顿不敏感，且天然避免 seek-to-zero
- * 2. **load() 一次性传入 url+seek+autoPlay**：Java 端原子完成 setMediaItem+prepare+playWhenReady
- * 3. **fire-and-forget**：所有原生调用 `void`，不等待返回
- * 4. **state 事件只更新结构性字段**：src / duration / paused / error，不动 _currentTime
- * 5. **seek 完成后接受原生上报**：仅当 expectPlaying=false（暂停 seek）才从原生确认位置
+ * 核心设计：
+ * 1. TS 用 performance.now() 插值拥有 currentTime，不接收原生周期上报（避免 seek-to-zero / 进度回退）
+ * 2. load() 原子传入 url+seek+autoPlay
+ * 3. 所有原生调用 fire-and-forget
+ * 4. state 事件只更新 src/duration/paused/error，不动 _currentTime
+ * 5. 仅暂停 seek 完成后才从原生确认位置
  */
 export class AndroidNativeAudioPlayer extends EventTarget implements IPlaybackEngine {
   public readonly capabilities: EngineCapabilities = {
     supportsRate: true,
     supportsSinkId: false,
     supportsEqualizer: false,
-    supportsSpectrum: false,
+    // Java 端用 FftAudioProcessor 在 ExoPlayer 渲染链上做 FFT 
+    supportsSpectrum: true,
   };
 
   private _src = "";
@@ -50,10 +49,23 @@ export class AndroidNativeAudioPlayer extends EventTarget implements IPlaybackEn
   /** 上一次 _currentTime / lastTimeSyncAt 校准时刻 (performance.now()) */
   private lastTimeSyncAt = 0;
 
+  /** 最后一次 JS 主动 seek 时刻，用于短期屏蔽 native 周期事件回拖进度 */
+  private seekPendingAt = 0;
+  /** seek 后多久内只接受 authoritative 事件，避开 native 处理 seek 前的旧周期事件 */
+  private static readonly SEEK_DRIFT_LOCK_MS = 800;
+
   /** ended 事件去重（3 秒内同一 src 只派发一次） */
   private static readonly ENDED_DEDUP_MS = 3000;
   private lastEndedEventAt = 0;
   private lastEndedSrc = "";
+
+  /** 频谱缓存：Java ~20Hz 推送，rAF 同步读取 */
+  private latestFftData: Uint8Array = new Uint8Array(256);
+  private latestLowFreq = 0;
+  /** 频谱采集是否已启用（避免重复 enable 调用） */
+  private visualizerEnabled = false;
+  /** 频谱操作串行化队列，防止快速 mount/unmount 导致原生态与 TS 标记不一致 */
+  private visualizerOpQueue: Promise<unknown> = Promise.resolve();
 
   public init(): void {
     if (this.isInitialized) return;
@@ -61,7 +73,32 @@ export class AndroidNativeAudioPlayer extends EventTarget implements IPlaybackEn
     if (!this.listenersBound && isCapacitorAndroid) {
       this.listenersBound = true;
       void this.bindNativeListeners();
+      this.bindVisibilitySync();
     }
+  }
+
+  /** 回前台时拉取 native 位置，纠正 WebView 冻结导致的 JS 估算落后 */
+  private bindVisibilitySync(): void {
+    if (typeof document === "undefined") return;
+    document.addEventListener("visibilitychange", () => {
+      if (document.visibilityState !== "visible") return;
+      if (!this._src) return;
+      void AndroidNativePlayback.getState()
+        .then((state) => {
+          if (!state || typeof state.positionMs !== "number") return;
+          // 与当前估算差距 > 500ms 才覆盖，避免来回波动
+          const estimatedMs = this.estimateCurrentTime() * 1000;
+          if (Math.abs(state.positionMs - estimatedMs) <= 500) return;
+          const safePositionSec = Math.max(0, state.positionMs) / 1000;
+          this._currentTime = safePositionSec;
+          this.lastTimeSyncAt = performance.now();
+          if (typeof state.durationMs === "number" && state.durationMs > 0) {
+            this._duration = state.durationMs / 1000;
+          }
+          this.dispatchEvent(new Event(AUDIO_EVENTS.TIME_UPDATE));
+        })
+        .catch(() => {});
+    });
   }
 
   public destroy(): void {
@@ -74,7 +111,64 @@ export class AndroidNativeAudioPlayer extends EventTarget implements IPlaybackEn
     this.lastTimeSyncAt = 0;
     this.lastEndedEventAt = 0;
     this.lastEndedSrc = "";
+    // 关闭频谱采集；同步清零缓存，防止下次 init 前 getFrequencyData 仍返回旧鼓点
+    if (this.visualizerEnabled) {
+      void AndroidNativePlayback.enableVisualizer({ enable: false }).catch(() => {});
+      this.visualizerEnabled = false;
+    }
+    this.latestFftData.fill(0);
+    this.latestLowFreq = 0;
     void this.releaseListeners();
+  }
+
+  // 频谱可视化
+
+  /**
+   * 获取最近一次 Java 推送的 FFT 数据（长度 256，与 PlayerSpectrum 格式一致）。
+   * 返回内部缓存引用，调用方不应修改。
+   */
+  public getFrequencyData(): Uint8Array {
+    return this.latestFftData;
+  }
+
+  /**
+   * 获取最近一次 Java 端推送的低频音量 [0.0, 1.0]，用于 AMLL 流体背景鼓点驱动。
+   */
+  public getLowFrequencyVolume(): number {
+    return this.latestLowFreq;
+  }
+
+  /**
+   * 按需启用/停用频谱采集（FftAudioProcessor，无需权限）。
+   * 不抛错；失败时 getFrequencyData 返回零数组（静默降级）。
+   */
+  public async enableVisualizer(enable: boolean): Promise<boolean> {
+    if (!isCapacitorAndroid) return false;
+    // 串行化避免并发 enable(true)/enable(false) 与 TS flag 错位
+    const op = this.visualizerOpQueue.then(async () => {
+      if (this.visualizerEnabled === enable) return true;
+      try {
+        const result = await AndroidNativePlayback.enableVisualizer({ enable });
+        // 仅原生确认成功才更新 flag；disable 路径直接置 false，避免 fast-path 跳过锁死
+        if (result.granted) {
+          this.visualizerEnabled = enable;
+        } else if (!enable) {
+          this.visualizerEnabled = false;
+        }
+        if (!enable) {
+          this.latestFftData.fill(0);
+          this.latestLowFreq = 0;
+        }
+        return result.granted;
+      } catch (error) {
+        console.warn("[AndroidNativeAudioPlayer] enableVisualizer failed:", error);
+        // 异常路径置反值，强制下次同语义请求重试原生
+        this.visualizerEnabled = !enable;
+        return false;
+      }
+    });
+    this.visualizerOpQueue = op.catch(() => {});
+    return op;
   }
 
   public async play(url?: string, options?: PlayOptions): Promise<void> {
@@ -146,6 +240,7 @@ export class AndroidNativeAudioPlayer extends EventTarget implements IPlaybackEn
 
     this._currentTime = safeTime;
     this.lastTimeSyncAt = performance.now();
+    this.seekPendingAt = this.lastTimeSyncAt;
 
     this.dispatchEvent(new Event(AUDIO_EVENTS.SEEKING));
     void AndroidNativePlayback.seek({
@@ -226,18 +321,26 @@ export class AndroidNativeAudioPlayer extends EventTarget implements IPlaybackEn
       }),
     );
 
-    // progressChanged: 同步 duration + 派发 timeupdate。
-    // 常规轮询不更新 _currentTime（防缓冲期 0 假数据回退）；authoritative=true 时强制刷新基准。
+    // progressChanged：以 native 为唯一进度源，每个事件都同步基准（JS 估算只做 250ms 之间的 60fps 平滑）。
+    // 唯一例外：JS 端刚发起 seek 后短期内 (SEEK_DRIFT_LOCK_MS)，只信任 authoritative 事件，
+    // 否则 native 还没处理完 seek 时残留的旧周期事件会把进度回拖到 seek 前位置。
     this.listenerHandles.push(
       await AndroidNativePlayback.addListener("progressChanged", (event) => {
         const nextDuration = Math.max(0, event.durationMs) / 1000;
         if (nextDuration > 0) this._duration = nextDuration;
-        if (event.authoritative === true) {
+        const isAuthoritative = event.authoritative === true;
+        const inSeekLock =
+          this.seekPendingAt > 0 &&
+          performance.now() - this.seekPendingAt < AndroidNativeAudioPlayer.SEEK_DRIFT_LOCK_MS;
+        if (isAuthoritative || !inSeekLock) {
           const safePositionSec = Math.max(0, event.positionMs) / 1000;
           this._currentTime = safePositionSec;
           this.lastTimeSyncAt = performance.now();
-          this.dispatchEvent(new Event(AUDIO_EVENTS.SEEKING));
-          this.dispatchEvent(new Event(AUDIO_EVENTS.SEEKED));
+          if (isAuthoritative) {
+            this.seekPendingAt = 0;
+            this.dispatchEvent(new Event(AUDIO_EVENTS.SEEKING));
+            this.dispatchEvent(new Event(AUDIO_EVENTS.SEEKED));
+          }
         }
         this.dispatchEvent(new Event(AUDIO_EVENTS.TIME_UPDATE));
       }),
@@ -274,6 +377,25 @@ export class AndroidNativeAudioPlayer extends EventTarget implements IPlaybackEn
             detail: { originalEvent: new Event("error"), errorCode: this._errorCode },
           }),
         );
+      }),
+    );
+
+    // visualizerData: Java 端 Visualizer FFT 数据 ~30Hz 推送，缓存到本地以便 rAF 同步读取。
+    // Payload 为 base64 字符串（256 字节），相比 number[] 跨桥体积 -70%，atob 单次调用解码。
+    this.listenerHandles.push(
+      await AndroidNativePlayback.addListener("visualizerData", (event) => {
+        if (typeof event.fftB64 === "string" && event.fftB64.length > 0) {
+          // atob 把 base64 解为二进制字符串，长度 = 原 byte 数
+          // 直接逐字节写入既有 Uint8Array，无中间分配
+          const decoded = atob(event.fftB64);
+          const len = Math.min(decoded.length, this.latestFftData.length);
+          for (let i = 0; i < len; i++) {
+            this.latestFftData[i] = decoded.charCodeAt(i);
+          }
+        }
+        if (typeof event.lowFreq === "number") {
+          this.latestLowFreq = event.lowFreq;
+        }
       }),
     );
   }

--- a/src/core/player/AudioManager.ts
+++ b/src/core/player/AudioManager.ts
@@ -403,6 +403,18 @@ class AudioManager extends TypedEventTarget<AudioEventMap> implements IPlaybackE
   }
 
   /**
+   * 启用/停用频谱采集（仅 Android 原生引擎，其他引擎 no-op）。
+   * 返回 true 表示成功启用；false 表示引擎不支持或调用失败。
+   */
+  public async enableVisualizer(enable: boolean): Promise<boolean> {
+    if (this.engine instanceof AndroidNativeAudioPlayer) {
+      return this.engine.enableVisualizer(enable);
+    }
+    // 其他引擎（element/ffmpeg）依赖 Web Audio AnalyserNode，已经常驻无需主动启用
+    return true;
+  }
+
+  /**
    * 设置高通滤波器频率
    */
   public setHighPassFilter(frequency: number, rampTime: number = 0): void {

--- a/src/core/player/MediaSessionManager.ts
+++ b/src/core/player/MediaSessionManager.ts
@@ -160,9 +160,25 @@ class MediaSessionManager {
           case "collapse":
             break;
           case "autoNext":
+            // 旧路径兼容：新队列走 trackChanged
             if (typeof event.songId === "number") {
               void player.applyNativeAutoNext(event.songId, event.liked);
             }
+            break;
+          case "trackChanged":
+            // Java 切歌通知：用 playListIndex 直接定位
+            if (typeof event.playListIndex === "number" && event.playListIndex >= 0) {
+              void player.applyNativeTrackChanged(
+                event.playListIndex,
+                typeof event.songId === "number" ? event.songId : undefined,
+                event.liked,
+                event.source,
+              );
+            }
+            break;
+          case "requestUrls":
+            // 窗口耗尽：补 prefetch 后重推窗口
+            void player.refreshAndroidQueueWindow();
             break;
         }
       },
@@ -187,10 +203,12 @@ class MediaSessionManager {
   public async syncAndroidApiContext() {
     if (!isCapacitorAndroid) return;
 
+    const settingStore = useSettingStore();
     const musicCookie = getCookie("MUSIC_U");
     await AndroidNativePlayback.syncApiContext({
       apiBaseUrl: EMBEDDED_API_BASE_URL,
       cookie: musicCookie ? `MUSIC_U=${musicCookie};os=pc;` : "",
+      songLevel: settingStore.songLevel,
     });
   }
 
@@ -394,7 +412,12 @@ class MediaSessionManager {
       // 不再通过 syncRemoteState 覆盖为 remote mode。
       const engineType = useAudioManager().engineType;
       if (engineType !== "android-native") {
-        this.throttledSyncAndroidRemoteState(true, position, duration);
+        // 秒 → ms（原生 API 统一 ms）
+        this.throttledSyncAndroidRemoteState(
+          true,
+          Math.max(0, Math.round(position * 1000)),
+          Math.max(0, Math.round(duration * 1000)),
+        );
       }
       return;
     }

--- a/src/core/player/PlayerController.ts
+++ b/src/core/player/PlayerController.ts
@@ -19,6 +19,7 @@ import { type DebouncedFunc, throttle } from "lodash-es";
 import {
   AndroidNativePlayback,
   type AndroidNativeMetadataPayload,
+  type AndroidNativeWindowTrack,
 } from "@/plugins/androidNativePlayback";
 import { useBlobURLManager } from "../resource/BlobURLManager";
 import { useAudioManager } from "./AudioManager";
@@ -65,10 +66,6 @@ class PlayerController {
   private rateResetTimer: ReturnType<typeof setTimeout> | undefined;
   /** 速率渐变动画帧 */
   private rateRampFrame: number | undefined;
-  /** Seek 防护：上次 seek 时间戳 */
-  private lastSeekTimestamp = 0;
-  /** Seek 防护：上次 seek 目标位置 (ms) */
-  private lastSeekTargetMs = 0;
 
   constructor() {
     // 初始化 AudioManager（会根据设置自动选择引擎）
@@ -204,25 +201,26 @@ class PlayerController {
     const lyricManager = useLyricManager();
 
     musicStore.playSong = song;
-    statusStore.currentTime = startSeek;
-    // 用元数据的 duration 立刻填上 statusStore.duration，否则进度条 max=0 会把所有 seek 钳到 0
+    // $patch 批量提交：persist 只触发 1 次写，避免切歌瞬间多次持久化卡主线程
+    // 用元数据 duration 立即填，否则进度条 max=0 会把所有 seek 钳到 0
     // （ExoPlayer 在 autoPlay=false 暂停态下 progressRunnable 不跑，duration 永远到不了 TS）
-    if (typeof song.duration === "number" && song.duration > 0) {
-      statusStore.duration = song.duration;
-    }
-    // 重置进度
-    statusStore.progress = 0;
-    statusStore.lyricIndex = -1;
+    statusStore.$patch((state) => {
+      state.currentTime = startSeek;
+      if (typeof song.duration === "number" && song.duration > 0) {
+        state.duration = song.duration;
+      }
+      state.progress = 0;
+      state.lyricIndex = -1;
+      state.lyricLoading = true;
+      state.abLoop.enable = false;
+      state.abLoop.pointA = null;
+      state.abLoop.pointB = null;
+    });
     // 重置重试计数
     const sid = song.type === "radio" ? song.dj?.id : song.id;
     if (this.retryInfo.songId !== sid) {
       this.retryInfo = { songId: sid || 0, count: 0 };
     }
-    statusStore.lyricLoading = true;
-    // 重置 AB 循环
-    statusStore.abLoop.enable = false;
-    statusStore.abLoop.pointA = null;
-    statusStore.abLoop.pointB = null;
     // 通知桌面歌词
     if (isElectron) {
       window.electron.ipcRenderer.send("desktop-lyric:update-data", {
@@ -665,78 +663,104 @@ class PlayerController {
     };
   }
 
-  private resolveAndroidNextSong(currentSong: SongType): SongType | null {
+  /** 同步取播放 URL，不发网络请求。返回 null 时窗口推 null，由 Java 端按需解析。 */
+  private resolveSyncSongUrl(song: SongType, isCurrent: boolean): string | null {
+    if (isCurrent && this.currentAudioSource?.url) return this.currentAudioSource.url;
+    if (song.path) return song.path;
+    if (song.type === "streaming" && song.streamUrl) return song.streamUrl;
+    if (typeof song.id === "number") {
+      const songManager = useSongManager();
+      const cached = songManager.peekPrefetch(song.id);
+      if (cached?.id === song.id && cached.url) return cached.url;
+    }
+    return null;
+  }
+
+  /**
+   * 构造 Android 播放队列窗口（当前 ±N 首）。
+   * URL 采用「已缓存即推、未缓存推 null」被动策略，personalFM 退化为窗口=0。
+   */
+  private buildAndroidWindowTracks(_currentSong: SongType): {
+    windowTracks: AndroidNativeWindowTrack[];
+    windowCurrentIndex: number;
+    hasPreviousOutsideWindow: boolean;
+    hasNextOutsideWindow: boolean;
+    repeatMode: "off" | "all" | "one";
+  } {
     const dataStore = useDataStore();
     const musicStore = useMusicStore();
     const statusStore = useStatusStore();
 
-    if (statusStore.repeatMode === "one") {
-      return currentSong;
+    const personalFm = statusStore.personalFmMode;
+    const sourceList: SongType[] = personalFm ? musicStore.personalFM.list : dataStore.playList;
+    const currentIndex = personalFm ? musicStore.personalFM.playIndex : statusStore.playIndex;
+    // personalFM=0；普通列表 ±100 = 201 首窗口（覆盖最大 200 首后台续播，payload ~70KB 无感知）
+    const radius = personalFm ? 0 : 100;
+
+    const empty = {
+      windowTracks: [] as AndroidNativeWindowTrack[],
+      windowCurrentIndex: -1,
+      hasPreviousOutsideWindow: false,
+      hasNextOutsideWindow: false,
+      repeatMode: this.toAndroidRepeatMode(),
+    };
+    if (sourceList.length === 0 || currentIndex < 0 || currentIndex >= sourceList.length) {
+      return empty;
     }
 
-    if (statusStore.personalFmMode) {
-      const fmList = musicStore.personalFM.list;
-      const nextSong = fmList[musicStore.personalFM.playIndex + 1];
-      return nextSong && !this.shouldSkipSong(nextSong) ? nextSong : null;
-    }
+    const windowStart = Math.max(0, currentIndex - radius);
+    const windowEnd = Math.min(sourceList.length - 1, currentIndex + radius);
+    const tracks: AndroidNativeWindowTrack[] = [];
+    let windowCurrentIndex = -1;
 
-    const playList = dataStore.playList;
-    const playListLength = playList.length;
-    if (playListLength === 0) {
-      return null;
-    }
+    for (let i = windowStart; i <= windowEnd; i++) {
+      const song = sourceList[i];
+      if (!song) continue;
+      // skipSong=true 表用户级屏蔽，与 url=null 的待解析语义严格分离
+      const skip = this.shouldSkipSong(song);
+      const isCurrent = i === currentIndex;
+      const url = skip ? null : this.resolveSyncSongUrl(song, isCurrent);
+      const meta = this.buildAndroidTrackMetadata(song);
 
-    let nextIndex = statusStore.playIndex;
-    let attempts = 0;
-    while (attempts < playListLength) {
-      nextIndex += 1;
-      if (nextIndex >= playListLength) nextIndex = 0;
-      const nextSong = playList[nextIndex];
-      if (nextSong && !this.shouldSkipSong(nextSong)) {
-        return nextSong;
+      tracks.push({
+        songId: typeof song.id === "number" ? song.id : 0,
+        title: meta.title,
+        artist: meta.artist,
+        album: meta.album,
+        coverUrl: meta.coverUrl,
+        durationMs: meta.durationMs,
+        canLike: meta.canLike ?? false,
+        liked: meta.liked ?? false,
+        url,
+        playListIndex: i,
+        skipSong: skip,
+      });
+
+      if (isCurrent) {
+        windowCurrentIndex = tracks.length - 1;
       }
-      attempts++;
-    }
-
-    return null;
-  }
-
-  private async buildAndroidQueuedNextTrack(currentSong: SongType) {
-    const statusStore = useStatusStore();
-    if (statusStore.repeatMode === "one") {
-      return undefined;
-    }
-
-    const nextSong = this.resolveAndroidNextSong(currentSong);
-    if (!nextSong) {
-      return undefined;
-    }
-
-    let nextUrl = "";
-    if (nextSong.path) {
-      nextUrl = nextSong.path;
-    } else if (nextSong.type === "streaming" && nextSong.streamUrl) {
-      nextUrl = nextSong.streamUrl;
-    } else if (typeof nextSong.id === "number") {
-      const songManager = useSongManager();
-      const prefetched =
-        songManager.peekPrefetch(nextSong.id) ?? (await songManager.prefetchNextSong());
-      if (prefetched?.id === nextSong.id && prefetched.url) {
-        nextUrl = prefetched.url;
-      }
-    }
-
-    if (!nextUrl) {
-      return undefined;
     }
 
     return {
-      ...this.buildAndroidTrackMetadata(nextSong),
-      url: nextUrl,
+      windowTracks: tracks,
+      windowCurrentIndex,
+      hasPreviousOutsideWindow: windowStart > 0,
+      hasNextOutsideWindow: windowEnd < sourceList.length - 1,
+      repeatMode: this.toAndroidRepeatMode(),
     };
   }
 
-  public async syncAndroidPlaybackContext(songOverride?: SongType) {
+  private toAndroidRepeatMode(): "off" | "all" | "one" {
+    const statusStore = useStatusStore();
+    if (statusStore.repeatMode === "one") return "one";
+    if (statusStore.repeatMode === "off") return "off";
+    return "all";
+  }
+
+  public async syncAndroidPlaybackContext(
+    songOverride?: SongType,
+    options?: { windowRefilled?: boolean },
+  ) {
     if (!isCapacitorAndroid) return;
 
     try {
@@ -762,20 +786,28 @@ class PlayerController {
       await AndroidNativePlayback.syncApiContext({
         apiBaseUrl: EMBEDDED_API_BASE_URL,
         cookie: musicCookie ? `MUSIC_U=${musicCookie};os=pc;` : "",
+        songLevel: settingStore.songLevel,
       });
       if (isStaleSong()) return;
 
-      let nextTrack:
-        | (AndroidNativeMetadataPayload & {
-            liked?: boolean;
-            url?: string;
-          })
-        | undefined;
-
+      let windowResult: {
+        windowTracks: AndroidNativeWindowTrack[];
+        windowCurrentIndex: number;
+        hasPreviousOutsideWindow: boolean;
+        hasNextOutsideWindow: boolean;
+        repeatMode: "off" | "all" | "one";
+      };
       try {
-        nextTrack = await this.buildAndroidQueuedNextTrack(song);
+        windowResult = this.buildAndroidWindowTracks(song);
       } catch (error) {
-        console.warn("[Android] failed to build next track context:", error);
+        console.warn("[Android] failed to build window tracks:", error);
+        windowResult = {
+          windowTracks: [],
+          windowCurrentIndex: -1,
+          hasPreviousOutsideWindow: false,
+          hasNextOutsideWindow: false,
+          repeatMode: this.toAndroidRepeatMode(),
+        };
       }
       if (isStaleSong()) return;
 
@@ -786,8 +818,8 @@ class PlayerController {
         controllerEnabled: settingStore.androidMediaControllerEnabled,
         desktopLyricButtonEnabled: settingStore.androidMediaControllerDesktopLyricEnabled,
         desktopLyricEnabled: statusStore.showDesktopLyric,
-        repeatOne: statusStore.repeatMode === "one",
-        nextTrack,
+        ...windowResult,
+        windowRefilled: options?.windowRefilled === true,
       });
 
       await AndroidNativePlayback.updateNotificationPrefs({
@@ -801,6 +833,95 @@ class PlayerController {
     } catch (error) {
       console.warn("[Android] sync playback context failed:", error);
     }
+  }
+
+  /**
+   * Java 端 emit trackChanged 时调用：同步 statusStore.playIndex 到 payload.playListIndex。
+   * 覆盖 ENDED / 用户 NEXT / 用户 PREVIOUS 三种来源。
+   */
+  public async applyNativeTrackChanged(
+    playListIndex: number,
+    songId?: number,
+    liked?: boolean,
+    _source?: "auto" | "next" | "previous",
+  ) {
+    const dataStore = useDataStore();
+    const musicStore = useMusicStore();
+    const statusStore = useStatusStore();
+
+    let nextSong: SongType | undefined;
+
+    if (statusStore.personalFmMode) {
+      const fmList = musicStore.personalFM.list;
+      if (playListIndex >= 0 && playListIndex < fmList.length) {
+        musicStore.personalFM.playIndex = playListIndex;
+        nextSong = fmList[playListIndex];
+      }
+    } else {
+      const playList = dataStore.playList;
+      if (playListIndex >= 0 && playListIndex < playList.length) {
+        statusStore.playIndex = playListIndex;
+        nextSong = playList[playListIndex];
+      }
+    }
+
+    if (!nextSong) {
+      console.warn("[Android] applyNativeTrackChanged: playListIndex 越界，忽略", {
+        playListIndex,
+        songId,
+      });
+      return;
+    }
+
+    // songId 校验仅告警：playListIndex 为权威来源
+    if (typeof songId === "number" && typeof nextSong.id === "number" && songId !== nextSong.id) {
+      console.warn("[Android] applyNativeTrackChanged: songId 与 playListIndex 不一致", {
+        expected: songId,
+        actual: nextSong.id,
+        playListIndex,
+      });
+    }
+
+    if (typeof liked === "boolean" && typeof nextSong.id === "number") {
+      this.applySongLikeState(nextSong.id, liked);
+    }
+
+    this.setupSongUI(nextSong, 0);
+    statusStore.currentTime = 0;
+    statusStore.duration = nextSong.duration || 0;
+    statusStore.progress = 0;
+    statusStore.playLoading = false;
+    statusStore.playStatus = true;
+    await this.afterPlaySetup(nextSong);
+  }
+
+  /** Java emit requestUrls 触发：prefetch 一首后重推窗口。幂等。 */
+  public async refreshAndroidQueueWindow() {
+    if (!isCapacitorAndroid) return;
+    const dataStore = useDataStore();
+    const statusStore = useStatusStore();
+
+    // 末尾 ALL wrap：列表已到末尾且 ALL 模式，把 playIndex 重置到 0，再推 0±100 的窗口。
+    // Java 端在窗口完整覆盖全局列表（≤201 首）时能自治 wrap，但列表 >201 首时
+    // hasPreviousOutsideWindow=true 让 advanceRaw 不能 wrap，必须 JS 这里负责重置。
+    const playList = dataStore.playList;
+    if (
+      statusStore.repeatMode === "list" &&
+      !statusStore.personalFmMode &&
+      playList.length > 0 &&
+      statusStore.playIndex >= playList.length - 1
+    ) {
+      statusStore.playIndex = 0;
+    }
+
+    try {
+      const songManager = useSongManager();
+      await songManager.prefetchNextSong();
+    } catch (error) {
+      console.warn("[Android] refreshAndroidQueueWindow prefetch failed:", error);
+    }
+    // 重要：windowRefilled=true 让 Java 端区分本次推送属于补窗响应，才会消费 pendingResumeAfterRefill 续播。
+    await this.syncAndroidPlaybackContext(undefined, { windowRefilled: true });
   }
 
   public async applyNativeAutoNext(songId: number, liked?: boolean) {
@@ -855,10 +976,10 @@ class PlayerController {
       return;
     }
     if (!matchedById) {
-      console.warn("[Android] applyNativeAutoNext: songId 未匹配到列表，已通过下一索引兜底", {
-        songId,
-        fallbackId: nextSong.id,
-      });
+      console.warn(
+        "[Android] applyNativeAutoNext: songId 未匹配到列表，已通过下一索引兜底",
+        { songId, fallbackId: nextSong.id },
+      );
     }
 
     if (typeof liked === "boolean" && typeof nextSong.id === "number") {
@@ -989,10 +1110,11 @@ class PlayerController {
       // 同步状态到 Android 通知栏（仅在非原生 ExoPlayer 引擎下）
       if (isCapacitorAndroid) {
         if (useAudioManager().engineType !== "android-native") {
+          // statusStore 单位为秒，原生 API 用 ms
           void AndroidNativePlayback.syncRemoteState({
             playing: true,
-            positionMs: statusStore.currentTime,
-            durationMs: statusStore.duration,
+            positionMs: Math.max(0, Math.round(statusStore.currentTime * 1000)),
+            durationMs: Math.max(0, Math.round(statusStore.duration * 1000)),
           });
         }
         this.syncFloatingLyricProgress(statusStore.currentTime, true);
@@ -1014,10 +1136,11 @@ class PlayerController {
       // 同步状态到 Android 通知栏（仅在非原生 ExoPlayer 引擎下）
       if (isCapacitorAndroid) {
         if (useAudioManager().engineType !== "android-native") {
+          // statusStore 单位为秒，原生 API 用 ms
           void AndroidNativePlayback.syncRemoteState({
             playing: false,
-            positionMs: statusStore.currentTime,
-            durationMs: statusStore.duration,
+            positionMs: Math.max(0, Math.round(statusStore.currentTime * 1000)),
+            durationMs: Math.max(0, Math.round(statusStore.duration * 1000)),
           });
         }
         this.syncFloatingLyricProgress(statusStore.currentTime, false);
@@ -1050,18 +1173,6 @@ class PlayerController {
       const rawTime = audioManager.currentTime;
       const currentTime = Math.floor(rawTime * 1000);
       const duration = Math.floor(audioManager.duration * 1000) || statusStore.duration;
-      // Seek 防护：seek 后 3 秒内，若原生上报的位置与目标偏差过大则丢弃
-      if (isCapacitorAndroid && this.lastSeekTimestamp > 0) {
-        const elapsed = Date.now() - this.lastSeekTimestamp;
-        if (elapsed < 3000) {
-          const drift = Math.abs(currentTime - this.lastSeekTargetMs);
-          if (drift > 3000) {
-            return;
-          }
-        } else {
-          this.lastSeekTimestamp = 0;
-        }
-      }
       // 计算歌词索引
       const songId = musicStore.playSong?.id;
       const offset = statusStore.getSongOffset(songId);
@@ -1309,7 +1420,12 @@ class PlayerController {
     const audioManager = useAudioManager();
     // 立即显示加载状态
     statusStore.playLoading = true;
-    audioManager.stop();
+    // Android 原生用 pause 替代 stop：避免 ExoPlayer 全链路重置，少一次 JNI 往返
+    if (audioManager.engineType === "android-native") {
+      audioManager.pause({ fadeOut: false });
+    } else {
+      audioManager.stop();
+    }
     // 私人FM
     if (statusStore.personalFmMode) {
       await songManager.initPersonalFM(true);
@@ -1396,15 +1512,6 @@ class PlayerController {
     const knownDuration = this.getDuration();
     const safeTime =
       knownDuration > 0 ? Math.max(0, Math.min(time, knownDuration)) : Math.max(0, time);
-    // 调试：追踪 seek-to-zero
-    if (safeTime < 100 && statusStore.currentTime > 3000) {
-      console.warn(
-        `[PC] setSeek BLOCKED: time=${time} safeTime=${safeTime} current=${statusStore.currentTime} stack=${new Error().stack?.split("\n").slice(1, 4).join(" <- ")}`,
-      );
-      return;
-    }
-    this.lastSeekTimestamp = Date.now();
-    this.lastSeekTargetMs = safeTime;
     audioManager.seek(safeTime / 1000);
     statusStore.currentTime = safeTime;
     mediaSessionManager.updateState(this.getDuration(), safeTime, true);
@@ -1834,6 +1941,33 @@ class PlayerController {
   }
 
   /**
+   * 频谱采集引用计数：多组件共享时，任一 unmount 不直接关闭 Visualizer。
+   */
+  private visualizerRefCount = 0;
+
+  /**
+   * 申请/释放频谱采集，引用计数管理生命周期。
+   * PC 端 AnalyserNode 常驻为 no-op；Android 端 0→1 启动 FFT、1→0 停止。
+   */
+  public async acquireVisualizer(): Promise<boolean> {
+    this.visualizerRefCount += 1;
+    if (this.visualizerRefCount === 1) {
+      const audioManager = useAudioManager();
+      return audioManager.enableVisualizer(true);
+    }
+    return true;
+  }
+
+  public releaseVisualizer(): void {
+    if (this.visualizerRefCount <= 0) return;
+    this.visualizerRefCount -= 1;
+    if (this.visualizerRefCount === 0) {
+      const audioManager = useAudioManager();
+      void audioManager.enableVisualizer(false);
+    }
+  }
+
+  /**
    * 获取低频音量 [0.0-1.0]
    * 用于驱动背景动画等视觉效果
    */
@@ -1936,18 +2070,30 @@ class PlayerController {
 
   /**
    * 同步歌词数据到 Android 悬浮歌词
+   *
+   * YRC 数据 JSON.stringify 同步开销可达 20-100ms，紧贴 setSongLyric 之后执行会和切歌的
+   * 响应式扇出、AMLL setLyricLines 抢主线程，推到 idle 帧执行让 UI 先把切歌动画跑完。
    */
   public syncFloatingLyricData() {
     if (!isCapacitorAndroid) return;
     const statusStore = useStatusStore();
     if (!statusStore.showDesktopLyric) return;
-    const musicStore = useMusicStore();
-    const lrcData = toRaw(musicStore.songLyric.lrcData ?? []);
-    const yrcData = toRaw(musicStore.songLyric.yrcData ?? []);
-    AndroidNativePlayback.updateFloatingLyricData({
-      lrcData: JSON.stringify(lrcData),
-      yrcData: JSON.stringify(yrcData),
-    }).catch(() => {});
+    const run = () => {
+      const musicStore = useMusicStore();
+      const lrcData = toRaw(musicStore.songLyric.lrcData ?? []);
+      const yrcData = toRaw(musicStore.songLyric.yrcData ?? []);
+      AndroidNativePlayback.updateFloatingLyricData({
+        lrcData: JSON.stringify(lrcData),
+        yrcData: JSON.stringify(yrcData),
+      }).catch(() => {});
+    };
+    const ric = (window as Window & { requestIdleCallback?: typeof requestIdleCallback })
+      .requestIdleCallback;
+    if (typeof ric === "function") {
+      ric(() => run(), { timeout: 500 });
+    } else {
+      setTimeout(run, 0);
+    }
   }
 
   /**

--- a/src/plugins/androidNativePlayback.ts
+++ b/src/plugins/androidNativePlayback.ts
@@ -30,6 +30,36 @@ export interface AndroidNativeMetadataPayload {
   canLike?: boolean;
 }
 
+/**
+ * 单首曲目在窗口中的元数据 + 已解析 URL + playListIndex。
+ *
+ * url 与 skipSong 严格区分语义：
+ * - url == null && !skipSong → 还没 prefetch，Java 端按需通过 UrlResolver 解析后播放
+ * - skipSong === true → JS 端 shouldSkipSong（Fuck DJ 等）已判定屏蔽，Java 直接跳过不解析
+ */
+export interface AndroidNativeWindowTrack {
+  songId: number;
+  title: string;
+  artist: string;
+  album: string;
+  coverUrl: string;
+  durationMs: number;
+  canLike: boolean;
+  liked: boolean;
+  url: string | null;
+  /** 该曲目在 JS 端 playList 中的实际索引；Java 切歌后 emit trackChanged 时回传，TS 端据此同步 statusStore.playIndex */
+  playListIndex: number;
+  /** JS 端 shouldSkipSong（Fuck DJ Mode）置 true；Java advance/back/peek 跳过且不调上游解析接口 */
+  skipSong: boolean;
+}
+
+/**
+ * 播放队列窗口推送 payload。
+ *
+ * 替代旧的 nextTrack 单首预载机制：JS 端在每次切歌完成 / 列表变化 / repeat 模式变化后，
+ * 推送当前播放点 ±N 首到 Java 端。Java 据此自治处理 ENDED / NEXT / PREVIOUS，
+ * 完全脱离 WebView 后台冻结的影响。详见 .scratch/native-queue-design.md。
+ */
 export interface AndroidNativeQueueContextPayload {
   liked: boolean;
   canSkipPrevious: boolean;
@@ -37,11 +67,21 @@ export interface AndroidNativeQueueContextPayload {
   controllerEnabled: boolean;
   desktopLyricButtonEnabled: boolean;
   desktopLyricEnabled: boolean;
-  repeatOne: boolean;
-  nextTrack?: AndroidNativeMetadataPayload & {
-    liked?: boolean;
-    url?: string;
-  };
+  /** "off" | "all" | "one"：单曲循环 "one" 由 Java 在 ENDED 时响应 */
+  repeatMode: "off" | "all" | "one";
+  /** 当前播放点 ±N 首；首位为可播曲目时 Java 立刻自治续播 */
+  windowTracks: AndroidNativeWindowTrack[];
+  /** 当前正在播的曲目在 windowTracks 中的索引（0-based） */
+  windowCurrentIndex: number;
+  /** 全局是否还有窗口左侧外的歌曲（false → Java 在 ALL 模式下可自行 wrap 到队首） */
+  hasPreviousOutsideWindow: boolean;
+  /** 全局是否还有窗口右侧外的歌曲（true → Java 在窗口耗尽时 emit requestUrls 让 JS 补） */
+  hasNextOutsideWindow: boolean;
+  /**
+   * 是否为「补窗响应」推送：仅 refreshAndroidQueueWindow（Java emit requestUrls 后）路径置 true。
+   * Java 端据此区分本次推送是否为续播触发，避免 liked / 桌面歌词等无关 sync 误消费 pendingResumeAfterRefill。
+   */
+  windowRefilled?: boolean;
 }
 
 export interface AndroidNativeNotificationPrefsPayload {
@@ -52,6 +92,8 @@ export interface AndroidNativeNotificationPrefsPayload {
 export interface AndroidNativeApiContextPayload {
   apiBaseUrl: string;
   cookie: string;
+  /** 当前用户偏好音质等级（exhigh / lossless / hires / standard …），Java 端 UrlResolver 用于 /song/url/v1?level= */
+  songLevel?: string;
 }
 
 export type AndroidNativePlaybackStateEvent = AndroidNativePlaybackState;
@@ -82,17 +124,43 @@ export interface AndroidNativeCustomActionEvent {
     | "desktopLyric"
     | "desktopLyricReady"
     | "collapse"
-    | "autoNext";
+    | "autoNext"
+    /** Java 自治切歌后通知 TS 同步 statusStore.playIndex（payload 含 playListIndex/source） */
+    | "trackChanged"
+    /** Java 队列窗口耗尽，请求 TS 推新窗口 */
+    | "requestUrls";
   songId?: number;
   liked?: boolean;
   desktopLyricEnabled?: boolean;
   collapsed?: boolean;
   success?: boolean;
   message?: string;
+  /** trackChanged 携带：Java 切到的曲目在 JS playList 中的真实索引 */
+  playListIndex?: number;
+  /** trackChanged 携带：触发原因，UI 据此区分 toast/动画 */
+  source?: "auto" | "next" | "previous";
 }
 
 export interface AndroidNativePermissionResult {
   granted: boolean;
+}
+
+/**
+ * 频谱可视化数据事件 payload
+ * - fft: 长度 256 的 0-255 整数数组，覆盖 0~24kHz（FftAudioProcessor 解码链 FFT 输出）
+ * - lowFreq: 归一化 + 平滑后的低频音量 [0.0, 1.0]，驱动 AMLL 流体背景鼓点
+ *
+ * Java 端节流 ~30Hz 推送，TS 端缓存最新值，rAF 内同步读取，避免每帧跨 JNI。
+ */
+export interface AndroidNativeVisualizerDataEvent {
+  /**
+   * 频谱字节数据的 base64 编码（256 字节 0-255）。
+   *
+   * <p>新格式：相比直接传 number[]，JSON 体积缩减 3-4×，跨 JNI 桥延迟显著降低，
+   * 避免每帧 30Hz × 256 个 JSArray.put 的 GC 压力。
+   */
+  fftB64: string;
+  lowFreq: number;
 }
 
 export interface AndroidNativeFloatingLyricDataPayload {
@@ -132,7 +200,7 @@ export interface AndroidNativePlaybackPlugin {
   play(): Promise<AndroidNativePlaybackState>;
   pause(): Promise<AndroidNativePlaybackState>;
   stop(): Promise<AndroidNativePlaybackState>;
-  /** 硬清理：清 MediaItem / 通知栏 / queuedNext。仅用于清场场景，切歌仍用 stop()。 */
+  /** 硬清理：清 MediaItem / 通知栏 / 播放队列窗口。仅用于清场场景，切歌仍用 stop()。 */
   cleanup(): Promise<AndroidNativePlaybackState>;
   seek(options: { positionMs: number }): Promise<AndroidNativePlaybackState>;
   setVolume(options: { volume: number }): Promise<void>;
@@ -158,6 +226,11 @@ export interface AndroidNativePlaybackPlugin {
   updateFloatingLyricConfig(options: AndroidNativeFloatingLyricConfigPayload): Promise<void>;
   checkOverlayPermission(): Promise<AndroidNativePermissionResult>;
   requestOverlayPermission(): Promise<AndroidNativePermissionResult>;
+  /**
+   * 启用/停用音频频谱可视化（Media3 AudioProcessor 内嵌 FFT，无需任何权限）。
+   * 关闭时 Java 端 listener=null 直接跳过 FFT 计算，CPU 占用归零。
+   */
+  enableVisualizer(options: { enable: boolean }): Promise<AndroidNativePermissionResult>;
   addListener(
     eventName: "playbackStateChanged",
     listenerFunc: (event: AndroidNativePlaybackStateEvent) => void,
@@ -177,6 +250,10 @@ export interface AndroidNativePlaybackPlugin {
   addListener(
     eventName: "customAction",
     listenerFunc: (event: AndroidNativeCustomActionEvent) => void,
+  ): Promise<PluginListenerHandle>;
+  addListener(
+    eventName: "visualizerData",
+    listenerFunc: (event: AndroidNativeVisualizerDataEvent) => void,
   ): Promise<PluginListenerHandle>;
   removeAllListeners(): Promise<void>;
 }

--- a/src/stores/music.ts
+++ b/src/stores/music.ts
@@ -142,8 +142,12 @@ export const useMusicStore = defineStore("music", {
     },
   },
   // 持久化
+  // songLyric 不进持久化：YRC/TTML 逐字歌词序列化可达 100-500KB，
+  // 每次切歌 setSongLyric 都会触发同步 localStorage 写入，手机 WebView 上单次 50-200ms 阻塞主线程，
+  // 进度事件与 UI 交互全被锁住。歌词随播放重新拉取/缓存，无需持久化。
   persist: {
     key: "music-store",
     storage: localStorage,
+    pick: ["playSong", "playPlaylistId", "personalFM", "dailySongsData"],
   },
 });


### PR DESCRIPTION
<!--
  感谢你为 SPlayer for Android 贡献代码！
  请认真填写下面的信息，便于 Review 与回归验证。
  标题格式建议：<type>(<scope>): <简要描述>
  例如：feat(DesktopLyric): 新增逐字描边开关
-->

## 📌 变更类型

- [x] ✨ feat — 新功能
- [x] 🐞 fix — Bug 修复
- [x] ♻️ refactor — 重构，不改变外部行为
- [x] ⚡ perf — 性能优化

## 📝 变更说明

本次 PR 聚焦于 **Android 原生播放链路自治化** 与 **频谱 / 进度 / 封面 等周边性能问题** 的修复，主线目标是 WebView 在后台被冻结或主线程长时间繁忙时，Android 端仍能完成自主切歌、续播、媒体会话同步与频谱展示。

### 1. Android 原生播放队列自治（核心）

- **JS 端推送 ±100 = 201 首滑动窗口**到 Java（[buildAndroidWindowTracks](cci:1://file:///d:/a/SPlayer-for-Android/src/core/player/PlayerController.ts:678:2-750:3)），覆盖最大 200 首后台续播，payload ~70KB 主线程无感知。
- **Java 端 `PlaybackQueue` 自主推进**：`advanceRaw / backRaw` 跳过 `skipSong`，窗口完整覆盖全局列表（≤201 首）时自治 ALL wrap；窗口边缘耗尽则 emit `requestUrls` 让 JS 补窗。
- **修复异步 URL 解析竞态**：在 `playFromQueue / load / cleanup` 入口统一自增 `resolveTokenCounter`，过期 token 回调直接丢弃；清理过期 `pendingResumeAfterRefill` 避免补窗误续播。
- **修复 ENDED 续播缺口**：窗口耗尽且 `hasNextOutsideWindow=true` 时拦截 ENDED，等下一次 [updateQueueContext](cci:1://file:///d:/a/SPlayer-for-Android/android/app/src/main/java/top/imsyy/splayer/android/playback/PlaybackManager.java:435:2-489:3) 拿到新窗口后立即 advance + [playFromQueue](cci:1://file:///d:/a/SPlayer-for-Android/android/app/src/main/java/top/imsyy/splayer/android/playback/PlaybackManager.java:1111:2-1146:3)，弥补 JS 不主动 play 的链路缺口。
- personalFM 退化为 `radius=0`，单首推进语义不破坏。

### 2. Android FFT 频谱采集

- 新增 [FftAudioProcessor](cci:2://file:///d:/a/SPlayer-for-Android/android/app/src/main/java/top/imsyy/splayer/android/playback/FftAudioProcessor.java:15:0-411:1) 接入 ExoPlayer 自定义 `RenderersFactory`，音频线程只写 snapshot buffer，主线程做 base64 编码 + IPC emit，避免阻塞音频回调。
- 支持多实例设计，为未来 Automix（双轨 crossfade）预留扩展。
- TS 端 [AndroidNativeAudioPlayer.enableVisualizer](cci:1://file:///d:/a/SPlayer-for-Android/src/core/audio-player/AndroidNativeAudioPlayer.ts:140:2-171:3) 串行化，原生调用失败时回滚 flag 避免锁死。

### 3. 频谱渲染拆分与 z-index 修复

- 桌面端 / 移动端频谱组件解耦，修复频谱画布与播放器 UI 的 z-index 冲突。
- 频谱绘制节流至 30Hz，改为单 `Path2D` 批绘减少 GPU 状态切换。
- `visibilitychange` 驱动采集 / 绘制启停，后台与锁屏不再无谓消耗 CPU / 电量。

### 4. 歌词存储优化

- `music-store` 的 `persist.pick` 收窄到 `playSong / playPlaylistId / personalFM / dailySongsData`，**`songLyric` 不再持久化**，每次切歌少写 100-500KB 逐字 yrcData JSON。
- [syncFloatingLyricData](cci:1://file:///d:/a/SPlayer-for-Android/src/core/player/PlayerController.ts:2070:2-2096:3) 用 `requestIdleCallback` 推迟 `JSON.stringify`，且只在 `showDesktopLyric=true` 时执行。
- [setupSongUI](cci:1://file:///d:/a/SPlayer-for-Android/src/core/player/PlayerController.ts:192:2-253:3) 改 `statusStore.$patch` 合并 7-8 个独立 setter 为一次序列化。

### 5. 播放进度更新重构

- 仅在「播放中 + 页面可见」时启动 60Hz rAF，暂停 / 不可见时停 rAF 并同步一次。
- 进度链路在缓冲期间保持存活，避免 UI 在 buffering 时假死等待。

### 6. 动态封面修复

- video 增加 `poster / playsinline / preload / disablepictureinpicture`，新增 `error / stalled` 事件兜底，失败时清理资源避免花屏与原生播放按钮占位。
- 动态封面 URL 升级 HTTPS 避免 Mixed Content。
- 修正 IPC 返回类型，完善本地封面资源清理。

### 7. 周边

- [getCoverColor](cci:1://file:///d:/a/SPlayer-for-Android/src/utils/color.ts:13:0-34:2) 采样降至 32×32 + `requestIdleCallback` 调度 + LRU 缓存，切歌时主线程更顺滑。


## 📱 影响范围

- [x] 🎵 播放引擎 / 音频
- [x] 📝 歌词 / 桌面歌词
- [x] 🔔 通知栏 / MediaSession
- [x] 🎨 UI / 主题 / 布局
- [x] 📱 Capacitor / 原生 Android 代码


## ✅ 自检清单

- [x] 本 PR **目标分支为 `dev`**
- [x] 本地已执行 `pnpm lint` 且无 warning
- [x] 本地已执行 `pnpm typecheck` 且无报错
- [x] 已在 **至少一台真机** 上构建并验证关键路径
- [x] UI 改动已兼顾 **手机竖屏 + 平板横屏** 两种布局
- [x] 新增 / 修改的文案使用中文，与项目整体风格一致
- [x] 未引入不必要的依赖 / 大体积资源
- [x] 未修改签名密钥 / CI Secrets 相关文件

## 🧪 测试方式

1. **后台自治续播**：构造 ≤200 首播放列表，进入播放后将应用切到后台并锁屏 ≥5 分钟（确保 WebView 被冻结），验证通知栏切歌按钮 / 自动续播 / ALL wrap 正常。
2. **窗口边缘补窗**：构造 >200 首列表，播放到接近窗口右缘时观察 `requestUrls` → JS 补窗 → Java 续播链路是否无缝。
3. **频谱 & 锁屏**：开启频谱可视化，分别在前台、后台、锁屏、息屏场景验证频谱采集启停与 CPU 占用变化。
4. **切歌流畅性**：连续点击下一首 ≥10 次，验证不再出现按钮无响应 / UI 跳跃 / 进度条假死。
5. **动态封面**：切到含动态封面的歌曲，断网或人为返回 4xx 验证错误兜底（不出现花屏与原生播放按钮占位）。
6. **类型 & Lint**：`pnpm lint` 与 `pnpm typecheck:web` 在改动文件无新增错误。

## 💬 其他说明 (选填)

- **窗口大小取舍**：±100（201 首）是性能甜点位，payload ~70KB / 序列化 ~8ms，远超日常需求；列表 >201 首时仍走 JS 补窗，行为正确但补窗瞬间会有一次 IPC 推送。如需放大到 ±150 / ±250，建议先做 `WindowTrack` 字段瘦身或增量 diff 推送。
- **Automix 兼容**：[FftAudioProcessor](cci:2://file:///d:/a/SPlayer-for-Android/android/app/src/main/java/top/imsyy/splayer/android/playback/FftAudioProcessor.java:15:0-411:1) 多实例设计已为未来双 ExoPlayer crossfade 预留扩展位，`setAudioProcessors` 传数组而非单元素。
- **既有类型错误**：`pnpm typecheck:web` 仍残留 58 个旧错误，集中在本 PR 未触及的 19 个文件