### PR TITLE
feat(android,web): 实现本地缓存与预加载优化，修复多项体验问题

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
@@ -8,8 +9,22 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
+    <!-- Android 12+ (API 31+) 隐私归因：MediaSession/通知/缓存等敏感能力分类标记，
+         消除系统 "AppOps: attributionTag not declared in manifest" 警告。
+         低于 API 31 的系统（含 minSdk=29 的 Android 10/11）会直接忽略该元素，不影响功能。 -->
+    <attribution
+        android:tag="playback"
+        android:label="@string/attribution_playback"
+        tools:targetApi="31" />
+    <attribution
+        android:tag="cache"
+        android:label="@string/attribution_cache"
+        tools:targetApi="31" />
+
     <application
         android:allowBackup="true"
+        android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:hardwareAccelerated="true"
         android:requestLegacyExternalStorage="true"
         android:icon="@mipmap/ic_launcher"

--- a/android/app/src/main/java/top/imsyy/splayer/android/MainActivity.java
+++ b/android/app/src/main/java/top/imsyy/splayer/android/MainActivity.java
@@ -3,26 +3,42 @@ package top.imsyy.splayer.android;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.preference.PreferenceManager;
 import android.view.View;
 import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
 import com.getcapacitor.BridgeActivity;
+import top.imsyy.splayer.android.cache.AndroidCachePlugin;
+import top.imsyy.splayer.android.cache.AudioPrefetchTtlIndex;
 import top.imsyy.splayer.android.download.AndroidDownloadPlugin;
 import top.imsyy.splayer.android.lyric.AndroidLocalLyricPlugin;
 import top.imsyy.splayer.android.playback.AndroidNativePlaybackPlugin;
 
 public class MainActivity extends BridgeActivity {
   private static final String PREF_SHOW_STATUS_BAR = "androidShowStatusBar";
+  /** 进程级 sweep 启动标记：Activity 重建（旋屏 / 配置变更）时不再重复 post Runnable。 */
+  private static volatile boolean sweepBootstrapped = false;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     registerPlugin(AndroidNativePlaybackPlugin.class);
     registerPlugin(AndroidLocalLyricPlugin.class);
     registerPlugin(AndroidDownloadPlugin.class);
+    registerPlugin(AndroidCachePlugin.class);
     super.onCreate(savedInstanceState);
     applyImmersiveMode();
+    // 音频预载 TTL：推迟到首帧后再初始化（构造期会同步读 SharedPreferences，冷启动加密磁盘可能耗百毫秒）。
+    // 这里 post 2s，startPeriodicSweep 内部再 postDelayed 5s，首次 sweep 实际 ≈7s 后开始；
+    // 之后每 30min 周期清理；TTL=50min；期间用户重复播放该 url 会通过 PlaybackManager.load 续期。
+    if (!sweepBootstrapped) {
+      sweepBootstrapped = true;
+      new Handler(Looper.getMainLooper()).postDelayed(
+          () -> AudioPrefetchTtlIndex.getInstance(getApplicationContext()).startPeriodicSweep(),
+          2_000L);
+    }
   }
 
   @Override

--- a/android/app/src/main/java/top/imsyy/splayer/android/cache/AndroidCachePlugin.java
+++ b/android/app/src/main/java/top/imsyy/splayer/android/cache/AndroidCachePlugin.java
@@ -1,0 +1,209 @@
+package top.imsyy.splayer.android.cache;
+
+import android.util.Base64;
+import com.getcapacitor.JSArray;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Android 端缓存 Capacitor 插件。
+ *
+ * <p>所有数据走 base64（JSON 不能携带二进制）。读取大文件性能损失可接受（封面通常 < 200KB，
+ * 歌词 < 50KB；音频不走该通道而是 ExoPlayer SimpleCache 直读）。
+ *
+ * <p>JS 调用 {@link top.imsyy.splayer.android.cache.CacheStorage} 单例。
+ */
+@CapacitorPlugin(name = "AndroidCache")
+public class AndroidCachePlugin extends Plugin {
+
+  /**
+   * type 白名单：仅允许 CacheStorage 已声明的子目录名，杜绝 "../shared_prefs" 之类路径穿越。
+   * 与 CacheStorage 层的第二道防线（typeDir canonical 校验）配合，双重隔离。
+   */
+  private static final Set<String> ALLOWED_TYPES =
+      new HashSet<>(Arrays.asList(CacheStorage.knownTypes()));
+
+  private CacheStorage storage() {
+    return CacheStorage.getInstance(getContext());
+  }
+
+  /** 校验 type 在白名单内；非法直接 reject 并返 false。 */
+  private boolean requireValidType(@androidx.annotation.Nullable String type, PluginCall call) {
+    if (type == null) {
+      call.reject("type 必填");
+      return false;
+    }
+    if (!ALLOWED_TYPES.contains(type)) {
+      call.reject("非法 type: " + type);
+      return false;
+    }
+    return true;
+  }
+
+  @PluginMethod
+  public void read(PluginCall call) {
+    String type = call.getString("type");
+    String key = call.getString("key");
+    if (!requireValidType(type, call)) return;
+    if (key == null) {
+      call.reject("key 必填");
+      return;
+    }
+    byte[] data = storage().read(type, key);
+    JSObject ret = new JSObject();
+    if (data == null) {
+      ret.put("hit", false);
+    } else {
+      ret.put("hit", true);
+      ret.put("data", Base64.encodeToString(data, Base64.NO_WRAP));
+      ret.put("size", data.length);
+    }
+    call.resolve(ret);
+  }
+
+  @PluginMethod
+  public void write(PluginCall call) {
+    String type = call.getString("type");
+    String key = call.getString("key");
+    String dataB64 = call.getString("data");
+    if (!requireValidType(type, call)) return;
+    if (key == null || dataB64 == null) {
+      call.reject("key / data 必填");
+      return;
+    }
+    byte[] bytes;
+    try {
+      bytes = Base64.decode(dataB64, Base64.DEFAULT);
+    } catch (IllegalArgumentException e) {
+      call.reject("data 不是合法 base64");
+      return;
+    }
+    boolean ok = storage().write(type, key, bytes);
+    JSObject ret = new JSObject();
+    ret.put("success", ok);
+    if (!ok) ret.put("message", "写入失败（磁盘不足或 IO 异常）");
+    call.resolve(ret);
+  }
+
+  @PluginMethod
+  public void remove(PluginCall call) {
+    String type = call.getString("type");
+    String key = call.getString("key");
+    if (!requireValidType(type, call)) return;
+    if (key == null) {
+      call.reject("key 必填");
+      return;
+    }
+    boolean ok = storage().remove(type, key);
+    JSObject ret = new JSObject();
+    ret.put("success", ok);
+    call.resolve(ret);
+  }
+
+  @PluginMethod
+  public void list(PluginCall call) {
+    String type = call.getString("type");
+    if (!requireValidType(type, call)) return;
+    List<CacheStorage.CacheEntry> entries = storage().list(type);
+    JSArray arr = new JSArray();
+    for (CacheStorage.CacheEntry e : entries) {
+      JSObject obj = new JSObject();
+      obj.put("key", e.key);
+      obj.put("size", e.size);
+      obj.put("mtime", e.mtime);
+      arr.put(obj);
+    }
+    JSObject ret = new JSObject();
+    ret.put("entries", arr);
+    call.resolve(ret);
+  }
+
+  @PluginMethod
+  public void clear(PluginCall call) {
+    String type = call.getString("type");
+    if (!requireValidType(type, call)) return;
+    boolean ok = storage().clear(type);
+    JSObject ret = new JSObject();
+    ret.put("success", ok);
+    call.resolve(ret);
+  }
+
+  @PluginMethod
+  public void clearAll(PluginCall call) {
+    boolean ok = storage().clearAll();
+    JSObject ret = new JSObject();
+    ret.put("success", ok);
+    call.resolve(ret);
+  }
+
+  /** 返回 {totalBytes, perType: {lyrics:..., covers:...}, deviceFreeBytes, maxBytes}。 */
+  @PluginMethod
+  public void getStats(PluginCall call) {
+    CacheStorage cs = storage();
+    JSObject ret = new JSObject();
+    ret.put("totalBytes", cs.getTotalBytes());
+    ret.put("deviceFreeBytes", cs.getDeviceFreeBytes());
+    ret.put("maxBytes", cs.getMaxBytes());
+    // 设备空间不足时的有效上限（剩余空间 × 60% 与用户设定取 min）；UI 用于展示「实际生效配额」。
+    ret.put("effectiveMaxBytes", cs.getEffectiveMaxBytes());
+
+    JSObject perType = new JSObject();
+    Map<String, Long> map = cs.getPerTypeBytes();
+    for (Map.Entry<String, Long> e : map.entrySet()) {
+      perType.put(e.getKey(), e.getValue());
+    }
+    ret.put("perType", perType);
+    call.resolve(ret);
+  }
+
+  /**
+   * 设置最大缓存上限（字节）。最小 256MB，setting 端调用。
+   *
+   * <p>注意：参数 maxBytes 用 Double 接收，避免 Capacitor JS number → Long 在大整数上的精度损失。
+   */
+  @PluginMethod
+  public void setMaxBytes(PluginCall call) {
+    Double bytes = call.getDouble("maxBytes");
+    if (bytes == null) {
+      call.reject("maxBytes 必填");
+      return;
+    }
+    storage().setMaxBytes(bytes.longValue());
+    JSObject ret = new JSObject();
+    ret.put("success", true);
+    ret.put("appliedMaxBytes", storage().getMaxBytes());
+    call.resolve(ret);
+  }
+
+  /** 主动触发一次全局 LRU 驱逐（设置面板「立即整理」按钮可用）。 */
+  @PluginMethod
+  public void enforceLimit(PluginCall call) {
+    storage().enforceLimit();
+    JSObject ret = new JSObject();
+    ret.put("success", true);
+    ret.put("totalBytes", storage().getTotalBytes());
+    call.resolve(ret);
+  }
+
+  /** 提供 JSON 序列化辅助（IDE 已 import 但部分调用未用，避免 unused warn）。 */
+  @SuppressWarnings("unused")
+  private JSObject toJsObject(JSONObject json) throws JSONException {
+    JSObject obj = new JSObject();
+    java.util.Iterator<String> it = json.keys();
+    while (it.hasNext()) {
+      String k = it.next();
+      obj.put(k, json.get(k));
+    }
+    return obj;
+  }
+}

--- a/android/app/src/main/java/top/imsyy/splayer/android/cache/AudioCacheProvider.java
+++ b/android/app/src/main/java/top/imsyy/splayer/android/cache/AudioCacheProvider.java
@@ -1,0 +1,624 @@
+package top.imsyy.splayer.android.cache;
+
+import android.content.Context;
+import android.net.Uri;
+import android.util.Log;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.media3.database.StandaloneDatabaseProvider;
+import androidx.media3.datasource.DataSource;
+import androidx.media3.datasource.DataSpec;
+import androidx.media3.datasource.DefaultHttpDataSource;
+import androidx.media3.datasource.cache.CacheDataSink;
+import androidx.media3.datasource.cache.CacheDataSource;
+import androidx.media3.datasource.cache.CacheSpan;
+import androidx.media3.datasource.cache.CacheWriter;
+import androidx.media3.datasource.cache.ContentMetadata;
+import androidx.media3.datasource.cache.NoOpCacheEvictor;
+import androidx.media3.datasource.cache.SimpleCache;
+import java.io.File;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.NavigableSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * ExoPlayer SimpleCache 单例提供者。
+ *
+ * <p>关键设计：
+ *
+ * <ul>
+ *   <li>使用 {@link NoOpCacheEvictor}：把驱逐权交给 {@link CacheStorage} 全局 LRU，避免双重逻辑。
+ *   <li>cacheKey：从 URL 路径尾段提取音频文件名作为指纹，去掉 expire 签名等动态参数；
+ *       同一首歌不同时间签出的 URL 仍可命中同一份缓存。
+ *   <li>{@link DataSource.Factory} 链：HTTP upstream → CacheDataSource。
+ * </ul>
+ */
+public final class AudioCacheProvider {
+
+  /**
+   * 音频文件名匹配：路径末段是 “xxxxx.{ext}” 形式时提取作为 cacheKey 主体。<br>
+   * 不仅适用 NCM；任何 CDN 返回“动态路径 + 音频后缀”均可命中。使用 (?i) 允许大写后缀。
+   */
+  private static final Pattern AUDIO_FILE_PATTERN =
+      Pattern.compile("/([A-Za-z0-9_-]+\\.(?i:mp3|flac|m4a|ogg|wav|aac|opus))");
+
+  /**
+   * 低磁盘阈值：设备剩余不足 1GB 时禁止音频缓存<strong>写入</strong>（prefetch + 播放期 sink）。<br>
+   * 读取不受影响：已缓存的歌仍可本地命中播放。
+   */
+  public static final long LOW_DISK_THRESHOLD_BYTES = 1024L * 1024L * 1024L;
+
+  /**
+   * 设备剩余空间是否低于 {@link #LOW_DISK_THRESHOLD_BYTES}。<br>
+   * StatFs 读取失败 (-1) 时返 false（保守：读不出不随意禁写）。
+   */
+  public static boolean isLowDiskSpace(@NonNull Context appContext) {
+    long free = CacheStorage.getInstance(appContext).getDeviceFreeBytes();
+    if (free < 0) return false;
+    return free < LOW_DISK_THRESHOLD_BYTES;
+  }
+
+  @SuppressWarnings("StaticFieldLeak")
+  private static volatile SimpleCache simpleCache;
+
+  private static final Object lock = new Object();
+
+  private AudioCacheProvider() {}
+
+  /** 懒初始化 SimpleCache 单例（同进程多次构造同目录会抛 IllegalStateException）。 */
+  @NonNull
+  public static SimpleCache getOrCreate(@NonNull Context appContext) {
+    SimpleCache cache = simpleCache;
+    if (cache != null) return cache;
+    synchronized (lock) {
+      if (simpleCache != null) return simpleCache;
+      CacheStorage storage = CacheStorage.getInstance(appContext);
+      simpleCache =
+          new SimpleCache(
+              storage.getAudioCacheDir(),
+              new NoOpCacheEvictor(),
+              new StandaloneDatabaseProvider(appContext));
+      return simpleCache;
+    }
+  }
+
+  /**
+   * 偷看已初始化的 SimpleCache 实例；未初始化返 null，不触发初始化。<br>
+   * 供 {@link CacheStorage#getTypeBytes} 在 SimpleCache 已就绪时走 O(1) 读取，否则回退扫盘。
+   */
+  @Nullable
+  public static SimpleCache peekSimpleCache() {
+    return simpleCache;
+  }
+
+  /** 释放（应用退出 / 测试场景）；正常运行不调用，单例随进程生命周期。 */
+  public static void release() {
+    synchronized (lock) {
+      if (simpleCache != null) {
+        simpleCache.release();
+        simpleCache = null;
+      }
+    }
+  }
+
+  /**
+   * 构造带缓存的 DataSource.Factory。
+   *
+   * <p>关键点 —— 必须显式设 {@link CacheDataSink}，否则 ExoPlayer 默认<strong>只读不写</strong>，
+   * 已 prefetch 的字节会命中，但 prefetch 范围之外（如 512 KB 之后 / seek 跳过的段落）走 HTTP
+   * upstream 拉取后不会落盘，导致"前半部分有、后半部分没"的缓存空洞。
+   *
+   * <p>{@link CacheDataSink#DEFAULT_FRAGMENT_SIZE} 是 5 MB；多数 NCM 歌曲单首 3-10 MB，
+   * 显式设 {@link Long#MAX_VALUE} 强制单文件 chunk，避免 seek 时碎片化 + 减少 SimpleCache 元数据开销。
+   *
+   * <p>flags：
+   * <ul>
+   *   <li>{@link CacheDataSource#FLAG_IGNORE_CACHE_ON_ERROR}：上游失败时仍可读已缓存部分
+   *   <li>{@link CacheDataSource#FLAG_BLOCK_ON_CACHE}：写入完成前阻塞读取，保证完整性
+   * </ul>
+   */
+  @NonNull
+  public static DataSource.Factory buildCachedDataSourceFactory(@NonNull Context appContext) {
+    SimpleCache cache = getOrCreate(appContext);
+
+    DataSource.Factory upstreamFactory =
+        new DefaultHttpDataSource.Factory()
+            .setAllowCrossProtocolRedirects(true)
+            .setConnectTimeoutMs(15_000)
+            .setReadTimeoutMs(15_000)
+            .setUserAgent("SPlayer-Android/1.0");
+
+    // 写入器：把 upstream 拉到的字节落到 SimpleCache。fragmentSize=MAX 让单首歌只产生 1 个文件
+    CacheDataSink.Factory cacheSinkFactory =
+        new CacheDataSink.Factory().setCache(cache).setFragmentSize(Long.MAX_VALUE);
+
+    // 包装为动态 Factory：每次 createDataSource 重新判断是否低磁盘，
+    // 低磁盘时不传 sinkFactory → CacheDataSource 只读不写，已缓存仍可命中，新字节不落盘。
+    return () -> {
+      CacheDataSource.Factory cf =
+          new CacheDataSource.Factory()
+              .setCache(cache)
+              .setUpstreamDataSourceFactory(upstreamFactory)
+              .setCacheKeyFactory(spec -> resolveCacheKey(spec.uri))
+              .setFlags(
+                  CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR
+                      | CacheDataSource.FLAG_BLOCK_ON_CACHE);
+      if (!isLowDiskSpace(appContext)) {
+        cf.setCacheWriteDataSinkFactory(cacheSinkFactory);
+      } else {
+        Log.w(TAG, "low disk: audio cache write disabled (read-only)");
+      }
+      return cf.createDataSource();
+    };
+  }
+
+  /** 已知的临时签名 / 过期参数：仅这些会被剔除以保证同曲目缓存命中。其余 query 参与 key 防碰撞。 */
+  private static final java.util.Set<String> EPHEMERAL_QUERY_KEYS =
+      new java.util.HashSet<>(
+          java.util.Arrays.asList(
+              "expire",
+              "expires",
+              "signature",
+              "sign",
+              "token",
+              "auth_key",
+              "_t",
+              "timestamp",
+              "ts"));
+
+  /**
+   * 从 URL 提取稳定 cacheKey。
+   *
+   * <p>API命中 {@link #NCM_FILE_PATTERN} 时走 {@code ncm:<id>}，最稳定。
+   * <p>其他场景（Subsonic / 自部署流媒体 / 签名 URL）兜底用 {@code host + path + 排序后非临时 query}
+   * 的 md5：仅剔除已知临时签名参数，保留区分歌曲的业务参数（如 ?id=xxx）防止 A/B 共用 key 播错歌。
+   */
+  @NonNull
+  public static String resolveCacheKey(@NonNull Uri uri) {
+    String scheme = uri.getScheme();
+    if (scheme != null && scheme.startsWith("file")) {
+      // 本地文件：直接用 path（不会进缓存，但 cacheKey 仍要求非空）
+      return "local:" + uri.getPath();
+    }
+    String path = uri.getPath();
+    if (path == null) path = "";
+    Matcher m = AUDIO_FILE_PATTERN.matcher(path);
+    if (m.find()) {
+      // 前缀 aud: 表示“从 URL 提取的音频文件名”；早期版本使用 ncm:，重命名后一次性 cache miss，可接受。
+      return "aud:" + m.group(1).toLowerCase(java.util.Locale.ROOT);
+    }
+    // 通用回退：host + path + 排序后的稳定 query（剔除签名/过期参数）
+    StringBuilder sb = new StringBuilder();
+    String host = uri.getHost();
+    if (host != null) sb.append(host);
+    sb.append(path);
+    java.util.Set<String> qnames;
+    try {
+      qnames = uri.getQueryParameterNames();
+    } catch (UnsupportedOperationException e) {
+      qnames = java.util.Collections.emptySet();
+    }
+    if (!qnames.isEmpty()) {
+      java.util.List<String> sortedKeys = new java.util.ArrayList<>(qnames);
+      java.util.Collections.sort(sortedKeys);
+      sb.append('?');
+      boolean first = true;
+      for (String qk : sortedKeys) {
+        if (EPHEMERAL_QUERY_KEYS.contains(qk.toLowerCase(java.util.Locale.ROOT))) continue;
+        String qv = uri.getQueryParameter(qk);
+        if (qv == null) qv = "";
+        if (!first) sb.append('&');
+        sb.append(qk).append('=').append(qv);
+        first = false;
+      }
+    }
+    return CacheStorage.keyFromUrl(sb.toString());
+  }
+
+  // ========== prefetch ==========
+
+  private static final String TAG = "AudioCachePrefetch";
+  /** 默认预下载字节数：512 KB，足够 ExoPlayer 启播第一帧解码 + 内部缓冲。 */
+  public static final long DEFAULT_PREFETCH_BYTES = 512L * 1024L;
+  /** 短预载单线程：供“下一首前 512KB”使用，低占用高响应。 */
+  private static volatile ExecutorService prefetchExecutor;
+  /**
+   * 全量下载独立单线程：全量一首 5-10MB 需背景跑，不能占着短预载走道。<br>
+   * 拆走后：load 下一首 → prefetchExecutor 立即跑 512KB；全量送到 fullDownloadExecutor。
+   */
+  private static volatile ExecutorService fullDownloadExecutor;
+  /** 全量下载任务取消标志；cancelAllPrefetch / clearAll 需要能同步中断。 */
+  @Nullable private static volatile AtomicBoolean currentFullCancelFlag;
+  /** 已在排队 / 进行中的 cacheKey 集合，幂等去重。 */
+  private static final Set<String> inFlight = new HashSet<>();
+  /**
+   * 每个 cacheKey 独立写锁：保证同 cacheKey 的 CacheWriter 不会并发执行（短预载 + 全量任务跨 executor 时
+   * 都从位置 0 写同一组 span，并发会触发 SimpleCache 的 holeSpan 锁竞争 + CacheException）。<br>
+   * 短任务持锁 ~1s 完成；全量任务后到达直接接力——FLAG_BLOCK_ON_CACHE 会跳过已缓存字节只下剩余部分。<br>
+   * 用 ConcurrentHashMap 保证 computeIfAbsent 的原子性。
+   */
+  private static final Map<String, Object> cacheKeyWriterLocks = new ConcurrentHashMap<>();
+  /** 当前 prefetch 任务的 cancel 标志：切歌时取消上一首的 prefetch，给新任务让带宽。 */
+  @Nullable private static volatile AtomicBoolean currentCancelFlag;
+
+  @NonNull
+  private static ExecutorService getExecutor() {
+    if (prefetchExecutor == null) {
+      synchronized (AudioCacheProvider.class) {
+        if (prefetchExecutor == null) {
+          prefetchExecutor =
+              Executors.newSingleThreadExecutor(
+                  r -> {
+                    Thread t = new Thread(r, "audio-cache-prefetch");
+                    t.setDaemon(true);
+                    t.setPriority(Thread.NORM_PRIORITY - 1);
+                    return t;
+                  });
+        }
+      }
+    }
+    return prefetchExecutor;
+  }
+
+  /** 全量下载独立 executor：与短预载不抢资源。 */
+  @NonNull
+  private static ExecutorService getFullDownloadExecutor() {
+    if (fullDownloadExecutor == null) {
+      synchronized (AudioCacheProvider.class) {
+        if (fullDownloadExecutor == null) {
+          fullDownloadExecutor =
+              Executors.newSingleThreadExecutor(
+                  r -> {
+                    Thread t = new Thread(r, "audio-cache-full-download");
+                    t.setDaemon(true);
+                    // 更低优先级：全量下载为后台作业，不应抢占短预载 / 当前播放。
+                    t.setPriority(Thread.NORM_PRIORITY - 2);
+                    return t;
+                  });
+        }
+      }
+    }
+    return fullDownloadExecutor;
+  }
+
+  /**
+   * 主动把 url 前 {@link #DEFAULT_PREFETCH_BYTES} 字节写入 SimpleCache。
+   *
+   * <p>用法：切歌成功后立即调用 {@code prefetchUrl(下一首 url)}。下次 ExoPlayer setMediaItem
+   * 这条 url 时，CacheDataSource 立刻命中本地，跳过 OPEN→网络握手 100-500ms。
+   *
+   * <p>幂等：同 cacheKey 已在队列或已 ready 时直接 no-op。
+   *
+   * @param appContext app context
+   * @param url 要预下载的 http(s) url；非 http 直接忽略
+   */
+  public static void prefetchUrl(@NonNull Context appContext, @Nullable String url) {
+    prefetchUrlWithLength(appContext, url, DEFAULT_PREFETCH_BYTES, /* cancelPrev= */ true);
+  }
+
+  /**
+   * 把 url 整首音频拉完写入 SimpleCache（length=EOF）。<br>
+   * 用法：当用户播放某首歌 >10s 时，调用此方法把整首存档为"正式缓存"，
+   * 为后续 automix（需要音频完整字节做 BPM / energy 分析）和离线播放铺路。
+   *
+   * <p>与短预载共用同一单线程池，按调用顺序排队；不取消已有任务（不抢带宽），
+   * 排到自己时若用户已经切歌，TTL 索引也会让本任务的字节仍然有效（promoted=true）。
+   */
+  public static void prefetchUrlFull(@NonNull Context appContext, @Nullable String url) {
+    // 幂等短路：已 promoted 跳过。全量下载的推进与最终 promote 标记都在 prefetchUrlWithLength 内负责。
+    if (url == null || url.isEmpty()) return;
+    Uri uri = Uri.parse(url);
+    // scheme 校验与短预载入口保持一致：非 http(s) 直接拒绝，避免误算 cacheKey 与日志噪声。
+    String scheme = uri.getScheme();
+    if (scheme == null || (!scheme.equals("http") && !scheme.equals("https"))) return;
+    String cacheKey = resolveCacheKey(uri);
+    if (AudioPrefetchTtlIndex.getInstance(appContext).isPromoted(cacheKey)) return;
+    // cancelPrev=false：完整下载不应抢占已经在跑的短预载
+    prefetchUrlWithLength(appContext, url, /* length= */ Long.MAX_VALUE, /* cancelPrev= */ false);
+  }
+
+  /** 公共实现：length 控制下载字节数；cancelPrev 控制是否取消上一首未完成的任务。 */
+  private static void prefetchUrlWithLength(
+      @NonNull Context appContext, @Nullable String url, long length, boolean cancelPrev) {
+    if (url == null || url.isEmpty()) return;
+    // 低磁盘：不启动任何 prefetch（短预载 / 全量下载都被拦）。在 PlaybackManager.schedulePromotion 调用前路拦截。
+    if (isLowDiskSpace(appContext)) {
+      Log.d(TAG, "low disk: prefetch skipped for " + url);
+      return;
+    }
+    Uri uri = Uri.parse(url);
+    String scheme = uri.getScheme();
+    if (scheme == null || (!scheme.equals("http") && !scheme.equals("https"))) return;
+
+    final String cacheKey = resolveCacheKey(uri);
+    final String inFlightKey = cacheKey + "|" + length; // 同 key 但不同 length 的请求不互斥
+    synchronized (inFlight) {
+      if (inFlight.contains(inFlightKey)) {
+        return; // 已在排队 / 进行中
+      }
+      inFlight.add(inFlightKey);
+    }
+
+    final SimpleCache cache = getOrCreate(appContext);
+    final AudioPrefetchTtlIndex ttlIndex = AudioPrefetchTtlIndex.getInstance(appContext);
+    // 已完整命中（cachedBytes ≥ length 阈值）则跳过 IO；但仍刷新 TTL 索引让缓存"续期"
+    long probeLength = length == Long.MAX_VALUE ? DEFAULT_PREFETCH_BYTES : length;
+    long cachedBytes = cache.getCachedBytes(cacheKey, 0, probeLength);
+    // 全量下载场景：还需要确认是否真的下完了（用 contentLength 判断更准但成本高，这里宽松判定）
+    if (length != Long.MAX_VALUE && cachedBytes >= length) {
+      ttlIndex.markAccess(cacheKey);
+      synchronized (inFlight) {
+        inFlight.remove(inFlightKey);
+      }
+      return;
+    }
+
+    // 取消上一首的 prefetch：给当前新任务腾带宽（仅短预载场景）
+    AtomicBoolean cancelFlag = new AtomicBoolean(false);
+    final boolean isFull = length == Long.MAX_VALUE;
+    if (cancelPrev) {
+      AtomicBoolean prevCancel = currentCancelFlag;
+      if (prevCancel != null) prevCancel.set(true);
+      currentCancelFlag = cancelFlag;
+    }
+    if (isFull) {
+      // 全量下载不抢带宽但要可被 cancelAll 中断；覆盖上次未完成的全量任务取消标。
+      AtomicBoolean prevFull = currentFullCancelFlag;
+      if (prevFull != null) prevFull.set(true);
+      currentFullCancelFlag = cancelFlag;
+    }
+    final AtomicBoolean cancelFlagFinal = cancelFlag;
+    final long lengthFinal = length;
+
+    // 路由：全量走后台 executor，短预载走响应 executor，互不阻塞。
+    ExecutorService chosen = isFull ? getFullDownloadExecutor() : getExecutor();
+    chosen.execute(() -> {
+      // 取每个 cacheKey 自己的 monitor：跨 executor 时同 cacheKey 串行，避免并发 CacheWriter 写同一组 span
+      final Object writerLock = cacheKeyWriterLocks.computeIfAbsent(cacheKey, k -> new Object());
+      try {
+        synchronized (writerLock) {
+          DataSource.Factory factory = buildCachedDataSourceFactory(appContext);
+          DataSource ds = factory.createDataSource();
+          DataSpec.Builder specBuilder =
+              new DataSpec.Builder().setUri(uri).setKey(cacheKey).setPosition(0);
+          if (lengthFinal != Long.MAX_VALUE) {
+            specBuilder.setLength(lengthFinal);
+          }
+          DataSpec spec = specBuilder.build();
+          CacheWriter writer =
+              new CacheWriter(
+                  (CacheDataSource) ds,
+                  spec,
+                  /* temporaryBuffer= */ null,
+                  (requestLength, bytesCached, newBytesCached) -> {
+                    // 取消信号：抛 InterruptedException 让 CacheWriter 退出
+                    if (cancelFlagFinal.get()) Thread.currentThread().interrupt();
+                  });
+          writer.cache();
+          // 全量下载（length=MAX_VALUE）成功返回才标 promoted；CacheWriter 中途抛异常会走到 catch，不会 promote。
+          // 这样 getPromotedAudioFile 看到 isPromoted=true 时，可认为文件完整；automix 不会读到截断字节。
+          //
+          // 修复 #1：promote 前比对实际缓存字节数 vs upstream Content-Length（CacheDataSource 在 open 时
+          // 已写入 ContentMetadata）。chunked encoding 服务端提前 EOF 等场景 writer.cache() 仍正常返回，
+          // 但 cachedBytes < contentLength → 不 promote，避免截断文件被当作完整 automix 源。
+          if (lengthFinal == Long.MAX_VALUE) {
+            long expected = ContentMetadata.getContentLength(cache.getContentMetadata(cacheKey));
+            long actual = cache.getCachedBytes(cacheKey, 0, Long.MAX_VALUE);
+            if (expected > 0 && actual < expected) {
+              Log.w(
+                  TAG,
+                  "promote skipped (truncated): "
+                      + cacheKey
+                      + " cached="
+                      + actual
+                      + " expected="
+                      + expected);
+            } else {
+              ttlIndex.promote(cacheKey);
+            }
+          } else {
+            ttlIndex.markAccess(cacheKey);
+          }
+          String lengthLabel = lengthFinal == Long.MAX_VALUE ? "FULL" : lengthFinal + " bytes";
+          Log.d(TAG, "prefetch done: " + cacheKey + " (" + lengthLabel + ")");
+        }
+      } catch (Throwable e) {
+        // 网络失败 / 取消都走这里；不致命，下次播放走正常流程
+        Log.d(TAG, "prefetch aborted: " + cacheKey + " - " + e.getMessage());
+      } finally {
+        synchronized (inFlight) {
+          inFlight.remove(inFlightKey);
+        }
+      }
+    });
+  }
+
+  /** 取消所有正在排队的 prefetch（应用关闭 / 清缓存场景）；同时中断全量下载。 */
+  public static void cancelAllPrefetch() {
+    AtomicBoolean flag = currentCancelFlag;
+    if (flag != null) flag.set(true);
+    AtomicBoolean fullFlag = currentFullCancelFlag;
+    if (fullFlag != null) fullFlag.set(true);
+    synchronized (inFlight) {
+      inFlight.clear();
+    }
+  }
+
+  /**
+   * 安全清空 audio 缓存：走 {@link SimpleCache#removeResource} 让 SimpleCache 同步内部 ContentIndex，
+   * 而非 deleteRecursive 物理删目录（后者会导致活跃 SimpleCache 实例索引/磁盘不一致，后续播放抛 IOException）。
+   *
+   * <p>同时清 promoted 索引，避免 isPromoted 命中已删 key。
+   */
+  public static void clearAll(@NonNull Context appContext) {
+    cancelAllPrefetch();
+    SimpleCache cache = simpleCache;
+    if (cache != null) {
+      // 取 keys 副本：cache.getKeys() 返回内部视图，迭代中 removeResource 会 ConcurrentModification
+      Set<String> keys = new HashSet<>(cache.getKeys());
+      for (String key : keys) {
+        try {
+          cache.removeResource(key);
+        } catch (Throwable e) {
+          Log.w(TAG, "removeResource failed: " + key, e);
+        }
+      }
+    }
+    AudioPrefetchTtlIndex.getInstance(appContext).clearAllPromoted();
+  }
+
+  /**
+   * 让 audio 缓存收缩到 {@code maxAudioBytes}：按 mtime 升序删 key，promoted 排到最后保护。
+   *
+   * <p>由 CacheStorage.enforceLimit 在非 audio 删完仍超配额时调用，让 audio 真正参与全局 LRU。
+   *
+   * @return 释放的字节数；调用方可记日志 / 汇报
+   */
+  public static long enforceLimitTo(@NonNull Context appContext, long maxAudioBytes) {
+    SimpleCache cache = simpleCache;
+    if (cache == null) return 0L;
+    long total = cache.getCacheSpace();
+    if (total <= maxAudioBytes) return 0L;
+
+    AudioPrefetchTtlIndex idx = AudioPrefetchTtlIndex.getInstance(appContext);
+    Set<String> keys;
+    try {
+      keys = new HashSet<>(cache.getKeys());
+    } catch (Throwable e) {
+      return 0L;
+    }
+
+    // 收集 (key, lastMtime, totalBytes, isPromoted)
+    final class KeyMeta {
+      final String key;
+      final long mtime;
+      final long bytes;
+      final boolean promoted;
+
+      KeyMeta(String k, long m, long b, boolean p) {
+        key = k;
+        mtime = m;
+        bytes = b;
+        promoted = p;
+      }
+    }
+    java.util.List<KeyMeta> metas = new java.util.ArrayList<>();
+    for (String key : keys) {
+      NavigableSet<CacheSpan> spans;
+      try {
+        spans = cache.getCachedSpans(key);
+      } catch (Throwable e) {
+        continue;
+      }
+      if (spans == null || spans.isEmpty()) continue;
+      long maxMtime = 0L, bytes = 0L;
+      for (CacheSpan s : spans) {
+        if (s.file != null) maxMtime = Math.max(maxMtime, s.file.lastModified());
+        bytes += s.length;
+      }
+      metas.add(new KeyMeta(key, maxMtime, bytes, idx.isPromoted(key)));
+    }
+    // 排序：promoted 排最后（不轻易删）；同组按 mtime 升序
+    metas.sort(
+        (a, b) -> {
+          if (a.promoted != b.promoted) return a.promoted ? 1 : -1;
+          return Long.compare(a.mtime, b.mtime);
+        });
+
+    long current = total;
+    long target = (long) (maxAudioBytes * 0.8);
+    long freed = 0L;
+    for (KeyMeta m : metas) {
+      if (current <= target) break;
+      try {
+        cache.removeResource(m.key);
+        // 同时清 TTL / promoted 索引（防孤儿条目）
+        if (m.promoted) idx.unmarkPromoted(m.key);
+        current -= m.bytes;
+        freed += m.bytes;
+      } catch (Throwable e) {
+        Log.w(TAG, "evict failed: " + m.key, e);
+      }
+    }
+    Log.i(TAG, "audio enforceLimit: 释放 " + freed + " 字节，回到 " + current + "/" + maxAudioBytes);
+    return freed;
+  }
+
+  // ========== automix 支持 ==========
+
+  /**
+   * 给 automix 等需要直接读完整音频字节的场景：返回 SimpleCache 中某 url 对应的本地完整文件。
+   *
+   * <p>判定条件（必须全部满足）：
+   * <ol>
+   *   <li>该 url 已 promoted（用户播放 > 10s，并触发过 prefetchUrlFull）
+   *   <li>SimpleCache 中存在 cacheKey 且字节连续（{@link CacheSpan#isCached}）
+   *   <li>从 offset=0 开始（不是 seek 后的中段缓存）
+   *   <li>只有一个 span（fragmentSize=MAX 保证）
+   * </ol>
+   *
+   * <p>返回的 {@link File} 是真实物理文件路径，调用方可直接 fopen 做：
+   * <ul>
+   *   <li>BPM 检测（Aubio / Essentia）
+   *   <li>波形分析 / 振幅包络
+   *   <li>能量段落分割（用于自动 crossfade in/out 点选择）
+   *   <li>淡入淡出 / EQ 等离线音频处理
+   * </ul>
+   *
+   * <p>文件名是 SimpleCache 内部编码（{@code <cacheKey>.<index>.<id>.v3.exo}），<br>
+   * 后缀 .exo 不是音频格式提示——文件内容是原始网络字节（mp3/flac/m4a 取决于 url），<br>
+   * 用 ffmpeg / MediaExtractor 等需要自动识别格式或显式指定。
+   *
+   * @param appContext app context
+   * @param url 原始 http(s) url（与播放时一致即可，签名 / expire 参数可不同）
+   * @return 完整本地文件 File；未 promoted / 未下完 / SimpleCache 未就绪均返 null
+   */
+  @Nullable
+  public static File getPromotedAudioFile(@NonNull Context appContext, @Nullable String url) {
+    if (url == null || url.isEmpty()) return null;
+    Uri uri;
+    try {
+      uri = Uri.parse(url);
+    } catch (Throwable e) {
+      return null;
+    }
+    String scheme = uri.getScheme();
+    if (scheme == null || (!scheme.equals("http") && !scheme.equals("https"))) return null;
+
+    String cacheKey = resolveCacheKey(uri);
+    if (!AudioPrefetchTtlIndex.getInstance(appContext).isPromoted(cacheKey)) return null;
+
+    SimpleCache cache = simpleCache;
+    if (cache == null) return null;
+
+    NavigableSet<CacheSpan> spans;
+    try {
+      spans = cache.getCachedSpans(cacheKey);
+    } catch (Throwable e) {
+      return null;
+    }
+    if (spans == null || spans.isEmpty()) return null;
+
+    // fragmentSize=MAX 保证单 span；若意外有多 span 说明文件被切片，无法整段使用
+    if (spans.size() > 1) return null;
+    CacheSpan span = spans.first();
+    if (span == null || span.position != 0L || !span.isCached || span.file == null) return null;
+    if (!span.file.isFile()) return null;
+    return span.file;
+  }
+
+  /**
+   * 给 automix 探测：某 url 对应的本地缓存音频是否已就绪（promoted + 单 span 完整）。<br>
+   * 等价于 {@link #getPromotedAudioFile} != null，但不分配 File 对象。
+   */
+  public static boolean isPromotedAudioReady(@NonNull Context appContext, @Nullable String url) {
+    return getPromotedAudioFile(appContext, url) != null;
+  }
+}

--- a/android/app/src/main/java/top/imsyy/splayer/android/cache/AudioPrefetchTtlIndex.java
+++ b/android/app/src/main/java/top/imsyy/splayer/android/cache/AudioPrefetchTtlIndex.java
@@ -1,0 +1,235 @@
+package top.imsyy.splayer.android.cache;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.util.Log;
+import androidx.annotation.NonNull;
+import androidx.media3.datasource.cache.SimpleCache;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 音频预载缓存 TTL 索引。
+ *
+ * <p>独立于 {@link CacheStorage} 的全局 LRU：仅作用于 ExoPlayer SimpleCache 中的 prefetch 字节，
+ * 给每个 cacheKey 维护"最后一次被访问"的时间戳，超过 {@link #TTL_MILLIS} 未访问则从 SimpleCache 删除。
+ *
+ * <p>访问语义：
+ *
+ * <ul>
+ *   <li>prefetchUrl() 完成后调 {@link #markAccess}：记录 t = now
+ *   <li>PlaybackManager.load() 真正播放时调 {@link #markAccess}：续期到 now（重复播放保留缓存）
+ * </ul>
+ *
+ * <p>{@link #sweep} 在应用启动 + 每 30 分钟跑一次，删掉过期条目并调用 SimpleCache.removeResource。
+ *
+ * <p>持久化：SharedPreferences 文件 audio_prefetch_index，仅存 cacheKey → lastAccessAtMs 映射。
+ */
+public final class AudioPrefetchTtlIndex {
+
+  private static final String TAG = "AudioPrefetchTtl";
+  private static final String PREF_NAME = "audio_prefetch_index";
+  /** promoted 集合 prefs：key 为 cacheKey，value 固定 true（只看 key 是否存在）。 */
+  private static final String PREF_PROMOTED = "audio_cache_promoted";
+  /** 50 分钟有效期；过期清除（仅适用于未 promoted 的 prefetch 字节）。 */
+  public static final long TTL_MILLIS = 50L * 60L * 1000L;
+  /** 周期清理间隔：30 分钟。 */
+  public static final long SWEEP_INTERVAL_MILLIS = 30L * 60L * 1000L;
+
+  private static volatile AudioPrefetchTtlIndex instance;
+
+  private final Context appContext;
+  /** prefetch 时间戳索引：cacheKey → lastAccessAtMs。仅包含「临时预载」条目。 */
+  private final SharedPreferences prefs;
+  /** promoted 集合：“正式缓存” cacheKey，不受 50min TTL，仅受全局 LRU 配额管。 */
+  private final SharedPreferences promotedPrefs;
+  /** 后台线程：sweep 涉及 SP 全表读 + SimpleCache.removeResource 物理删文件，不能跑在主线程。 */
+  private final HandlerThread sweepThread;
+  private final Handler sweepHandler;
+  private final Runnable sweepRunnable =
+      new Runnable() {
+        @Override
+        public void run() {
+          sweep();
+          // 重新调度
+          sweepHandler.postDelayed(this, SWEEP_INTERVAL_MILLIS);
+        }
+      };
+
+  private AudioPrefetchTtlIndex(@NonNull Context appContext) {
+    this.appContext = appContext.getApplicationContext();
+    this.prefs = this.appContext.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
+    this.promotedPrefs =
+        this.appContext.getSharedPreferences(PREF_PROMOTED, Context.MODE_PRIVATE);
+    // 后台优先级线程：避免 sweep 时 SP/磁盘 IO 阻塞主线程。
+    this.sweepThread = new HandlerThread("audio-prefetch-sweep", Thread.NORM_PRIORITY - 2);
+    this.sweepThread.start();
+    this.sweepHandler = new Handler(this.sweepThread.getLooper());
+  }
+
+  @NonNull
+  public static AudioPrefetchTtlIndex getInstance(@NonNull Context appContext) {
+    if (instance == null) {
+      synchronized (AudioPrefetchTtlIndex.class) {
+        if (instance == null) {
+          instance = new AudioPrefetchTtlIndex(appContext);
+        }
+      }
+    }
+    return instance;
+  }
+
+  /**
+   * 标记一次访问：cacheKey → now。<br>
+   * 调用方：prefetchUrl 完成 / PlaybackManager.load 时各调一次。重复调用即续期。
+   * <p>若该 key 已 promoted，markAccess 为 no-op（promoted 不受 TTL）。
+   */
+  public void markAccess(@NonNull String cacheKey) {
+    if (cacheKey.isEmpty()) return;
+    if (promotedPrefs.contains(cacheKey)) return; // 已正式缓存，无需记时间戳
+    prefs.edit().putLong(cacheKey, System.currentTimeMillis()).apply();
+  }
+
+  /**
+   * 升级为“正式缓存”：调用者判定用户真的听了这首歌（如播放 > 10s）。<br>
+   * 从 prefetch 索引中移除，加入 promoted 集合；将不再被 50min TTL sweep 清。
+   *
+   * @return true 表示是首次 promote（调用者可据此决定是否启动全量下载）
+   */
+  public boolean promote(@NonNull String cacheKey) {
+    if (cacheKey.isEmpty()) return false;
+    if (promotedPrefs.contains(cacheKey)) return false;
+    promotedPrefs.edit().putBoolean(cacheKey, true).apply();
+    prefs.edit().remove(cacheKey).apply();
+    Log.d(TAG, "promoted: " + cacheKey);
+    return true;
+  }
+
+  /** 查询是否已 promoted。供 PlaybackManager / 设置面板统计使用。 */
+  public boolean isPromoted(@NonNull String cacheKey) {
+    return !cacheKey.isEmpty() && promotedPrefs.contains(cacheKey);
+  }
+
+  /** 取消单个 key 的 promoted 标记。供 audio LRU 驱逐时同步索引使用。 */
+  public void unmarkPromoted(@NonNull String cacheKey) {
+    if (cacheKey.isEmpty()) return;
+    promotedPrefs.edit().remove(cacheKey).apply();
+  }
+
+  /** 清空所有 promoted 标记 + prefetch 时间戳；调用方：clearAll audio 缓存时同步索引。 */
+  public void clearAllPromoted() {
+    promotedPrefs.edit().clear().apply();
+    prefs.edit().clear().apply();
+  }
+
+  /** 返回 promoted cacheKey 总数。供设置面板统计。 */
+  public int countPromoted() {
+    return promotedPrefs.getAll().size();
+  }
+
+  /** 返回 prefetch-only cacheKey 总数（未 promoted）。 */
+  public int countPrefetchOnly() {
+    return prefs.getAll().size();
+  }
+
+  /**
+   * 扫描所有条目，删除：
+   *
+   * <ol>
+   *   <li>过期（now - lastAccessAt > TTL_MILLIS）的条目，从 SimpleCache 中清除对应资源
+   *   <li>SimpleCache 中已经不存在该 cacheKey 的"孤儿"索引项
+   * </ol>
+   */
+  public void sweep() {
+    final long now = System.currentTimeMillis();
+    final long expireBefore = now - TTL_MILLIS;
+
+    Map<String, ?> all = prefs.getAll();
+
+    SimpleCache cache;
+    try {
+      cache = AudioCacheProvider.getOrCreate(appContext);
+    } catch (Throwable e) {
+      Log.w(TAG, "sweep: SimpleCache not ready, skip");
+      return;
+    }
+    Set<String> liveKeys = new HashSet<>(cache.getKeys());
+
+    // 1) 扫 prefetch 索引：TTL 过期 / orphan 清除
+    SharedPreferences.Editor editor = prefs.edit();
+    int expired = 0;
+    int orphan = 0;
+    for (Map.Entry<String, ?> entry : all.entrySet()) {
+      String cacheKey = entry.getKey();
+      Object v = entry.getValue();
+      if (!(v instanceof Long)) {
+        editor.remove(cacheKey);
+        continue;
+      }
+      long ts = (Long) v;
+
+      // 防御：若 cacheKey 已 promoted，不应出现在 prefetch 索引里（除非 markAccess 发生在 promote 之前且有并发）
+      if (promotedPrefs.contains(cacheKey)) {
+        editor.remove(cacheKey);
+        continue;
+      }
+
+      if (!liveKeys.contains(cacheKey)) {
+        editor.remove(cacheKey);
+        orphan++;
+        continue;
+      }
+
+      if (ts < expireBefore) {
+        // TOCTOU 二次校验：sweep 进入 if 后、调 removeResource 前，
+        // 另一线程的 promote() 可能刚把这个 key 升为正式缓存。
+        // 若已 promoted 则跳过物理删，避免误删用户刚听过 >10s 的音频字节。
+        if (promotedPrefs.contains(cacheKey)) {
+          editor.remove(cacheKey);
+          continue;
+        }
+        try {
+          cache.removeResource(cacheKey);
+        } catch (Throwable e) {
+          Log.w(TAG, "sweep: removeResource failed: " + cacheKey, e);
+        }
+        editor.remove(cacheKey);
+        expired++;
+      }
+    }
+    editor.apply();
+
+    // 2) 扫 promoted 集合：清除 SimpleCache 已不存在的孤儿条目（被全局 LRU 配额删过）
+    Map<String, ?> promotedAll = promotedPrefs.getAll();
+    SharedPreferences.Editor pEditor = promotedPrefs.edit();
+    int promotedOrphan = 0;
+    for (String cacheKey : promotedAll.keySet()) {
+      if (!liveKeys.contains(cacheKey)) {
+        pEditor.remove(cacheKey);
+        promotedOrphan++;
+      }
+    }
+    pEditor.apply();
+
+    if (expired > 0 || orphan > 0 || promotedOrphan > 0) {
+      Log.d(
+          TAG,
+          "sweep done: expired=" + expired + ", orphan=" + orphan + ", promotedOrphan=" + promotedOrphan);
+    }
+  }
+
+  /** 启动周期清理（应用启动时调一次）；幂等，重复调不会重复 schedule。 */
+  public void startPeriodicSweep() {
+    sweepHandler.removeCallbacks(sweepRunnable);
+    // 延后 5s 跑首次 sweep，避免与启动期 IO 抢资源
+    sweepHandler.postDelayed(sweepRunnable, 5_000L);
+  }
+
+  /** 停止周期清理（仅测试 / 应用关闭使用）。 */
+  public void stopPeriodicSweep() {
+    sweepHandler.removeCallbacks(sweepRunnable);
+  }
+}

--- a/android/app/src/main/java/top/imsyy/splayer/android/cache/CacheStorage.java
+++ b/android/app/src/main/java/top/imsyy/splayer/android/cache/CacheStorage.java
@@ -1,0 +1,633 @@
+package top.imsyy.splayer.android.cache;
+
+import android.content.Context;
+import android.os.StatFs;
+import android.util.Log;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * 统一缓存存储：cacheDir 下分类型子目录，全局 LRU（按 mtime），严格遵从 maxBytes。
+ *
+ * <p>设计要点：
+ *
+ * <ul>
+ *   <li>落盘到 {@link Context#getCacheDir()}，App 卸载随系统清理；ROM 「应用缓存」识别。
+ *   <li>所有文件统一 {@code .bin} 扩展名，避开 MediaStore 扫描。
+ *   <li>{@code .nomedia} 兜底。
+ *   <li>读命中时刷新 mtime，确保「最近播放」不被误删。
+ *   <li>写后概率性触发驱逐（10%），全局节流。手动调用 {@link #enforceLimit()} 立即执行。
+ *   <li>maxBytes 由用户在 setting 设置严格生效；运行期不擅自下调。
+ * </ul>
+ */
+public final class CacheStorage {
+
+  private static final String TAG = "CacheStorage";
+  /** 默认 5GB；setting 端调用 setMaxBytes 之前的兜底值。 */
+  private static final long DEFAULT_MAX_BYTES = 5L * 1024 * 1024 * 1024;
+  /** 最低 256MB：低于此值频繁驱逐反而损伤体验。 */
+  private static final long MIN_MAX_BYTES = 256L * 1024 * 1024;
+  /** 驱逐回到 80% 水位（避免抖动反复触发）。 */
+  private static final double EVICT_TARGET_RATIO = 0.8;
+  /** 写入后随机触发驱逐检查的概率，节流 stat 调用。 */
+  private static final double EVICT_PROBE_PROB = 0.1;
+  /** 文件扩展名：所有缓存文件统一 .bin 防 MediaStore 扫描。 */
+  public static final String CACHE_EXT = ".bin";
+
+  /** 已知缓存类型子目录名。新增类型在此扩展。ExoPlayer 的 exo/ 子目录由音频侧管理但参与全局 LRU。 */
+  public static final String TYPE_LYRICS = "lyrics";
+
+  public static final String TYPE_COVERS = "covers";
+  public static final String TYPE_LIST_COVERS = "list-covers";
+  public static final String TYPE_LIST_DATA = "list-data";
+  public static final String TYPE_AUDIO = "exo"; // ExoPlayer SimpleCache 子目录
+
+  private static final String[] ALL_TYPES = {
+    TYPE_LYRICS, TYPE_COVERS, TYPE_LIST_COVERS, TYPE_LIST_DATA, TYPE_AUDIO
+  };
+
+  @SuppressWarnings("StaticFieldLeak")
+  private static volatile CacheStorage instance;
+
+  private final Context appContext;
+  private final File rootDir;
+  private final ExecutorService writeExecutor = Executors.newSingleThreadExecutor();
+  private final AtomicLong maxBytes = new AtomicLong(DEFAULT_MAX_BYTES);
+
+  /** 上次「驱逐至失败」日志时间戳，避免日志洪水。 */
+  private volatile long lastEvictWarnAtMs = 0L;
+
+  /**
+   * 内存索引：type → 当前总字节。读 O(1) 替代扫盘。<br>
+   * 维护策略：
+   * <ul>
+   *   <li>构造期一次性 baseline 扫描所有 type 子目录
+   *   <li>{@link #write} 成功后增量加（若文件已存在则先减旧 size）
+   *   <li>{@link #remove} / {@link #clear} 同步减或归零
+   *   <li>{@link #enforceLimit} 删文件时同步减
+   *   <li>{@code audio} 类型不进此 map（由 ExoPlayer SimpleCache.getCacheSpace 直接返）
+   *   <li>启动后每 30min reconcile 一次：和实际扫描值对账，漂移 > 5% 则纠正
+   * </ul>
+   */
+  private final ConcurrentHashMap<String, AtomicLong> perTypeBytes = new ConcurrentHashMap<>();
+
+  /** 上次 reconcile 时间戳，防止短时间重复扫盘。 */
+  private volatile long lastReconcileAtMs = 0L;
+
+  /** reconcile 节流间隔：30 分钟。 */
+  private static final long RECONCILE_INTERVAL_MS = 30L * 60L * 1000L;
+
+  /** mtime 节流间隔：1 小时；read 命中时若 mtime 已 < 1h 前则不再 setLastModified。 */
+  private static final long MTIME_THROTTLE_MS = 60L * 60L * 1000L;
+
+  /**
+   * 单次 read 返回给 JS 的上限：8MB。封面/歌词<2MB，list-data 歌单<5MB，8MB 足够且避免低端机 OOM。<br>
+   * 超过该大小一定是异常（调用方错误使用 /烒文件写入），提前 reject。
+   */
+  private static final long MAX_READ_BYTES = 8L * 1024 * 1024;
+
+  /**
+   * 设备剩余空间不足时的自适应上限比例：缓存总占用不能超过剩余空间 × 60%。<br>
+   * 例：设备剩 8GB → 有效封顶 4.8GB；设备剩 4GB → 有效封顶 2.4GB。<br>
+   * 仅在该限制低于用户设定值时生效；高于用户设定仍以用户设定为准。
+   */
+  private static final double ADAPTIVE_FREE_RATIO = 0.6;
+
+  private CacheStorage(@NonNull Context context) {
+    this.appContext = context.getApplicationContext();
+    this.rootDir = appContext.getCacheDir();
+    if (!rootDir.exists()) {
+      // noinspection ResultOfMethodCallIgnored
+      rootDir.mkdirs();
+    }
+    ensureNoMediaSentinel();
+    for (String type : ALL_TYPES) {
+      ensureTypeDir(type);
+      // 非 audio 类型预创建索引项（audio 走 SimpleCache.getCacheSpace 不入索引）
+      if (!TYPE_AUDIO.equals(type)) {
+        perTypeBytes.put(type, new AtomicLong(0L));
+      }
+    }
+    // 构造期 baseline scan：后台线程跑，不阻塞首屏
+    writeExecutor.submit(this::reconcileAllNow);
+  }
+
+  public static CacheStorage getInstance(@NonNull Context context) {
+    if (instance == null) {
+      synchronized (CacheStorage.class) {
+        if (instance == null) {
+          instance = new CacheStorage(context);
+        }
+      }
+    }
+    return instance;
+  }
+
+  /** 设置缓存上限（字节），最小 256MB；低于则按 256MB 处理。 */
+  public void setMaxBytes(long bytes) {
+    long clamped = Math.max(MIN_MAX_BYTES, bytes);
+    long old = maxBytes.getAndSet(clamped);
+    if (old != clamped) {
+      // 上限调小时立即异步驱逐
+      writeExecutor.submit(this::enforceLimit);
+    }
+  }
+
+  /** 返回用户设定的原始上限（设置面板展示用）；不含设备容量自适应调控。 */
+  public long getMaxBytes() {
+    return maxBytes.get();
+  }
+
+  /**
+   * 返回运行期生效的上限。计算逻辑：
+   *
+   * <ol>
+   *   <li>读用户设定值 {@code maxBytes}（同 {@link #getMaxBytes}）
+   *   <li>读设备剩余可用空间 {@code free}；StatFs 失败 (-1) 时跳过自适应
+   *   <li>取 {@code min(maxBytes, free * 0.6)}，再与 {@link #MIN_MAX_BYTES} 取 max
+   * </ol>
+   *
+   * <p>例：用户设 5GB、设备剩 8GB → effective = min(5GB, 4.8GB) = 4.8GB；<br>
+   * 用户设 5GB、设备剩 20GB → effective = min(5GB, 12GB) = 5GB（用户设为准）。
+   */
+  public long getEffectiveMaxBytes() {
+    long userMax = maxBytes.get();
+    long free = getDeviceFreeBytes();
+    if (free < 0) return userMax; // 读不出剩余空间，退化为用户设定
+    long adaptive = (long) (free * ADAPTIVE_FREE_RATIO);
+    long effective = Math.min(userMax, adaptive);
+    return Math.max(MIN_MAX_BYTES, effective);
+  }
+
+  /** 当前剩余可用磁盘空间（用于 UI 校验，不参与运行期 cap 计算）。 */
+  public long getDeviceFreeBytes() {
+    try {
+      StatFs stat = new StatFs(rootDir.getAbsolutePath());
+      return stat.getAvailableBytes();
+    } catch (Exception e) {
+      return -1L;
+    }
+  }
+
+  /** 获取总占用（O(1)：累加内存索引 + audio SimpleCache 占用）。 */
+  public long getTotalBytes() {
+    long total = 0L;
+    for (String type : ALL_TYPES) {
+      total += getTypeBytes(type);
+    }
+    return total;
+  }
+
+  /** 单类型占用 O(1)：非 audio 类型读内存索引；audio 走 SimpleCache.getCacheSpace。 */
+  public long getTypeBytes(@NonNull String type) {
+    if (TYPE_AUDIO.equals(type)) {
+      return getAudioCacheSpace();
+    }
+    AtomicLong v = perTypeBytes.get(type);
+    return v == null ? 0L : v.get();
+  }
+
+  /** 全部类型分项占用 O(1)。 */
+  public Map<String, Long> getPerTypeBytes() {
+    Map<String, Long> map = new HashMap<>();
+    for (String type : ALL_TYPES) {
+      map.put(type, getTypeBytes(type));
+    }
+    return map;
+  }
+
+  /**
+   * 读 ExoPlayer SimpleCache 当前占用 —— 它内部已维护索引，O(1) 无扫盘。<br>
+   * SimpleCache 尚未初始化（应用启动早期）则回退到一次性扫盘。
+   */
+  private long getAudioCacheSpace() {
+    try {
+      androidx.media3.datasource.cache.SimpleCache cache =
+          AudioCacheProvider.peekSimpleCache();
+      if (cache != null) return cache.getCacheSpace();
+    } catch (Throwable e) {
+      // SimpleCache 不可用时静默回退
+    }
+    return dirSize(typeDir(TYPE_AUDIO));
+  }
+
+  /** 读取（命中后节流刷新 mtime 让 LRU 视作最近使用）。 */
+  @Nullable
+  public byte[] read(@NonNull String type, @NonNull String key) {
+    if (TYPE_AUDIO.equals(type)) {
+      // audio 由 ExoPlayer SimpleCache 内部读取；JS 侧不应走 read('exo', …)。
+      Log.w(TAG, "read('exo', " + key + ") rejected: audio cache is managed by SimpleCache");
+      return null;
+    }
+    File f = fileFor(type, key);
+    if (!f.isFile()) return null;
+    long fileLen = f.length();
+    if (fileLen > MAX_READ_BYTES) {
+      Log.w(TAG, "read rejected: " + type + "/" + key + " size=" + fileLen + " > " + MAX_READ_BYTES);
+      return null;
+    }
+    long oldMtime = f.lastModified();
+    try (FileInputStream fis = new FileInputStream(f);
+        ByteArrayOutputStream bos =
+            new ByteArrayOutputStream(Math.max(1024, (int) Math.min(fileLen, MAX_READ_BYTES)))) {
+      byte[] buf = new byte[8192];
+      int n;
+      while ((n = fis.read(buf)) != -1) bos.write(buf, 0, n);
+      byte[] data = bos.toByteArray();
+      // mtime 节流：仅在距上次更新已超 1 小时才 setLastModified，避免高频读触发 metadata 写
+      long now = System.currentTimeMillis();
+      if (now - oldMtime > MTIME_THROTTLE_MS) {
+        // noinspection ResultOfMethodCallIgnored
+        f.setLastModified(now);
+      }
+      return data;
+    } catch (IOException e) {
+      Log.w(TAG, "read failed: " + type + "/" + key, e);
+      return null;
+    }
+  }
+
+  /** 写入（同步路径；调用方需自行决定是否在异步线程执行）。写到 .tmp 后 rename，保证原子性。 */
+  public boolean write(@NonNull String type, @NonNull String key, @NonNull byte[] data) {
+    if (TYPE_AUDIO.equals(type)) {
+      // 避免使用者在 audio/exo 目录写入普通 .bin；会被 SimpleCache 忽略并永不被 LRU 驱逐。
+      Log.w(TAG, "write('exo', " + key + ") rejected: audio cache is managed by SimpleCache");
+      return false;
+    }
+    File f = fileFor(type, key);
+    File parent = f.getParentFile();
+    if (parent != null && !parent.exists()) {
+      // noinspection ResultOfMethodCallIgnored
+      parent.mkdirs();
+    }
+    // 若文件已存在，先记录旧 size 用于索引差分
+    long oldSize = f.isFile() ? f.length() : 0L;
+    // 原子写：写临时文件 → rename 覆盖；进程被杀 / OOM 不会产生半截断缓存。
+    // tmp 名带 UUID 防并发写同一 key 时互改 .tmp。Capacitor 插件多线程调用 + 内部 writeAsync 可能同时出现。
+    File tmp = new File(f.getParentFile(), f.getName() + "." + UUID.randomUUID() + ".tmp");
+    try (FileOutputStream fos = new FileOutputStream(tmp)) {
+      fos.write(data);
+      fos.getFD().sync();
+    } catch (IOException e) {
+      // noinspection ResultOfMethodCallIgnored
+      tmp.delete();
+      long now = System.currentTimeMillis();
+      if (now - lastEvictWarnAtMs > 60_000L) {
+        Log.w(TAG, "write failed (磁盘不足或 IO 异常): " + type + "/" + key, e);
+        lastEvictWarnAtMs = now;
+      }
+      return false;
+    }
+    // rename 原子覆盖；Windows 上 rename 覆盖已存在文件会失败，先 delete（Android 实际是 POSIX 语义可直接覆盖，但保险起见）。
+    if (f.exists() && !f.delete()) {
+      Log.w(TAG, "write rename: 预删旧文件失败 " + type + "/" + key);
+    }
+    if (!tmp.renameTo(f)) {
+      // noinspection ResultOfMethodCallIgnored
+      tmp.delete();
+      Log.w(TAG, "write rename failed: " + type + "/" + key);
+      return false;
+    }
+    // 内存索引增量维护：新 size - 旧 size
+    addBytes(type, data.length - oldSize);
+    // 节流触发驱逐：内存索引 O(1)，可以提高检查频率（仍走异步线程）
+    if (Math.random() < EVICT_PROBE_PROB) {
+      writeExecutor.submit(this::enforceLimit);
+    }
+    // 周期 reconcile：30min 跑一次，纠正外部修改 / 索引漂移
+    maybeReconcile();
+    return true;
+  }
+
+  /** 异步写入。 */
+  public void writeAsync(@NonNull String type, @NonNull String key, @NonNull byte[] data) {
+    writeExecutor.submit(() -> write(type, key, data));
+  }
+
+  /** 删除单文件。 */
+  public boolean remove(@NonNull String type, @NonNull String key) {
+    if (TYPE_AUDIO.equals(type)) {
+      Log.w(TAG, "remove('exo', " + key + ") rejected: audio cache is managed by SimpleCache");
+      return false;
+    }
+    File f = fileFor(type, key);
+    if (!f.isFile()) return false;
+    long size = f.length();
+    boolean ok = f.delete();
+    if (ok) addBytes(type, -size);
+    return ok;
+  }
+
+  /** 列出某类型下所有缓存文件（递归）。 */
+  @NonNull
+  public List<CacheEntry> list(@NonNull String type) {
+    List<CacheEntry> out = new ArrayList<>();
+    collectFiles(typeDir(type), type, out);
+    return out;
+  }
+
+  /**
+   * 清空单类型。
+   *
+   * <p>{@code exo}（音频）走 SimpleCache.removeResource：不能直接 deleteRecursive，
+   * 否则活跃 SimpleCache 实例仍报握内部 ContentIndex，后续写入或 sweep 会招致索引/磁盘不一致。
+   */
+  public boolean clear(@NonNull String type) {
+    if (TYPE_AUDIO.equals(type)) {
+      AudioCacheProvider.clearAll(appContext);
+      return true;
+    }
+    File dir = typeDir(type);
+    boolean ok = deleteRecursive(dir);
+    ensureTypeDir(type); // 重建空目录
+    AtomicLong v = perTypeBytes.get(type);
+    if (v != null) v.set(0L);
+    return ok;
+  }
+
+  /** 清空所有类型。 */
+  public boolean clearAll() {
+    boolean allOk = true;
+    for (String type : ALL_TYPES) {
+      allOk = clear(type) && allOk;
+    }
+    ensureNoMediaSentinel();
+    // 全清后索引归零（clear 已分别 set 0，这里 paranoia 二次确认）
+    for (AtomicLong v : perTypeBytes.values()) {
+      v.set(0L);
+    }
+    return allOk;
+  }
+
+  /**
+   * 全局 LRU 驱逐：扫描所有类型，按 mtime 升序删除直到回到 maxBytes * 80%。
+   *
+   * <p>同步执行；调用方按需放到 {@link #writeExecutor}。
+   * <p>驱逐时同步更新内存索引；audio 类型由 ExoPlayer 自管，这里不扫 exo/ 目录。
+   */
+  public synchronized void enforceLimit() {
+    // 走有效上限：设备空间不足时会从 DEFAULT_MAX_BYTES 自适应降到 free * 60%。
+    long limit = getEffectiveMaxBytes();
+    // 快照 audio size：避免二轮计算 nonAudio 时与首轮 total 不一致。
+    long audioSnapshot = getTypeBytes(TYPE_AUDIO);
+    long nonAudioSnapshot = 0L;
+    for (String t : ALL_TYPES) {
+      if (TYPE_AUDIO.equals(t)) continue;
+      nonAudioSnapshot += getTypeBytes(t);
+    }
+    long total = audioSnapshot + nonAudioSnapshot;
+    if (total <= limit) return;
+
+    long target = (long) (limit * EVICT_TARGET_RATIO);
+
+    List<CacheEntry> all = new ArrayList<>();
+    for (String type : ALL_TYPES) {
+      // 这一轮仅收集非 audio：audio 不能走 file-level deleteRecursive（会破坏 SimpleCache 索引），
+      // 后面如果还超配额统一交给 AudioCacheProvider.enforceLimitTo 走 SimpleCache.removeResource 路径。
+      if (TYPE_AUDIO.equals(type)) continue;
+      collectFiles(typeDir(type), type, all);
+    }
+    // 按 mtime 升序：最旧的先删
+    all.sort(Comparator.comparingLong(e -> e.mtime));
+
+    long deleted = 0L;
+    for (CacheEntry e : all) {
+      if (total - deleted <= target) break;
+      File f = new File(e.absolutePath);
+      long size = e.size;
+      if (f.delete()) {
+        deleted += size;
+        addBytes(e.type, -size);
+      }
+    }
+    long nonAudioAfter = nonAudioSnapshot - deleted;
+    // 二轮：非 audio 全删完仍超额 → 压缩 audio。计算使用快照的 audio size 避免中途变化调控偏差。
+    if (nonAudioAfter + audioSnapshot > limit) {
+      long audioBudget = Math.max(0L, limit - nonAudioAfter);
+      AudioCacheProvider.enforceLimitTo(appContext, audioBudget);
+    }
+    Log.i(
+        TAG,
+        "enforceLimit: 非 audio 已驱逐 " + deleted + " 字节，总计回到 " + getTotalBytes() + "/" + limit);
+  }
+
+  /** 计算给定 url 的缓存 key（md5 hex）。封面 / list-data 等有 url 的场景使用。 */
+  @NonNull
+  public static String keyFromUrl(@NonNull String url) {
+    try {
+      MessageDigest md = MessageDigest.getInstance("MD5");
+      byte[] digest = md.digest(url.getBytes("UTF-8"));
+      StringBuilder sb = new StringBuilder(digest.length * 2);
+      for (byte b : digest) {
+        String hex = Integer.toHexString(b & 0xFF);
+        if (hex.length() == 1) sb.append('0');
+        sb.append(hex);
+      }
+      return sb.toString();
+    } catch (Exception e) {
+      // 兜底：直接 hashCode（碰撞概率高，但不致命）
+      return Integer.toHexString(url.hashCode());
+    }
+  }
+
+  /** ExoPlayer SimpleCache 路径：cacheDir/exo/。供 PlaybackManager 构造 SimpleCache 用。 */
+  @NonNull
+  public File getAudioCacheDir() {
+    return ensureTypeDir(TYPE_AUDIO);
+  }
+
+  // ==================== 内部 ====================
+
+  /** 缓存项元数据。 */
+  public static final class CacheEntry {
+    public final String type;
+    public final String key;
+    public final long size;
+    public final long mtime;
+    public final String absolutePath;
+
+    public CacheEntry(String type, String key, long size, long mtime, String absolutePath) {
+      this.type = type;
+      this.key = key;
+      this.size = size;
+      this.mtime = mtime;
+      this.absolutePath = absolutePath;
+    }
+  }
+
+  /** type 白名单（与 plugin 层 ALLOWED_TYPES 同步），用 Set 加速校验。 */
+  private static final java.util.Set<String> KNOWN_TYPE_SET =
+      new java.util.HashSet<>(java.util.Arrays.asList(ALL_TYPES));
+
+  /**
+   * 解析 type 子目录。
+   *
+   * <ol>
+   *   <li>type 必须在白名单 {@link #ALL_TYPES} 内
+   *   <li>canonical 路径必须以 rootDir 为前缀（防 Windows/Linux 任意符号链接 / 路径穿越）
+   * </ol>
+   *
+   * 不满足任一条件直接抛 IAE：违法调用方应当被立刻发现，不可静默回退。
+   */
+  private File typeDir(@NonNull String type) {
+    if (!KNOWN_TYPE_SET.contains(type)) {
+      throw new IllegalArgumentException("非法 cache type: " + type);
+    }
+    File dir = new File(rootDir, type);
+    try {
+      String dirCanonical = dir.getCanonicalPath();
+      String rootCanonical = rootDir.getCanonicalPath();
+      if (!dirCanonical.equals(rootCanonical)
+          && !dirCanonical.startsWith(rootCanonical + File.separator)) {
+        throw new IllegalArgumentException("type 逃出 cache 根目录: " + type);
+      }
+    } catch (IOException e) {
+      throw new IllegalArgumentException("canonical 解析失败: " + type, e);
+    }
+    return dir;
+  }
+
+  private File ensureTypeDir(@NonNull String type) {
+    File dir = typeDir(type);
+    if (!dir.exists()) {
+      // noinspection ResultOfMethodCallIgnored
+      dir.mkdirs();
+    }
+    return dir;
+  }
+
+  private File fileFor(@NonNull String type, @NonNull String key) {
+    String safeKey = sanitizeKey(key);
+    if (!safeKey.endsWith(CACHE_EXT)) {
+      safeKey = safeKey + CACHE_EXT;
+    }
+    return new File(typeDir(type), safeKey);
+  }
+
+  /** 防路径穿越：去掉 .. 与 / 等。空 key 直接拒绝（sanitize 退化成 ".bin" 隐藏文件，list/sweep 反推会得到空 key，往返不对称）。 */
+  @NonNull
+  private static String sanitizeKey(@NonNull String key) {
+    if (key.isEmpty()) {
+      throw new IllegalArgumentException("cache key must not be empty");
+    }
+    return key.replace("..", "_").replace('/', '_').replace('\\', '_').replace(':', '_');
+  }
+
+  private void ensureNoMediaSentinel() {
+    File flag = new File(rootDir, ".nomedia");
+    if (!flag.exists()) {
+      try {
+        // noinspection ResultOfMethodCallIgnored
+        flag.createNewFile();
+      } catch (IOException ignored) {
+      }
+    }
+  }
+
+  private static long dirSize(@Nullable File dir) {
+    if (dir == null || !dir.isDirectory()) return 0L;
+    long total = 0L;
+    File[] children = dir.listFiles();
+    if (children == null) return 0L;
+    for (File f : children) {
+      if (f.isDirectory()) {
+        total += dirSize(f);
+      } else {
+        total += f.length();
+      }
+    }
+    return total;
+  }
+
+  private static boolean deleteRecursive(@Nullable File f) {
+    if (f == null || !f.exists()) return true;
+    if (f.isDirectory()) {
+      File[] children = f.listFiles();
+      if (children != null) {
+        for (File c : children) deleteRecursive(c);
+      }
+    }
+    return f.delete();
+  }
+
+  /** 递归收集类型目录下所有文件，相对路径作为 key（不带 .bin 扩展）。 */
+  private void collectFiles(@Nullable File dir, @NonNull String type, @NonNull List<CacheEntry> out) {
+    if (dir == null || !dir.isDirectory()) return;
+    File[] children = dir.listFiles();
+    if (children == null) return;
+    for (File f : children) {
+      if (f.isDirectory()) {
+        collectFiles(f, type, out);
+      } else if (f.isFile()) {
+        String name = f.getName();
+        String key = name.endsWith(CACHE_EXT) ? name.substring(0, name.length() - CACHE_EXT.length()) : name;
+        out.add(new CacheEntry(type, key, f.length(), f.lastModified(), f.getAbsolutePath()));
+      }
+    }
+  }
+
+  /** 仅供调试 / 测试：拿全部 type 列表 */
+  @NonNull
+  public static String[] knownTypes() {
+    return Arrays.copyOf(ALL_TYPES, ALL_TYPES.length);
+  }
+
+  // ==================== 内存索引维护 ====================
+
+  /** 给指定 type 的内存索引加减字节数；audio 不进索引。 */
+  private void addBytes(@NonNull String type, long delta) {
+    if (TYPE_AUDIO.equals(type) || delta == 0L) return;
+    AtomicLong v = perTypeBytes.get(type);
+    if (v != null) {
+      long newVal = v.addAndGet(delta);
+      // 兜底：理论不会负，但若外部删 / 索引未跟上则纠正
+      if (newVal < 0L) v.set(0L);
+    }
+  }
+
+  /**
+   * 节流 reconcile：仅在距上次 reconcile 已超 30min 时触发后台全扫，纠正索引漂移。<br>
+   * 漂移来源：外部删文件（系统清缓存）、构造期 baseline 尚未跑完的并发写。
+   */
+  private void maybeReconcile() {
+    long now = System.currentTimeMillis();
+    if (now - lastReconcileAtMs < RECONCILE_INTERVAL_MS) return;
+    lastReconcileAtMs = now;
+    writeExecutor.submit(this::reconcileAllNow);
+  }
+
+  /** 强制 reconcile：扫所有非 audio type 目录，把内存索引校准到真实 size。 */
+  private void reconcileAllNow() {
+    for (String type : ALL_TYPES) {
+      if (TYPE_AUDIO.equals(type)) continue;
+      long real = dirSize(typeDir(type));
+      AtomicLong v = perTypeBytes.get(type);
+      if (v != null) {
+        long old = v.getAndSet(real);
+        long diff = Math.abs(real - old);
+        // 漂移 > 1MB 时记日志，便于排查异常
+        if (diff > 1024 * 1024) {
+          Log.i(TAG, "reconcile " + type + ": " + old + " → " + real + " (diff=" + diff + ")");
+        }
+      }
+    }
+    lastReconcileAtMs = System.currentTimeMillis();
+  }
+}

--- a/android/app/src/main/java/top/imsyy/splayer/android/playback/AndroidNativePlaybackPlugin.java
+++ b/android/app/src/main/java/top/imsyy/splayer/android/playback/AndroidNativePlaybackPlugin.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.function.Supplier;
 import org.json.JSONException;
 import org.json.JSONObject;
+import top.imsyy.splayer.android.cache.AudioCacheProvider;
 
 @CapacitorPlugin(
     name = "AndroidNativePlayback",
@@ -142,7 +143,11 @@ public class AndroidNativePlaybackPlugin extends Plugin {
                   call.getBoolean("hasNextOutsideWindow", false),
                   // windowRefilled：仅 refreshAndroidQueueWindow 路径置 true，
                   // Java 端据此区分本次推送是否为「补窗响应」，避免无关 sync（liked / 桌面歌词等）误触发续播。
-                  call.getBoolean("windowRefilled", false));
+                  call.getBoolean("windowRefilled", false),
+                  // windowResetFromWrap：仅末尾 ALL wrap 路径置 true（修复 #3）。
+                  // true 时 Java 用 current() 续播（windowCurrentIndex 已指向 track 0）；
+                  // false 时仍用 advanceRaw(false)（窗口右滑场景，currentIndex 是刚结束的曲目）。
+                  call.getBoolean("windowResetFromWrap", false));
           call.resolve();
         });
   }
@@ -380,6 +385,25 @@ public class AndroidNativePlaybackPlugin extends Plugin {
   }
 
   // 频谱可视化 Media3 AudioProcessor 内嵌 FFT
+
+  /**
+   * 预下载下一首音频前 512 KB 到 SimpleCache。
+   *
+   * <p>调用方（SongManager.prefetchNextSong）拿到下一首 url 后立即 fire-and-forget。
+   * 切歌后 ExoPlayer setMediaItem 命中缓存，跳过 100-500ms 的 OPEN→网络握手。
+   *
+   * <p>同 cacheKey 的并发请求会被 dedup；切歌时上一首未完成的 prefetch 会被自动取消让带宽。
+   */
+  @PluginMethod
+  public void prefetchAudio(PluginCall call) {
+    String url = call.getString("url", "");
+    if (url == null || url.isEmpty()) {
+      call.resolve();
+      return;
+    }
+    AudioCacheProvider.prefetchUrl(getContext(), url);
+    call.resolve();
+  }
 
   @PluginMethod
   public void enableVisualizer(PluginCall call) {

--- a/android/app/src/main/java/top/imsyy/splayer/android/playback/PlaybackManager.java
+++ b/android/app/src/main/java/top/imsyy/splayer/android/playback/PlaybackManager.java
@@ -20,6 +20,7 @@ import android.os.Looper;
 import android.os.PowerManager;
 import android.util.Log;
 import android.view.KeyEvent;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
@@ -64,6 +65,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import top.imsyy.splayer.android.MainActivity;
 import top.imsyy.splayer.android.R;
+import top.imsyy.splayer.android.cache.AudioCacheProvider;
+import top.imsyy.splayer.android.cache.AudioPrefetchTtlIndex;
 
 @UnstableApi
 public final class PlaybackManager {
@@ -99,16 +102,31 @@ public final class PlaybackManager {
   private Player sessionPlayer;
   private MediaSession mediaSession;
   private PlaybackService service;
+  /** PlaybackService 是否已通过 onCreate→attachService 启动并保持运行；用于 ensureServiceRunning 节流。 */
+  private volatile boolean serviceStarted;
   private AndroidNativePlaybackPlugin plugin;
   private Bitmap coverBitmap;
   /** 封面 JPEG 编码缓存，仅在 coverBitmap 变化时重压。 */
   private byte[] coverArtworkBytes;
   private Typeface notificationIconTypeface;
 
-  private String currentSource = "";
+  /** volatile：promotion runnable 不持 this monitor 就能读到最新值（修复 #7 避免主线程锁竞争 → ANR 抖动） */
+  private volatile String currentSource = "";
   private String apiBaseUrl = "";
   private String cookie = "";
   private String songLevel = "exhigh";
+
+  /**
+   * 当前 promotion 任务 —— load() 时排 10s timer，到期仍是这首歌则把它从 prefetch 升级为
+   * promoted（正式缓存）并启动完整下载（为 automix 做准备）。<br>
+   * 切歌 / stop / cleanup 时通过 {@link #cancelPromotion} 取消。
+   *
+   * <p>volatile：Runnable 末尾在主线程内清 null，而 cancelPromotion 经 synchronized 方法可能从
+   * 其他线程进入读，需跨线程可见性保证。
+   */
+  @Nullable private volatile Runnable pendingPromotionRunnable;
+  /** promotion 触发阈值：用户持续播放 10 秒 → 视为「真的喜欢」。 */
+  private static final long PROMOTE_AFTER_MS = 10_000L;
   /** Java 端 URL 解析器：WebView 冻结时仍可自治取地址。 */
   private final PlaybackUrlResolver urlResolver = new PlaybackUrlResolver();
   private TrackMetadata currentMetadata = new TrackMetadata();
@@ -275,6 +293,7 @@ public final class PlaybackManager {
 
   public synchronized void attachService(PlaybackService playbackService) {
     service = playbackService;
+    serviceStarted = true;
     ensureInitialized();
     updateNotification();
   }
@@ -282,6 +301,7 @@ public final class PlaybackManager {
   public synchronized void detachService(PlaybackService playbackService) {
     if (service == playbackService) {
       service = null;
+      serviceStarted = false;
     }
   }
 
@@ -313,6 +333,29 @@ public final class PlaybackManager {
     remoteMode = false;
     currentSource = url == null ? "" : url;
     currentMetadata.url = currentSource;
+
+    // 取消上一首未到期的 10s promotion timer：用户已切歌，旧任务无意义
+    cancelPromotion();
+
+    // 实际播放：给该 cacheKey 续期 TTL + 排 10s timer 决定是否升级正式缓存
+    if (!currentSource.isEmpty()) {
+      try {
+        android.net.Uri parsed = android.net.Uri.parse(currentSource);
+        String scheme = parsed.getScheme();
+        if (scheme != null && (scheme.equals("http") || scheme.equals("https"))) {
+          final String cacheKey = AudioCacheProvider.resolveCacheKey(parsed);
+          final String sourceSnapshot = currentSource;
+          AudioPrefetchTtlIndex ttlIndex = AudioPrefetchTtlIndex.getInstance(appContext);
+          ttlIndex.markAccess(cacheKey);
+          // 已 promoted 的歌不再排 timer（已是正式缓存，全量下载也已经触发过）
+          if (!ttlIndex.isPromoted(cacheKey)) {
+            schedulePromotion(cacheKey, sourceSnapshot);
+          }
+        }
+      } catch (Throwable e) {
+        // mark 失败不影响播放
+      }
+    }
     clearPendingSeek();
     lastKnownPositionMs = 0L;
     // 失效在路上的 async resolve 回调；清旧 pending 避免补窗误消费
@@ -365,6 +408,52 @@ public final class PlaybackManager {
     return buildState();
   }
 
+  /**
+   * 排定 promotion timer：10s 后若仍是这首歌且 ExoPlayer 处于播放态，
+   * 则把 cacheKey 升级为正式缓存 + 启动完整下载（为 automix 铺路）。
+   *
+   * <p>切歌 / stop / cleanup 时通过 {@link #cancelPromotion} 取消未到期的 timer。
+   */
+  private void schedulePromotion(@NonNull String cacheKey, @NonNull String sourceSnapshot) {
+    cancelPromotion(); // 防御性：理论上 load 已调过，二次保险
+    final String urlSnapshot = sourceSnapshot;
+    final Runnable[] holder = new Runnable[1];
+    Runnable r = () -> {
+      // 主线程执行：currentSource 是 volatile 可直接读；player.isPlaying() / getPlayWhenReady() 必须在 applicationLooper（即主线程）调用。
+      // 修复 #7：不再持 this monitor，避免与 Capacitor 工作线程上的 synchronized load/play/pause 竞争 → 减少 ANR 抖动。
+      // 这里读 currentSource 是「快照对比」语义，跟 load() 写入的最终一致性可接受：若新一首 load 已经写入 currentSource，本 Runnable 会自然短路退出。
+      final String curSource = currentSource;
+      if (!urlSnapshot.equals(curSource)) {
+        if (pendingPromotionRunnable == holder[0]) pendingPromotionRunnable = null;
+        return;
+      }
+      if (!player.isPlaying() && !player.getPlayWhenReady()) {
+        if (pendingPromotionRunnable == holder[0]) pendingPromotionRunnable = null;
+        return;
+      }
+      // compare-and-clear：避免覆盖竞态间已经被 cancel/重排的新 Runnable 引用。
+      // pendingPromotionRunnable 是 volatile，主线程内的写入对其他线程立即可见。
+      if (pendingPromotionRunnable == holder[0]) pendingPromotionRunnable = null;
+      // 不在此处立即写 promoted 标记：若网络中断，automix 可能读到截断文件。
+      // 改由 AudioCacheProvider.prefetchUrlFull 在 CacheWriter 真正写完整后调 promote()。
+      // 本处仅触发下载，AudioCacheProvider 内部 inFlight + isPromoted 短路保证幂等。
+      AudioCacheProvider.prefetchUrlFull(appContext, urlSnapshot);
+      Log.d(TAG, "promotion scheduled (download starts): " + cacheKey);
+    };
+    holder[0] = r;
+    pendingPromotionRunnable = r;
+    mainHandler.postDelayed(r, PROMOTE_AFTER_MS);
+  }
+
+  /** 取消未到期的 promotion timer。幂等。调用方需持 PlaybackManager 锁（load/cleanup 已 synchronized）。 */
+  private void cancelPromotion() {
+    Runnable r = pendingPromotionRunnable;
+    if (r != null) {
+      mainHandler.removeCallbacks(r);
+      pendingPromotionRunnable = null;
+    }
+  }
+
   /** 硬清理：清播放列表 / 登入登出等场景，清空 MediaItem、通知栏、queuedNext 及快路径锁。 */
   public synchronized JSObject cleanup() {
     ensureInitialized();
@@ -373,6 +462,7 @@ public final class PlaybackManager {
     player.stop();
     player.clearMediaItems();
     currentSource = "";
+    cancelPromotion();
     clearPendingSeek();
     lastKnownPositionMs = 0L;
     playbackQueue.replace(null, -1, PlaybackQueue.RepeatMode.OFF, false, false, false);
@@ -451,7 +541,8 @@ public final class PlaybackManager {
       String repeatMode,
       boolean hasPreviousOutsideWindow,
       boolean hasNextOutsideWindow,
-      boolean windowRefilled) {
+      boolean windowRefilled,
+      boolean windowResetFromWrap) {
     liked = likedState;
     currentMetadata.liked = likedState;
     canSkipPrevious = canSkipPreviousState;
@@ -482,7 +573,13 @@ public final class PlaybackManager {
     // 若不门控会导致那些 sync 误触发续播，播错歌或播未完全 resolve 的曲目。
     if (pendingResumeAfterRefill && windowRefilled) {
       pendingResumeAfterRefill = false;
-      PlaybackQueue.Track resume = playbackQueue.advanceRaw(false);
+      // 修复 #3：续播取曲方式按 wrap 与否分流：
+      // - wrap=true（末尾 ALL wrap）：JS 已把 playIndex 重置到 0，windowCurrentIndex 指向 track 0，
+      //   直接 current() 播；advanceRaw 会跳到 track 1，丢掉 track 0。
+      // - wrap=false（窗口右滑）：JS 推送时 windowCurrentIndex 仍指向刚结束的曲目，
+      //   必须 advanceRaw(false) 推进到下一首；用 current() 会重播刚结束的歌。
+      PlaybackQueue.Track resume =
+          windowResetFromWrap ? playbackQueue.current() : playbackQueue.advanceRaw(false);
       if (resume != null) {
         resolveAndPlayAsync(resume, "auto", true, 5);
       }
@@ -730,13 +827,19 @@ public final class PlaybackManager {
           }
         };
 
-    player = new ExoPlayer.Builder(appContext, renderersFactory)
-        .setMediaSourceFactory(
-            new DefaultMediaSourceFactory(
-                appContext,
+    // 远端音频走 SimpleCache：第二次播放同一首歌直接读 cacheDir/exo/，无网络请求；
+    // 本地 file:// / content:// 走默认 DataSource。CacheDataSource 仅对 http(s) 起作用。
+    androidx.media3.datasource.DataSource.Factory cachedFactory =
+        AudioCacheProvider.buildCachedDataSourceFactory(appContext);
+    DefaultMediaSourceFactory mediaSourceFactory =
+        new DefaultMediaSourceFactory(
+                cachedFactory,
                 new DefaultExtractorsFactory()
                     .setConstantBitrateSeekingEnabled(true)
-                    .setConstantBitrateSeekingAlwaysEnabled(true)))
+                    .setConstantBitrateSeekingAlwaysEnabled(true));
+
+    player = new ExoPlayer.Builder(appContext, renderersFactory)
+        .setMediaSourceFactory(mediaSourceFactory)
         .build();
     player.setAudioAttributes(
         new AudioAttributes.Builder()
@@ -905,7 +1008,17 @@ public final class PlaybackManager {
     return null;
   }
 
+  /**
+   * 启动 PlaybackService 前台服务。
+   *
+   * 节流：已 attach（onCreate 已跑过）直接返回，避免每次 load/play/syncRemoteState
+   * 都重复触发 startForegroundService —— 这会让系统 Binder 走一遭、FGS 通知重建，
+   * 在频繁 seek/切歌时表现为通知抖动 + 多次 "Background started FGS" 日志。
+   */
   private void ensureServiceRunning() {
+    if (serviceStarted && service != null) {
+      return;
+    }
     Intent intent = new Intent(appContext, PlaybackService.class);
     ContextCompat.startForegroundService(appContext, intent);
   }
@@ -1085,11 +1198,40 @@ public final class PlaybackManager {
                 }));
   }
 
-  /** 预解析窗口前方 3 首，让 ENDED 时直接 playable；重复 prefetch 由 urlResolver.inFlight 去重 */
+  /**
+   * 预解析窗口前方 3 首，让 ENDED 时直接 playable；同时对已解析的下一首 1-2 个触发音频字节预载，
+   * 锁屏 / WebView 冻结时仍能秒响。
+   *
+   * <ul>
+   *   <li>未 resolved 的 URL：urlResolver.prefetchAsync 后台解析，回调里再触发音频字节预载
+   *   <li>已 resolved 的 URL：直接 AudioCacheProvider.prefetchUrl 让 SimpleCache warm 512KB
+   * </ul>
+   *
+   * <p>所有 prefetch 都是 fire-and-forget；inFlight / cachedBytes 短路保证幂等，多次调用不浪费带宽。
+   */
   private void prefetchUpcomingUrls() {
+    // 1) 已 resolved 的下一首 1-2 个：立刻让 SimpleCache 预载前 512KB
+    //    这里是锁屏后切歌秒响的关键路径——不依赖 JS / WebView 调度。
+    List<String> resolvedUrls = playbackQueue.peekUpcomingResolvedUrls(2);
+    for (String url : resolvedUrls) {
+      AudioCacheProvider.prefetchUrl(appContext, url);
+    }
+
+    // 2) 未 resolved 的 1-3 个：UrlResolver 后台解析 URL，
+    //    解析完成回调里再补一次音频字节预载（确保 ENDED 时新解析出的 URL 也被 warm）
     List<PlaybackQueue.Track> upcoming = playbackQueue.peekUpcomingUnresolved(3);
     for (PlaybackQueue.Track t : upcoming) {
-      urlResolver.prefetchAsync(t, playbackQueue, null);
+      final long songId = t.songId;
+      urlResolver.prefetchAsync(
+          t,
+          playbackQueue,
+          () -> {
+            // onResolved 在 resolver 池线程；URL 已通过 updateTrackUrl 写回 queue，可直接查
+            String resolvedUrl = playbackQueue.findUrlBySongId(songId);
+            if (resolvedUrl != null && !resolvedUrl.isEmpty()) {
+              AudioCacheProvider.prefetchUrl(appContext, resolvedUrl);
+            }
+          });
     }
   }
 

--- a/android/app/src/main/java/top/imsyy/splayer/android/playback/PlaybackQueue.java
+++ b/android/app/src/main/java/top/imsyy/splayer/android/playback/PlaybackQueue.java
@@ -218,6 +218,31 @@ public final class PlaybackQueue {
     return out;
   }
 
+  /**
+   * 取窗口内当前曲目之后 N 首已 resolved 的 URL 列表（!skipSong）。<br>
+   * 供 Java 端音频字节预载用：锁屏 / WebView 冻结时仍能保证下一首切歌秒响。
+   */
+  public synchronized List<String> peekUpcomingResolvedUrls(int count) {
+    List<String> out = new ArrayList<>(count);
+    if (windowTracks.isEmpty() || windowCurrentIndex < 0) return out;
+    for (int i = windowCurrentIndex + 1; i < windowTracks.size() && out.size() < count; i++) {
+      Track t = windowTracks.get(i);
+      if (t.url != null && !t.url.isEmpty() && !t.skipSong) out.add(t.url);
+    }
+    return out;
+  }
+
+  /** 用 songId 在窗口里查找 Track 的当前 URL；找不到 / 未解析返 null。 */
+  @Nullable
+  public synchronized String findUrlBySongId(long songId) {
+    for (Track t : windowTracks) {
+      if (t.songId == songId) {
+        return t.url;
+      }
+    }
+    return null;
+  }
+
   /** 用 songId 在窗口里查找 Track 并就地写回 url（UrlResolver 解析完成回调用）。 */
   public synchronized boolean updateTrackUrl(long songId, @Nullable String url) {
     if (url == null || url.isEmpty()) return false;

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -12,4 +12,6 @@
     <string name="playback_notification_favorite">Favorite</string>
     <string name="playback_notification_desktop_lyric">Desktop lyric</string>
     <string name="playback_notification_collapse">Collapse</string>
+    <string name="attribution_playback">Background music playback</string>
+    <string name="attribution_cache">Local media cache</string>
 </resources>

--- a/android/app/src/main/res/xml/backup_rules.xml
+++ b/android/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  排除以下数据：
+  - cache / external_cache：体积膨胀且语义无需迁移
+  - WebView 内部存储（app_webview）：含登录态 cookie / localStorage / IndexedDB 等敏感数据，
+    跨设备恢复会泄露账号会话（修复 #5 隐私风险）
+  - Capacitor 的 SharedPreferences (CapacitorStorage)：用户偏好可重建，且部分设置含 API 配置
+  其余如音乐设置、播放历史等无敏感字段的 prefs 仍允许备份，方便重装恢复体验。
+-->
+<full-backup-content>
+    <exclude domain="cache" />
+    <exclude domain="external_cache" />
+    <exclude domain="file" path="app_webview/" />
+    <exclude domain="database" path="webview.db" />
+    <exclude domain="database" path="webviewCookiesChromium.db" />
+    <exclude domain="sharedpref" path="CapacitorStorage.xml" />
+</full-backup-content>

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Android 12+ (API 31+) 备份/迁移规则：
+  - cache / external_cache：缓存语义无需迁移
+  - WebView 存储 + Capacitor SharedPreferences：含登录 cookie / 会话信息，
+    跨设备恢复会泄露账号态（修复 #5 隐私风险）
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="cache" />
+        <exclude domain="external_cache" />
+        <exclude domain="file" path="app_webview/" />
+        <exclude domain="database" path="webview.db" />
+        <exclude domain="database" path="webviewCookiesChromium.db" />
+        <exclude domain="sharedpref" path="CapacitorStorage.xml" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="cache" />
+        <exclude domain="external_cache" />
+        <exclude domain="file" path="app_webview/" />
+        <exclude domain="database" path="webview.db" />
+        <exclude domain="database" path="webviewCookiesChromium.db" />
+        <exclude domain="sharedpref" path="CapacitorStorage.xml" />
+    </device-transfer>
+</data-extraction-rules>

--- a/src/components/AMLL/LyricPlayer.vue
+++ b/src/components/AMLL/LyricPlayer.vue
@@ -360,15 +360,50 @@ watchEffect(() => {
 });
 
 // 歌词行数据
+// AMLL setLyricLines 同步构造每词 LyricLineEl + KeyframeEffect Animation：
+// YRC 100-300 行 × 5-15 词 ≈ 2000 DOM 节点，主线程同步 100-500ms。
+// 推到 idle frame：切歌 UI（封面/标题/进度条）先消化完，再幕后建词级动画；
+// 200ms timeout 兜底避免歌词显示推迟过久。
+let pendingSetLyricRic: number | null = null;
+const cancelPendingSetLyric = () => {
+  if (pendingSetLyricRic !== null) {
+    const cic = (window as Window & { cancelIdleCallback?: typeof cancelIdleCallback })
+      .cancelIdleCallback;
+    if (typeof cic === "function") cic(pendingSetLyricRic);
+    else clearTimeout(pendingSetLyricRic);
+    pendingSetLyricRic = null;
+  }
+};
+
 watch(
   [() => props.lyricLines, playerRef],
   ([lines, player]) => {
     if (lines === undefined || !player) return;
-    player.setLyricLines(lines);
-    syncSeekTime(props.currentTime);
+    cancelPendingSetLyric();
+    const apply = () => {
+      pendingSetLyricRic = null;
+      // 异步窗口可能跨过组件销毁，二次校验 player 仍然存在
+      if (!playerRef.value) return;
+      playerRef.value.setLyricLines(lines);
+      syncSeekTime(props.currentTime);
+    };
+    // 空数组（切歌瞬间清空）走同步：不会卡且能立即让 LoadingSpinner 显出
+    if (lines.length === 0) {
+      apply();
+      return;
+    }
+    const ric = (window as Window & { requestIdleCallback?: typeof requestIdleCallback })
+      .requestIdleCallback;
+    if (typeof ric === "function") {
+      pendingSetLyricRic = ric(apply, { timeout: 200 });
+    } else {
+      pendingSetLyricRic = window.setTimeout(apply, 0);
+    }
   },
   { immediate: true },
 );
+
+onBeforeUnmount(cancelPendingSetLyric);
 
 // 当前播放时间
 watch(

--- a/src/components/Card/SongCard.vue
+++ b/src/components/Card/SongCard.vue
@@ -24,6 +24,7 @@
           v-if="!hiddenCover"
           :key="song.cover"
           :src="song.path ? song.cover : song.coverSize?.s || song.cover"
+          cache-type="covers"
           class="cover"
         />
         <!-- 信息 -->

--- a/src/components/List/ArtistList.vue
+++ b/src/components/List/ArtistList.vue
@@ -18,12 +18,14 @@
             <s-image
               :src="item.coverSize?.m || item.cover"
               default-src="/images/artist.jpg?asset"
+              cache-type="list-covers"
               class="cover-img"
             />
-            <!-- 封面背板 -->
+            <!-- 封面背板：与主封面同 source，走 list-covers同步命中 -->
             <s-image
               :src="item.coverSize?.m || item.cover"
               default-src="/images/artist.jpg?asset"
+              cache-type="list-covers"
               class="cover-shadow"
             />
             <!-- 图标 -->

--- a/src/components/List/CoverList.vue
+++ b/src/components/List/CoverList.vue
@@ -19,6 +19,7 @@
               :default-src="
                 type !== 'video' ? '/images/album.jpg?asset' : '/images/video.jpg?asset'
               "
+              cache-type="list-covers"
               class="cover-img"
               once
             />

--- a/src/components/List/ListDetail.vue
+++ b/src/components/List/ListDetail.vue
@@ -5,7 +5,7 @@
       <div v-if="detailData" class="detail">
         <div class="cover" v-if="!settingStore.hiddenCovers.list">
           <n-image
-            :src="detailData.coverSize?.m || detailData.cover"
+            :src="resolvedHeaderCover"
             :previewed-img-props="{ style: { borderRadius: '8px' } }"
             :preview-src="detailData.cover"
             :renderToolbar="renderToolbar"
@@ -19,11 +19,11 @@
               </div>
             </template>
           </n-image>
-          <!-- 封面背板 -->
+          <!-- 封面背板 （与主图同 source，复用同一 blob URL、共享引用计数） -->
           <n-image
             class="cover-shadow"
             preview-disabled
-            :src="detailData.coverSize?.m || detailData.cover"
+            :src="resolvedHeaderCover"
           />
           <!-- 遮罩 -->
           <div v-if="config.showCoverMask" class="cover-mask" />
@@ -238,6 +238,7 @@
 <script setup lang="ts">
 import type { CoverType, SongType } from "@/types/main";
 import type { DropdownOption } from "naive-ui";
+import { useCoverCache } from "@/composables/useCoverCache";
 import { coverLoaded, formatNumber } from "@/utils/helper";
 import { removeBrackets, formatCommentCount } from "@/utils/format";
 import { renderToolbar } from "@/utils/meta";
@@ -288,6 +289,14 @@ const emit = defineEmits<{
 
 const router = useRouter();
 const settingStore = useSettingStore();
+
+// 头部大封面走 list-covers 本地缓存：命中返 blob URL，未命中返原 url 同时后台下载入档。
+// preview-src 仍用原始 url（预览低频次，误差可接受）。
+const headerCoverSrc = computed(
+  () => props.detailData?.coverSize?.m || props.detailData?.cover,
+);
+const cachedHeaderCover = useCoverCache(headerCoverSrc, "list-covers");
+const resolvedHeaderCover = computed(() => cachedHeaderCover.value || headerCoverSrc.value);
 
 // 当前 tab
 const currentTab = ref<"songs" | "comments">("songs");

--- a/src/components/Menu/MobileSongMenu.vue
+++ b/src/components/Menu/MobileSongMenu.vue
@@ -14,7 +14,7 @@
     >
       <template #header>
         <div class="menu-header">
-          <s-image :src="currentSong?.coverSize?.s" class="cover" />
+          <s-image :src="currentSong?.coverSize?.s" cache-type="covers" class="cover" />
           <div class="info">
             <div class="name text-hidden">{{ currentSong?.name }}</div>
             <div class="artist text-hidden">{{ songArtist }}</div>

--- a/src/components/Menu/SongListMenu.vue
+++ b/src/components/Menu/SongListMenu.vue
@@ -92,7 +92,8 @@ const openDropdown = (
                   },
                 ),
               ];
-              if (!props.hiddenCover) list.unshift(h(SImage, { src: song.coverSize?.s }));
+              if (!props.hiddenCover)
+                list.unshift(h(SImage, { src: song.coverSize?.s, cacheType: "covers" }));
               return list;
             },
           },

--- a/src/components/Player/FullPlayerMobile.vue
+++ b/src/components/Player/FullPlayerMobile.vue
@@ -124,7 +124,7 @@ let savedPageIndex = 0;
 
       <div class="page lyric-page">
         <div class="lyric-header">
-          <s-image :src="musicStore.getSongCover('s')" class="lyric-cover" />
+          <s-image :src="musicStore.getSongCover('s')" cache-type="covers" class="lyric-cover" />
           <div class="lyric-info">
             <div class="name text-hidden">
               {{

--- a/src/components/Player/PlayerMeta/PlayerBackground.vue
+++ b/src/components/Player/PlayerMeta/PlayerBackground.vue
@@ -12,6 +12,7 @@
         v-else-if="settingStore.playerBackgroundType === 'blur'"
         :src="musicStore.songCover"
         :observe-visibility="false"
+        cache-type="none"
         class="bg-img"
         alt="cover"
       />

--- a/src/components/Player/PlayerMeta/PlayerCover.vue
+++ b/src/components/Player/PlayerMeta/PlayerCover.vue
@@ -7,6 +7,7 @@
   >
     <s-image
       :src="getCoverUrl('xl')"
+      cache-type="covers"
       :alt="musicStore.playSong.name"
       :title="musicStore.playSong.name"
       :lazy="false"
@@ -30,6 +31,7 @@
     <s-image
       :key="getCoverUrl('l')"
       :src="getCoverUrl('l')"
+      cache-type="covers"
       :observe-visibility="false"
       object-fit="cover"
       class="cover-img"

--- a/src/components/Setting/components/CacheSizeLimit.vue
+++ b/src/components/Setting/components/CacheSizeLimit.vue
@@ -2,74 +2,111 @@
   <n-card class="set-item">
     <div class="label">
       <n-text class="name">{{ item?.label || "缓存大小上限" }}</n-text>
-      <n-text class="tip" :depth="3" v-if="item?.description" v-html="item.description" />
-      <n-text class="tip" :depth="3" v-else>
-        达到上限后将清理最旧的缓存，可以是小数，最低 2GB
+      <n-text class="tip" :depth="3">
+        达到上限后将自动驱逐最久未访问的缓存（优先长期未播放的音频）。下限 256 MB。
+      </n-text>
+      <n-text v-if="deviceFreeDisplay" class="tip" :depth="3">
+        设备剩余：{{ deviceFreeDisplay }}。当前生效上限：{{ effectiveLimitDisplay }}
       </n-text>
     </div>
     <n-input-group class="set">
       <n-input-number
-        :value="cacheLimit"
+        :value="limitGB"
         :update-value-on-input="false"
-        :min="2"
-        :max="9999"
-        :style="{
-          width: cacheLimited ? '55%' : '0%',
-          transition: 'width 0.3s',
-        }"
+        :min="0.25"
+        :step="0.5"
+        :precision="2"
+        style="width: 70%"
         @update:value="onUpdateLimit"
       />
-      <n-select
-        v-model:value="cacheLimited"
-        :options="[
-          { label: '不限制', value: 0 },
-          { label: cacheLimited === 0 ? '自定义大小 (GB)' : 'GB', value: 1 },
-        ]"
-        :style="{
-          width: cacheLimited ? '45%' : '100%',
-          transition: 'width 0.3s',
-        }"
-        @update:value="onUpdateLimited"
-      />
+      <n-select :value="1" :options="[{ label: 'GB', value: 1 }]" disabled style="width: 30%" />
     </n-input-group>
   </n-card>
 </template>
 
 <script setup lang="ts">
 import { SettingItem } from "@/types/settings";
+import { useSettingStore } from "@/stores";
+import { useCacheManager } from "@/core/resource/CacheManager";
+import { formatFileSize } from "@/utils/helper";
 
 defineProps<{ item?: SettingItem }>();
 
-const cacheLimit = ref<number>(10);
-const cacheLimited = ref<number>(1);
+const settingStore = useSettingStore();
+const cacheManager = useCacheManager();
 
-const changeCacheLimit = async (value: number) => {
-  await window.api.store.set("cacheLimit", value);
-};
+// store 存 MB；UI 展示 GB；同步到 Java 端
+const limitGB = computed(() => +(settingStore.maxCacheSizeMB / 1024).toFixed(2));
+const deviceFreeBytes = ref<number>(-1);
+const effectiveMaxBytes = ref<number>(0);
 
-const onUpdateLimit = (value: number | null) => {
-  cacheLimit.value = value ?? 2;
-  changeCacheLimit(cacheLimit.value);
-};
+const deviceFreeDisplay = computed(() =>
+  deviceFreeBytes.value > 0 ? formatFileSize(deviceFreeBytes.value) : "",
+);
+const effectiveLimitDisplay = computed(() =>
+  effectiveMaxBytes.value > 0
+    ? formatFileSize(effectiveMaxBytes.value)
+    : formatFileSize(settingStore.maxCacheSizeMB * 1024 * 1024),
+);
 
-const onUpdateLimited = (value: number) => {
-  if (value === 0) {
-    changeCacheLimit(0);
-  } else {
-    if (cacheLimit.value === 0) cacheLimit.value = 2;
-    changeCacheLimit(cacheLimit.value);
+const refreshStats = async () => {
+  try {
+    const r = await cacheManager.getStats();
+    if (r.success && r.data) {
+      deviceFreeBytes.value = r.data.deviceFreeBytes;
+      // 走 effectiveMaxBytes：设备空间不足时会自动从用户设定降到 free * 60%。
+      effectiveMaxBytes.value = r.data.effectiveMaxBytes;
+    }
+  } catch (e) {
+    console.warn("[CacheSizeLimit] getStats failed:", e);
   }
+};
+
+const applyLimit = async (mb: number) => {
+  settingStore.maxCacheSizeMB = mb;
+  try {
+    await cacheManager.setMaxBytes(Math.round(mb * 1024 * 1024));
+  } catch (e) {
+    console.warn("[CacheSizeLimit] setMaxBytes failed:", e);
+  }
+  await refreshStats();
+};
+
+const onUpdateLimit = async (value: number | null) => {
+  if (value == null) return;
+  // 下限夹紧：256 MB = 0.25 GB
+  const gb = Math.max(0.25, value);
+  const mb = Math.round(gb * 1024);
+  const wantBytes = mb * 1024 * 1024;
+  // 超过设备剩余 90% 时弹二次确认；确认后仍按用户设置严格生效
+  if (deviceFreeBytes.value > 0 && wantBytes > deviceFreeBytes.value * 0.9) {
+    await new Promise<void>((resolve) => {
+      window.$dialog.warning({
+        title: "设置超过剩余存储",
+        content: `当前设备剩余 ${formatFileSize(deviceFreeBytes.value)}，你即将设置上限为 ${formatFileSize(wantBytes)}，可能导致缓存写入失败。仍要继续吗？`,
+        positiveText: "仍然使用该值",
+        negativeText: "取消",
+        onPositiveClick: async () => {
+          await applyLimit(mb);
+          resolve();
+        },
+        onNegativeClick: () => resolve(),
+        onClose: () => resolve(),
+        onMaskClick: () => resolve(),
+      });
+    });
+    return;
+  }
+  await applyLimit(mb);
 };
 
 onMounted(async () => {
+  // 启动同步 store → Java：避免升级后 Java 默认值与用户设置不一致
   try {
-    const limit = await window.api.store.get("cacheLimit");
-    if (typeof limit === "number") {
-      cacheLimit.value = limit;
-      if (limit === 0) cacheLimited.value = 0;
-    }
-  } catch (error) {
-    console.error("读取缓存配置失败:", error);
+    await cacheManager.setMaxBytes(settingStore.maxCacheSizeMB * 1024 * 1024);
+  } catch (e) {
+    console.warn("[CacheSizeLimit] init setMaxBytes failed:", e);
   }
+  await refreshStats();
 });
 </script>

--- a/src/components/Setting/config/local.ts
+++ b/src/components/Setting/config/local.ts
@@ -19,18 +19,37 @@ export const useLocalSettings = (): SettingConfig => {
   const cacheSizeDisplay = ref<string>("--");
   const cachePath = ref<string>("");
 
-  // 统计全部缓存目录占用大小
+  // 各类分项占用（人类可读格式）
+  const lyricsSizeDisplay = ref<string>("--");
+  const coversSizeDisplay = ref<string>("--");
+  const listCoversSizeDisplay = ref<string>("--");
+  const listDataSizeDisplay = ref<string>("--");
+  const musicSizeDisplay = ref<string>("--");
+
+  /**
+   * 拉取总占用与各类分项。Android 端走 Capacitor 插件 stat；Electron 仅取总数。
+   */
   const loadCacheSize = async () => {
-    const res = await cacheManager.getSize();
-    if (res.success && res.data !== undefined) {
-      cacheSizeDisplay.value = formatFileSize(res.data);
+    const res = await cacheManager.getStats();
+    if (res.success && res.data) {
+      cacheSizeDisplay.value = formatFileSize(res.data.totalBytes);
+      const per = res.data.perType;
+      lyricsSizeDisplay.value = formatFileSize(per?.lyrics ?? 0);
+      coversSizeDisplay.value = formatFileSize(per?.covers ?? 0);
+      listCoversSizeDisplay.value = formatFileSize(per?.["list-covers"] ?? 0);
+      listDataSizeDisplay.value = formatFileSize(per?.["list-data"] ?? 0);
+      musicSizeDisplay.value = formatFileSize(per?.music ?? 0);
     } else {
       cacheSizeDisplay.value = "--";
     }
   };
 
-  // 获取缓存目录
+  // 获取缓存目录（Electron 遗留，Android 不使用）
   const loadCachePath = async () => {
+    if (isCapacitorAndroid) {
+      cachePath.value = "";
+      return;
+    }
     try {
       const path = await window.api.store.get("cachePath");
       cachePath.value = path || "";
@@ -45,26 +64,21 @@ export const useLocalSettings = (): SettingConfig => {
     loadCachePath();
   };
 
-  // 更改缓存目录
-  const changeCachePath = async () => {
-    const path = await window.electron.ipcRenderer.invoke("choose-path");
-    if (path) {
-      cachePath.value = path;
-      await window.api.store.set("cachePath", path);
+  /**
+   * 按类型清空：改动面小，避免一键清除所有。
+   */
+  const clearByType = async (
+    types: ("lyrics" | "covers" | "list-covers" | "list-data" | "music")[],
+    label: string,
+  ) => {
+    let allOk = true;
+    for (const t of types) {
+      const r = await cacheManager.clear(t);
+      if (!r.success) allOk = false;
     }
-  };
-
-  // 确认更改缓存目录
-  const confirmChangeCachePath = () => {
-    window.$dialog.warning({
-      title: "更改缓存目录",
-      content: "更改缓存目录不会自动移动已有缓存文件，建议在清空缓存后再更改目录。确定要继续吗？",
-      positiveText: "确定更改",
-      negativeText: "取消",
-      onPositiveClick: () => {
-        return changeCachePath();
-      },
-    });
+    await loadCacheSize();
+    if (allOk) window.$message.success(`${label} 已清空`);
+    else window.$message.error(`${label} 清理失败（部分项未删除）`);
   };
 
   // 清空所有缓存目录
@@ -82,13 +96,26 @@ export const useLocalSettings = (): SettingConfig => {
   const confirmClearCache = () => {
     window.$dialog.warning({
       title: "清空缓存",
-      content: "将删除所有缓存的音乐、歌词和本地数据，此操作不可恢复，确定要继续吗？",
+      content: "将删除所有缓存的音乐、歌词、封面与列表数据，此操作不可恢复，确定要继续吗？",
       positiveText: "清空缓存",
       negativeText: "取消",
       onPositiveClick: () => {
         return clearCache();
       },
     });
+  };
+
+  /** 手动触发一次全局 LRU 驱逐：供设置面板「立即整理」使用。 */
+  const enforceCacheLimit = async () => {
+    const res = await cacheManager.enforceLimit();
+    await loadCacheSize();
+    if (res.success) {
+      window.$message.success(
+        `整理完成，当前总占用 ${formatFileSize(res.data?.totalBytes ?? 0)}`,
+      );
+    } else {
+      window.$message.error(`整理失败: ${res.message || "未知错误"}`);
+    }
   };
 
   // --- 下载逻辑 ---
@@ -199,7 +226,7 @@ export const useLocalSettings = (): SettingConfig => {
       }
       return;
     }
-    const path = await window.electron.ipcRenderer.invoke("choose-path");
+    const path = (await window.electron.ipcRenderer.invoke("choose-path")) as string | undefined;
     if (path) settingStore.downloadPath = path;
   };
 
@@ -287,28 +314,62 @@ export const useLocalSettings = (): SettingConfig => {
             key: "cacheLimit",
             label: "缓存大小上限",
             type: "custom",
-            description: "达到上限后将清理最旧的缓存，可以是小数，最低 2GB",
+            description: "达到上限后将清理最旧的缓存，可以是小数，最低 256 MB",
             component: markRaw(CacheSizeLimit),
             condition: () => settingStore.cacheEnabled,
             noWrapper: true,
           },
           {
-            key: "cachePath",
-            label: "缓存目录",
-            type: "button",
-            description: computed(() => cachePath.value || "未配置时将使用默认缓存目录"),
-            buttonLabel: "更改",
-            action: confirmChangeCachePath,
-            condition: () => settingStore.cacheEnabled,
-          },
-          {
             key: "clearCache",
-            label: "缓存占用与清理",
+            label: "缓存总占用",
             type: "button",
-            description: () => `当前缓存占用：${cacheSizeDisplay.value}`,
-            buttonLabel: "清空缓存",
+            description: () =>
+              `总占用：${cacheSizeDisplay.value}。清空后仅下次访问重新下载，不影响账号与设置。`,
+            buttonLabel: "清空全部",
             action: confirmClearCache,
             componentProps: { type: "error" },
+          },
+          {
+            key: "clearMusicCache",
+            label: "音频缓存",
+            type: "button",
+            description: () => `音频（边播边缓存）：${musicSizeDisplay.value}`,
+            buttonLabel: "清空音频",
+            action: () => clearByType(["music"], "音频缓存"),
+          },
+          {
+            key: "clearLyricsCache",
+            label: "歌词缓存",
+            type: "button",
+            description: () => `歌词：${lyricsSizeDisplay.value}`,
+            buttonLabel: "清空歌词",
+            action: () => clearByType(["lyrics"], "歌词缓存"),
+          },
+          {
+            key: "clearCoversCache",
+            label: "封面缓存",
+            type: "button",
+            description: () =>
+              `歌曲封面：${coversSizeDisplay.value}、列表封面：${listCoversSizeDisplay.value}`,
+            buttonLabel: "清空封面",
+            action: () => clearByType(["covers", "list-covers"], "封面缓存"),
+          },
+          {
+            key: "clearListDataCache",
+            label: "列表数据缓存",
+            type: "button",
+            description: () => `歌单 / 专辑 / 电台等元信息：${listDataSizeDisplay.value}`,
+            buttonLabel: "清空列表数据",
+            action: () => clearByType(["list-data"], "列表数据缓存"),
+          },
+          {
+            key: "enforceCacheLimit",
+            label: "立即整理",
+            type: "button",
+            description:
+              "主动触发一次全局 LRU 驱逐，把占用压缩到上限的 80%。达到上限时本来也会自动触发。",
+            buttonLabel: "整理",
+            action: enforceCacheLimit,
           },
         ],
       },

--- a/src/components/Setting/config/lyric.ts
+++ b/src/components/Setting/config/lyric.ts
@@ -534,7 +534,7 @@ export const useLyricSettings = (): SettingConfig => {
             label: "启用在线 TTML 歌词",
             type: "switch",
             description:
-              "是否从 AMLL TTML DB 获取歌词（如有），TTML 歌词支持逐字、翻译、音译等功能，将会在下一首歌生效",
+              "是否从 AMLL TTML DB 获取歌词（如有），TTML 歌词支持逐字、翻译、音译等功能，将会在下一首歌生效。命中后自动写入歌词缓存，重播无需再请求。",
             tags: [{ text: "Beta", type: "warning" }],
             value: computed({
               get: () => settingStore.enableOnlineTTMLLyric,

--- a/src/components/UI/s-image.vue
+++ b/src/components/UI/s-image.vue
@@ -30,6 +30,8 @@
 </template>
 
 <script setup lang="ts">
+import { useCoverCache } from "@/composables/useCoverCache";
+
 const props = withDefaults(
   defineProps<{
     /** 图片地址 */
@@ -54,6 +56,16 @@ const props = withDefaults(
     crossorigin?: "" | "anonymous" | "use-credentials" | undefined;
     /** 圆角 */
     round?: boolean;
+    /**
+     * 封面缓存类型（仅 Android 生效）
+     * - "covers"：歌曲封面（需要持久化缓存）
+     * - "list-covers"：歌单 / 专辑 / 电台等列表封面
+     * - "none"：默认；禁用本地缓存（直接走原始 url）
+     *
+     * 设计原则：默认 "none" 不污染缓存桶。仅在确实是歌曲封面的调用点显式传 "covers"，
+     * 列表场景显式传 "list-covers"。这样 MV 缩略图 / 头像 / 主题预览等非封面图片不会进缓存目录。
+     */
+    cacheType?: "covers" | "list-covers" | "none";
   }>(),
   {
     defaultSrc: "/images/song.jpg?asset",
@@ -62,8 +74,17 @@ const props = withDefaults(
     decodeAsync: true,
     nativeLazy: true,
     objectFit: "cover",
+    cacheType: "none",
   },
 );
+
+// Android 端命中本地封面缓存返回 blob URL，未命中时后台下载并保存；其他平台直接透传 src。
+// cacheType="none" 时退化为透传，避免大图（背景模糊）走 base64 IPC 浪费 CPU/内存。
+const srcRef = computed(() => props.src);
+const cachedSrc =
+  props.cacheType === "none"
+    ? srcRef
+    : useCoverCache(srcRef, props.cacheType);
 
 const emit = defineEmits<{
   // 加载完成
@@ -122,11 +143,12 @@ watch(
       emit("update:show", show);
     }
     if (show) {
-      // 进入可视区再加载，避免重复赋值
-      if (imgSrc.value !== props.src) {
+      // 进入可视区再加载，避免重复赋值；优先用缓存命中后的 src
+      const target = cachedSrc.value;
+      if (imgSrc.value !== target) {
         loadToken.value += 1;
         currentToken.value = loadToken.value;
-        imgSrc.value = props.src;
+        imgSrc.value = target;
       }
     } else if (props.releaseOnHide) {
       // 释放图片以回收内存
@@ -136,9 +158,9 @@ watch(
   { immediate: true },
 );
 
-// 监听 src 变化
+// 监听 src 变化（含异步缓存命中后的 src 升级）
 watch(
-  () => props.src,
+  () => cachedSrc.value,
   (val) => {
     isLoaded.value = false;
     // 不同值时才进行赋值，减少重绘

--- a/src/composables/List/useListDataCache.ts
+++ b/src/composables/List/useListDataCache.ts
@@ -1,11 +1,14 @@
 import type { CoverType, SongType } from "@/types/main";
 import { useCacheManager } from "@/core/resource/CacheManager";
-import { isElectron } from "@/utils/env";
 
 /**
  * 列表类型
+ *
+ * - playlist / album / radio：网易云资源详情
+ * - streaming-playlist：流媒体歌单，id 为字符串
+ * - home-rec：首页推荐区聚合数据（4 条 API 合一），id 固定 0
  */
-export type ListType = "playlist" | "album" | "radio";
+export type ListType = "playlist" | "album" | "radio" | "streaming-playlist" | "home-rec";
 
 /**
  * 列表缓存数据结构
@@ -15,10 +18,12 @@ export interface ListCacheData {
   version: number;
   /** 缓存时间戳 */
   timestamp: number;
+  /** 缓存是否完整 */
+  complete: boolean;
   /** 列表类型 */
   type: ListType;
-  /** 列表 ID */
-  id: number;
+  /** 列表 ID（数字 或 字符串，后者供 streaming 场景） */
+  id: number | string;
   /** 列表详情 */
   detail: CoverType;
   /** 歌曲列表 */
@@ -26,7 +31,7 @@ export interface ListCacheData {
 }
 
 /** 缓存版本号 */
-const CACHE_VERSION = 2; // Bump version due to logic change
+const CACHE_VERSION = 2; // 因缓存逻辑变更提升版本
 
 /**
  * 列表数据缓存组合式函数
@@ -40,7 +45,7 @@ export const useListDataCache = () => {
    * @param type 列表类型
    * @param id 列表 ID
    */
-  const getCacheKey = (type: ListType, id: number): string => {
+  const getCacheKey = (type: ListType, id: number | string): string => {
     return `${type}-${id}.json`;
   };
 
@@ -53,15 +58,15 @@ export const useListDataCache = () => {
    */
   const saveCache = async (
     type: ListType,
-    id: number,
+    id: number | string,
     detail: CoverType,
     songs: SongType[],
+    complete: boolean = true,
   ): Promise<void> => {
-    if (!isElectron) return;
-
     const cacheData: ListCacheData = {
       version: CACHE_VERSION,
       timestamp: Date.now(),
+      complete,
       type,
       id,
       detail,
@@ -85,9 +90,10 @@ export const useListDataCache = () => {
    * @param id 列表 ID
    * @returns 缓存数据，如果不存在或已过期则返回 null
    */
-  const loadCache = async (type: ListType, id: number): Promise<ListCacheData | null> => {
-    if (!isElectron) return null;
-
+  const loadCache = async (
+    type: ListType,
+    id: number | string,
+  ): Promise<ListCacheData | null> => {
     const key = getCacheKey(type, id);
 
     try {
@@ -107,6 +113,10 @@ export const useListDataCache = () => {
         return null;
       }
 
+      if (typeof cacheData.complete !== "boolean") {
+        cacheData.complete = true;
+      }
+
       console.log(`✅ List cache loaded: ${key}`);
       return cacheData;
     } catch (error) {
@@ -123,6 +133,10 @@ export const useListDataCache = () => {
    * @returns 是否需要更新
    */
   const checkNeedsUpdate = (cached: ListCacheData, latestDetail: CoverType): boolean => {
+    // 修复 #9：partial cache（complete=false）不应触发全量重拉，应由调用方走「续传」路径
+    // （getPlaylistAllSongs 从 cached.songs.length 偏移开始续传）。
+    // 仅当上游 updateTime / count 真发生变化才返回 true。
+
     // 如果有 updateTime，则比较
     if (cached.detail.updateTime && latestDetail.updateTime) {
       const needsUpdate = cached.detail.updateTime !== latestDetail.updateTime;
@@ -156,9 +170,7 @@ export const useListDataCache = () => {
    * @param type 列表类型
    * @param id 列表 ID
    */
-  const removeCache = async (type: ListType, id: number): Promise<void> => {
-    if (!isElectron) return;
-
+  const removeCache = async (type: ListType, id: number | string): Promise<void> => {
     const key = getCacheKey(type, id);
 
     try {
@@ -173,8 +185,6 @@ export const useListDataCache = () => {
    * 清除所有列表缓存
    */
   const clearAllCache = async (): Promise<void> => {
-    if (!isElectron) return;
-
     try {
       await cacheManager.clear("list-data");
       console.log(`🗑️ All list cache cleared`);

--- a/src/composables/List/useListDetail.ts
+++ b/src/composables/List/useListDetail.ts
@@ -1,6 +1,7 @@
 import type { CoverType, SongType } from "@/types/main";
 import { useStatusStore } from "@/stores";
 import { useDevice } from "@/composables/useDevice";
+import { prefetchListCovers } from "@/composables/useCoverCache";
 
 export const useListDetail = () => {
   const statusStore = useStatusStore();
@@ -9,6 +10,9 @@ export const useListDetail = () => {
   const detailData = ref<CoverType | null>(null);
   const listData = shallowRef<SongType[]>([]);
   const loading = ref<boolean>(true);
+
+  /** 进入详情页 / 缓存命中时预热前 N 首歌曲封面，避免滚动时逐张走 IPC 抖动。 */
+  const PREFETCH_SONG_COVER_LIMIT = 20;
 
   const getSongListHeight = (listScrolling: boolean) => {
     if (isPhone.value) {
@@ -34,10 +38,20 @@ export const useListDetail = () => {
 
   const setListData = (data: SongType[]) => {
     listData.value = data;
+    // 仅对首批 N 首做 prefetch；后续 append/replace 重复触发由 inFlight 去重，但首屏只关心前 20。
+    if (data.length > 0) {
+      prefetchListCovers(data, "covers", PREFETCH_SONG_COVER_LIMIT, "s");
+    }
   };
 
   const appendListData = (data: SongType[]) => {
+    const before = listData.value.length;
     listData.value = [...listData.value, ...data];
+    // 仅当首批未填满预热配额时才补窗（继续滚动加载是用户行为驱动，不必激进预热）
+    if (before < PREFETCH_SONG_COVER_LIMIT && data.length > 0) {
+      const remain = PREFETCH_SONG_COVER_LIMIT - before;
+      prefetchListCovers(data.slice(0, remain), "covers", remain, "s");
+    }
   };
 
   const setLoading = (value: boolean) => {

--- a/src/composables/useCoverCache.ts
+++ b/src/composables/useCoverCache.ts
@@ -1,0 +1,342 @@
+import { ref, watch, onBeforeUnmount, type Ref } from "vue";
+import { useCacheManager, type CacheResourceType } from "@/core/resource/CacheManager";
+import { isCapacitorAndroid } from "@/utils/env";
+import { useSettingStore } from "@/stores";
+
+/** 封面缓存 type；其他类型不进入此 helper。 */
+export type CoverCacheType = Extract<CacheResourceType, "covers" | "list-covers">;
+
+/** url → 仅 ASCII 的安全 key（取末段路径，附加 hash 防同名冲突）。 */
+const buildKey = (url: string): string => {
+  // 简单 hash：dj2b 算法，碰撞概率极低且 deterministic
+  let h = 5381;
+  for (let i = 0; i < url.length; i++) h = ((h << 5) + h + url.charCodeAt(i)) | 0;
+  const hashHex = (h >>> 0).toString(16);
+  // path tail 提供可读性（调试时方便看出是哪首歌的封面）
+  let tail = "";
+  try {
+    const u = new URL(url);
+    const seg = u.pathname.split("/").filter(Boolean).pop() || "";
+    tail = seg.replace(/[^A-Za-z0-9._-]/g, "_").slice(-32);
+  } catch {
+    /* not a valid URL: 走 hash 兜底 */
+  }
+  return tail ? `${tail}_${hashHex}` : hashHex;
+};
+
+/**
+ * 内存级 blob URL LRU：上限 200 张；超出时尝试弹出最旧条目并 revokeObjectURL。
+ *
+ * <p>引入引用计数：useCoverCache 组件挂载时 retain，卸载时 release；refCount > 0 的条目
+ * **不会被 LRU 立即 revoke**，而是标记成 pending revoke，等最后一个使用者 release 时再清。
+ * 这样可以解决「LRU 顶掉的 blob 仍被某个活动 <img> 引用导致破图」的问题。
+ *
+ * <p>refCount=0 且未被引用的条目正常按 LRU 淘汰；超限但仍被引用的条目暂留，count 释放时再清。
+ */
+const MEMORY_HIT_LIMIT = 200;
+type CoverEntry = { blobUrl: string; refCount: number; pendingRevoke: boolean };
+const memoryHit = new Map<string, CoverEntry>(); // url → entry，LRU（Map 保留插入顺序）
+
+/**
+ * 入档新条目。<br>
+ * <b>关键修复 #2</b>：新条目以 refCount=1 入档（pre-retain），
+ * 调用方在用完 blobUrl 后必须配对调一次 memoryHitRelease 释放。<br>
+ * 旧实现 refCount=0 入档，从 resolveCachedCover 返回到 useCoverCache 的 watch 处理器
+ * 调 memoryHitRetain 之间存在异步窗口（await microtask），期间若并发触发 memoryHitPut
+ * 把上限顶爆，本条目（refCount=0）就是第一个被 LRU 选中 revoke 的候选，
+ * 等调用方拿到 blobUrl 时已是失效 URL，浏览器渲染为破图。
+ */
+const memoryHitPut = (url: string, blobUrl: string): void => {
+  if (memoryHit.has(url)) memoryHit.delete(url);
+  memoryHit.set(url, { blobUrl, refCount: 1, pendingRevoke: false });
+  // 超限淘汰：跳过仍被引用的条目（含本次新条目），给它们打上 pendingRevoke 标记延迟到 release 时清
+  while (memoryHit.size > MEMORY_HIT_LIMIT) {
+    let evicted = false;
+    for (const [k, v] of memoryHit) {
+      if (v.refCount > 0) {
+        // 暂不能 revoke：等 release 收尾
+        v.pendingRevoke = true;
+        continue;
+      }
+      memoryHit.delete(k);
+      URL.revokeObjectURL(v.blobUrl);
+      evicted = true;
+      break;
+    }
+    // 全部仍被引用：跳出避免死循环；超额暂存留，等 release 自然清
+    if (!evicted) break;
+  }
+};
+
+/**
+ * 命中返 blobUrl 同时 refCount+1（所有权移交调用方）。<br>
+ * 配合 memoryHitPut 的 pre-retain 语义统一：无论 HIT 还是 MISS，调用方都拿到「已 retain」的 url，
+ * 用完必须配对调用 memoryHitRelease（修复 #2）。
+ */
+const memoryHitGet = (url: string): string | undefined => {
+  const e = memoryHit.get(url);
+  if (e !== undefined) {
+    // LRU touch：删除后重新 set，挪到 Map 末尾
+    memoryHit.delete(url);
+    memoryHit.set(url, e);
+    e.refCount++;
+    return e.blobUrl;
+  }
+  return undefined;
+};
+
+/** 引用计数 -1；refCount=0 且 pendingRevoke 时立刻 revoke 并清出 Map。 */
+const memoryHitRelease = (url: string): void => {
+  const e = memoryHit.get(url);
+  if (!e) return;
+  e.refCount = Math.max(0, e.refCount - 1);
+  if (e.refCount === 0 && e.pendingRevoke) {
+    memoryHit.delete(url);
+    URL.revokeObjectURL(e.blobUrl);
+  }
+};
+
+/** type|url → 解析中的 Promise，仅活到 cm.get 完成，去重首次解析并发。type 隔离防串话。 */
+const inFlight = new Map<string, Promise<string | undefined>>();
+/** type|url → 后台下载 Promise，活到 fetch + cm.set 写盘完成；防止 #4 同 url 重复网络请求。 */
+const downloadInFlight = new Map<string, Promise<void>>();
+
+/**
+ * 解析 url：命中本地缓存返 blob URL；未命中返 undefined（调用方应回退到原 url，
+ * 同时本 helper 会在后台异步下载并写入缓存，下次进入直接命中）。
+ */
+const resolveCachedCover = async (
+  url: string,
+  type: CoverCacheType,
+): Promise<string | undefined> => {
+  if (!url || !url.startsWith("http")) return undefined;
+  const cm = useCacheManager();
+  const key = buildKey(url);
+  const flightKey = `${type}|${url}`;
+  // 内存级 hit 直接返（带 LRU touch + refCount++）
+  const hit = memoryHitGet(url);
+  if (hit) return hit;
+  // 并发 dedup（按 type+url 隔离，避免 covers 与 list-covers 串话）。
+  // 修复 #4：pending 命中时不能直接返 await 结果——首次调用方在 memoryHitPut 已拿走那 1 个引用，
+  // 后续 waiter 必须各自再过一次 memoryHitGet 拿到自己的 retain，否则卸载时多次 release 会让
+  // refCount 错误归零，触发 LRU pendingRevoke 把仍被使用的 blob URL revoke 掉（破图）。
+  const pending = inFlight.get(flightKey);
+  if (pending) {
+    return pending.then((firstResult) => {
+      if (firstResult && firstResult.startsWith("blob:")) {
+        // 走 memoryHitGet 拿本调用方的 retain；若 entry 已被 evict 则降级返原值（调用方走原 url 兜底）
+        const ownRef = memoryHitGet(url);
+        return ownRef ?? firstResult;
+      }
+      return firstResult;
+    });
+  }
+
+  const task = (async (): Promise<string | undefined> => {
+    try {
+      const r = await cm.get(type, key);
+      if (r.success && r.data) {
+        // Blob 构造在 TS 5.x 对 Uint8Array.buffer (ArrayBufferLike) 推断过严，断言为 ArrayBuffer 兜底
+        const ab = r.data.buffer.slice(
+          r.data.byteOffset,
+          r.data.byteOffset + r.data.byteLength,
+        ) as ArrayBuffer;
+        const blob = new Blob([ab]);
+        const blobUrl = URL.createObjectURL(blob);
+        memoryHitPut(url, blobUrl);
+        return blobUrl;
+      }
+    } catch {
+      /* miss：走未命中分支 */
+    }
+    // 未命中：后台异步下载并写入；不阻塞返回，让调用方先用原 url 显示
+    void downloadAndCache(url, key, type);
+    return undefined;
+  })();
+
+  inFlight.set(flightKey, task);
+  try {
+    return await task;
+  } finally {
+    inFlight.delete(flightKey);
+  }
+};
+
+/**
+ * 后台抓取并写入缓存（fire-and-forget）。同 url 期间已有下载在跑则直接复用，
+ * 防止 resolveCachedCover 在 cm.get miss 后多次触发同一 url 的网络请求（#4 修复）。
+ */
+const downloadAndCache = (url: string, key: string, type: CoverCacheType): Promise<void> => {
+  const flightKey = `${type}|${url}`;
+  const existing = downloadInFlight.get(flightKey);
+  if (existing) return existing;
+
+  // AbortController 兜底：30s 还没完成则主动取消 fetch，配合 finally 清 inflight
+  const ctrl = new AbortController();
+  // 包成 holder：正常完成时立刻 clearTimeout，避免闭包延寿 30s（ctrl/job/flightKey 占内存）
+  const timer: { id?: ReturnType<typeof setTimeout> } = {};
+  const job = (async () => {
+    try {
+      const settingStore = useSettingStore();
+      if (!settingStore.cacheEnabled) return;
+      const resp = await fetch(url, { signal: ctrl.signal });
+      if (!resp.ok) return;
+      const buf = await resp.arrayBuffer();
+      if (buf.byteLength === 0) return;
+      const cm = useCacheManager();
+      await cm.set(type, key, new Uint8Array(buf));
+    } catch (e) {
+      // 网络失败 / abort 不致命：下次访问仍可能命中或重试
+      console.warn("[useCoverCache] download failed:", url, e);
+    } finally {
+      downloadInFlight.delete(flightKey);
+      if (timer.id !== undefined) clearTimeout(timer.id);
+    }
+  })();
+
+  downloadInFlight.set(flightKey, job);
+  // 30s 兜底超时：abort fetch + 清 inflight；正常完成时由上面 finally clearTimeout 取消
+  timer.id = setTimeout(() => {
+    if (downloadInFlight.get(flightKey) === job) {
+      ctrl.abort();
+      downloadInFlight.delete(flightKey);
+    }
+  }, 30_000);
+  return job;
+};
+
+/**
+ * 预下载封面到本地缓存：供 SongManager.prefetchNextSong 等场景主动调用。
+ *
+ * <p>已在缓存命中或正在下载时直接跳过；并发安全（同 url 只发一次请求）。
+ * 与 resolveCachedCover 共享 inFlight / memoryHit map，去重彻底。
+ *
+ * @param url 远端封面 url（http/https）
+ * @param type 默认 "covers"；列表场景传 "list-covers"
+ */
+export const prefetchCoverToCache = async (
+  url: string | undefined,
+  type: CoverCacheType = "covers",
+): Promise<void> => {
+  if (!url || !url.startsWith("http")) return;
+  if (!isCapacitorAndroid) return;
+  // 复用 resolveCachedCover：命中直接返，未命中触发后台下载。
+  // 拿到 blob URL 后立即 release（修复 #2 pre-retain 副作用）：
+  // prefetch 仅是「写入缓存」语义，本身不持有 blob URL 引用。
+  const cached = await resolveCachedCover(url, type);
+  if (cached && cached.startsWith("blob:")) {
+    memoryHitRelease(url);
+  }
+};
+
+/** 列表项最小形态：从 cover / coverSize 提取首选 url。 */
+type CoverLike = { cover?: string; coverSize?: { s?: string; m?: string; l?: string; xl?: string } };
+
+/**
+ * 从一条列表项按尺寸偏好提取 url。<br>
+ * 关键：必须与实际 <s-image :src=...> 使用的 url 一致，否则 prefetch 写入和组件读取不在同一缓存条目上，浪费下载。
+ *
+ * - "s"（小图）：SongCard、SongList 行封面
+ * - "m"（中图）：CoverList、ArtistList、Local/Streaming/HomeMobile 列表卡片
+ */
+const pickListCoverUrl = (
+  item: CoverLike,
+  sizePref: "s" | "m" = "m",
+): string | undefined => {
+  if (sizePref === "s") return item?.coverSize?.s || item?.cover;
+  return item?.coverSize?.m || item?.coverSize?.s || item?.cover;
+};
+
+/**
+ * 批量后台 prefetch 列表中前 N 张封面，进入详情页 / 首页加载完成后调用。
+ *
+ * <p>fire-and-forget；并发由 useCoverCache 内的 inFlight 去重，不会重复请求。
+ * 仅 Android 走本地缓存路径；其他平台 noop。
+ *
+ * @param items     列表项（含 cover / coverSize）
+ * @param type      "list-covers"（默认） / "covers"
+ * @param limit     预热的前 N 条；默认 20
+ * @param sizePref  尺寸偏好：与 <s-image> 实际请求的尺寸保持一致才能命中
+ */
+export const prefetchListCovers = (
+  items: readonly CoverLike[] | undefined,
+  type: CoverCacheType = "list-covers",
+  limit = 20,
+  sizePref: "s" | "m" = "m",
+): void => {
+  if (!items || items.length === 0) return;
+  if (!isCapacitorAndroid) return;
+  const max = Math.min(limit, items.length);
+  for (let i = 0; i < max; i++) {
+    const url = pickListCoverUrl(items[i], sizePref);
+    if (url) void prefetchCoverToCache(url, type);
+  }
+};
+
+/**
+ * 把远端封面 url 映射为「优先本地、回退远端」的反应式 src。
+ *
+ * - 仅 Android 启用；其他平台直接透传原 url（项目仅安卓运行，但保留兜底）
+ * - 卸载时释放 blob URL，避免内存泄漏
+ *
+ * @param srcRef 原始 url ref（来自 props.src 等）
+ * @param type 默认 "covers"；列表场景传 "list-covers"
+ * @returns 处理后的 src ref
+ */
+export const useCoverCache = (
+  srcRef: Ref<string | undefined>,
+  type: CoverCacheType = "covers",
+): Ref<string | undefined> => {
+  const resolved = ref<string | undefined>(srcRef.value);
+  /** 当前组件 retain 的源 url 列表（不是 blob URL，是原始 http url 作为 memoryHit 的 key）。 */
+  const retainedUrls: string[] = [];
+
+  watch(
+    srcRef,
+    async (url, prevUrl) => {
+      // 切换 src：先 release 旧 url 的引用计数
+      if (prevUrl && retainedUrls.includes(prevUrl)) {
+        memoryHitRelease(prevUrl);
+        const idx = retainedUrls.indexOf(prevUrl);
+        if (idx >= 0) retainedUrls.splice(idx, 1);
+      }
+      if (!url) {
+        resolved.value = undefined;
+        return;
+      }
+      // 非 http(s) 直接透传：本地路径 / data URI / blob URL / capacitor://
+      if (!url.startsWith("http")) {
+        resolved.value = url;
+        return;
+      }
+      if (!isCapacitorAndroid) {
+        resolved.value = url;
+        return;
+      }
+      // 先用原始 url 显示，避免等待 IPC（命中时立即升级）
+      resolved.value = url;
+      const cached = await resolveCachedCover(url, type);
+      if (cached && srcRef.value === url) {
+        resolved.value = cached;
+        if (cached.startsWith("blob:")) {
+          // resolveCachedCover 已 pre-retain（修复 #2），这里只需记录 url 等卸载时 release
+          retainedUrls.push(url);
+        } else if (cached.startsWith("blob:") === false) {
+          // 极少见：返回非 blob URL（透传场景），不持有引用
+        }
+      } else if (cached && cached.startsWith("blob:")) {
+        // src 已切换：本次拿到的 blob 没用上，立即释放所有权避免泄漏
+        memoryHitRelease(url);
+      }
+    },
+    { immediate: true },
+  );
+
+  onBeforeUnmount(() => {
+    // 释放所有 retain 的 blob URL；refCount 归零且 LRU 已超额则真正 revoke。
+    for (const u of retainedUrls) memoryHitRelease(u);
+    retainedUrls.length = 0;
+  });
+
+  return resolved;
+};

--- a/src/core/player/LyricManager.ts
+++ b/src/core/player/LyricManager.ts
@@ -78,9 +78,9 @@ class LyricManager {
    */
   private async getRawLyricCache(id: number, type: "lrc" | "ttml" | "qrc"): Promise<string | null> {
     const settingStore = useSettingStore();
-    if (!isElectron || !settingStore.cacheEnabled) return null;
+    const cacheManager = useCacheManager();
+    if (!cacheManager.isAvailable() || !settingStore.cacheEnabled) return null;
     try {
-      const cacheManager = useCacheManager();
       const ext = type === "ttml" ? "ttml" : type === "qrc" ? "qrc.json" : "json";
       const result = await cacheManager.get("lyrics", `${id}.${ext}`);
       if (result.success && result.data) {
@@ -102,9 +102,9 @@ class LyricManager {
    */
   private async saveRawLyricCache(id: number, type: "lrc" | "ttml" | "qrc", data: string) {
     const settingStore = useSettingStore();
-    if (!isElectron || !settingStore.cacheEnabled) return;
+    const cacheManager = useCacheManager();
+    if (!cacheManager.isAvailable() || !settingStore.cacheEnabled) return;
     try {
-      const cacheManager = useCacheManager();
       const ext = type === "ttml" ? "ttml" : type === "qrc" ? "qrc.json" : "json";
       await cacheManager.set("lyrics", `${id}.${ext}`, data);
     } catch (error) {

--- a/src/core/player/MediaSessionManager.ts
+++ b/src/core/player/MediaSessionManager.ts
@@ -200,16 +200,64 @@ class MediaSessionManager {
     }
   }
 
-  public async syncAndroidApiContext() {
+  /**
+   * 切歌时 PlayerController.syncAndroidPlaybackContext 与 MediaSessionManager.updateMetadata
+   * 都会调一次 syncApiContext，参数完全一致。Java 端幂等，但 IPC 跨 JNI 仍要 30-150ms。
+   * 这里用 lastKey 去重：参数无变化直接 resolve，避免主线程上重复 await。
+   */
+  private lastSyncedApiContextKey: string | null = null;
+  /**
+   * 并发去重：相同 key 的 IPC 正在跑时，后续调用复用同一 Promise；
+   * lastSyncedApiContextKey 只在 await 后赋值，不能拦住「同时进入 await」的并发。
+   * 详见 fix#4：避免切歌瞬间 2-3 处并行调用都打穿到 Java 端。
+   */
+  private pendingSyncApiContextKey: string | null = null;
+  private pendingSyncApiContextPromise: Promise<void> | null = null;
+
+  public async syncAndroidApiContext(force: boolean = false) {
     if (!isCapacitorAndroid) return;
 
     const settingStore = useSettingStore();
     const musicCookie = getCookie("MUSIC_U");
-    await AndroidNativePlayback.syncApiContext({
-      apiBaseUrl: EMBEDDED_API_BASE_URL,
-      cookie: musicCookie ? `MUSIC_U=${musicCookie};os=pc;` : "",
-      songLevel: settingStore.songLevel,
-    });
+    const cookie = musicCookie ? `MUSIC_U=${musicCookie};os=pc;` : "";
+    const key = `${EMBEDDED_API_BASE_URL}|${cookie}|${settingStore.songLevel}`;
+    if (!force && this.lastSyncedApiContextKey === key) return;
+    // 并发去重：同 key 已有 IPC 在跑直接复用 Promise；force 时强制新发起
+    if (
+      !force &&
+      this.pendingSyncApiContextKey === key &&
+      this.pendingSyncApiContextPromise
+    ) {
+      return this.pendingSyncApiContextPromise;
+    }
+
+    const jobRef: { current: Promise<void> | null } = { current: null };
+    const job = (async () => {
+      try {
+        await AndroidNativePlayback.syncApiContext({
+          apiBaseUrl: EMBEDDED_API_BASE_URL,
+          cookie,
+          songLevel: settingStore.songLevel,
+        });
+        this.lastSyncedApiContextKey = key;
+      } finally {
+        // 仅当 pending 还是本任务时才清；force 重入场景下可能已被新 job 覆盖
+        if (this.pendingSyncApiContextPromise === jobRef.current) {
+          this.pendingSyncApiContextKey = null;
+          this.pendingSyncApiContextPromise = null;
+        }
+      }
+    })();
+    jobRef.current = job;
+    this.pendingSyncApiContextKey = key;
+    this.pendingSyncApiContextPromise = job;
+    return job;
+  }
+
+  /** 用户登录登出 / 切换音质后调用，清空 dedup 强制下次同步。 */
+  public invalidateSyncedApiContext() {
+    this.lastSyncedApiContextKey = null;
+    // 不清 pending：让正在跑的 IPC 完成后自然清理；下次调用 key 不同会自然 force
   }
 
   public init() {

--- a/src/core/player/PlayerController.ts
+++ b/src/core/player/PlayerController.ts
@@ -6,14 +6,12 @@ import type { RepeatModeType, ShuffleModeType } from "@/types/shared/play-mode";
 import { type AudioAnalysis } from "@/types/audio/automix";
 import { calculateLyricIndex } from "@/utils/calc";
 import { getCoverColor } from "@/utils/color";
-import { EMBEDDED_API_BASE_URL } from "@/utils/embeddedApi";
 import { isCapacitorAndroid, isElectron, isMac } from "@/utils/env";
 import { getPlayerInfoObj, getPlaySongData } from "@/utils/format";
 import { handleSongQuality, shuffleArray, sleep } from "@/utils/helper";
 import lastfmScrobbler from "@/utils/lastfmScrobbler";
 import { DJ_MODE_KEYWORDS } from "@/utils/meta";
 import { calculateProgress } from "@/utils/time";
-import { getCookie } from "@/utils/cookie";
 import type { LyricLine } from "@applemusic-like-lyrics/lyric";
 import { type DebouncedFunc, throttle } from "lodash-es";
 import {
@@ -605,9 +603,20 @@ class PlayerController {
       await this.parseLocalMusicInfo(song.path);
     }
 
-    // 必须 await：fire-and-forget 会让 playLoading=false 早于 Android Native
-    // 队列上下文更新，触发"音频已播但 MainPlayer / FullPlayer UI 滞后半秒"的回潮。
-    await this.syncAndroidPlaybackContext(song);
+    // 预载下一首：fire-and-forget，让 playLoading=false 不被网络请求阻塞 1-3s
+    // syncAndroidPlaybackContext 内部 buildAndroidWindowTracks 同步遍历 41 首歌（5-30ms），
+    // 后续 4 个 Capacitor IPC 累计 100-300ms。这些都不应卡在切歌热路径上，
+    // 推到 idle frame 让 UI 把切歌动画 / 歌词加载先跑完，再幕后做队列同步。
+    // Java 触发的 applyNativeTrackChanged / refreshAndroidQueueWindow 等仍走立即路径。
+    const ric = (
+      window as Window & { requestIdleCallback?: typeof requestIdleCallback }
+    ).requestIdleCallback;
+    const runSync = () => void this.syncAndroidPlaybackContext(song);
+    if (typeof ric === "function") {
+      ric(runSync, { timeout: 500 });
+    } else {
+      setTimeout(runSync, 0);
+    }
     if (settingStore.useNextPrefetch) songManager.prefetchNextSong();
 
     // Last.fm Scrobbler
@@ -759,77 +768,74 @@ class PlayerController {
 
   public async syncAndroidPlaybackContext(
     songOverride?: SongType,
-    options?: { windowRefilled?: boolean },
+    options?: { windowRefilled?: boolean; windowResetFromWrap?: boolean },
   ) {
     if (!isCapacitorAndroid) return;
 
+    const dataStore = useDataStore();
+    const musicStore = useMusicStore();
+    const settingStore = useSettingStore();
+    const statusStore = useStatusStore();
+    const song = songOverride || getPlaySongData() || musicStore.playSong;
+
+    if (!song) return;
+
+    // 推 ±N 窗口给 Java 自治处理 ENDED/NEXT/PREVIOUS，脱离 WebView 后台冻结
+    let windowResult: {
+      windowTracks: AndroidNativeWindowTrack[];
+      windowCurrentIndex: number;
+      hasPreviousOutsideWindow: boolean;
+      hasNextOutsideWindow: boolean;
+      repeatMode: "off" | "all" | "one";
+    };
+
+    const initialSongId = song.id;
+    const isStaleSong = () =>
+      !!musicStore.playSong &&
+      typeof initialSongId !== "undefined" &&
+      musicStore.playSong.id !== initialSongId;
+    if (isStaleSong()) return;
+
     try {
-      const dataStore = useDataStore();
-      const musicStore = useMusicStore();
-      const settingStore = useSettingStore();
-      const statusStore = useStatusStore();
-      const song = songOverride || getPlaySongData() || musicStore.playSong;
-
-      if (!song) return;
-
-      // 不论是否传入 songOverride 都做 stale 守卫：
-      // 多次 await 之间用户可能切到了另一首歌，此时把旧歌的元数据/队列上下文写入 Native 是脏数据。
-      const initialSongId = song.id;
-      const isStaleSong = () =>
-        !!musicStore.playSong &&
-        typeof initialSongId !== "undefined" &&
-        musicStore.playSong.id !== initialSongId;
-      if (isStaleSong()) return;
-
-      const musicCookie = getCookie("MUSIC_U");
-
-      await AndroidNativePlayback.syncApiContext({
-        apiBaseUrl: EMBEDDED_API_BASE_URL,
-        cookie: musicCookie ? `MUSIC_U=${musicCookie};os=pc;` : "",
-        songLevel: settingStore.songLevel,
-      });
-      if (isStaleSong()) return;
-
-      let windowResult: {
-        windowTracks: AndroidNativeWindowTrack[];
-        windowCurrentIndex: number;
-        hasPreviousOutsideWindow: boolean;
-        hasNextOutsideWindow: boolean;
-        repeatMode: "off" | "all" | "one";
+      windowResult = this.buildAndroidWindowTracks(song);
+    } catch (error) {
+      console.warn("[Android] failed to build window tracks:", error);
+      windowResult = {
+        windowTracks: [],
+        windowCurrentIndex: -1,
+        hasPreviousOutsideWindow: false,
+        hasNextOutsideWindow: false,
+        repeatMode: this.toAndroidRepeatMode(),
       };
-      try {
-        windowResult = this.buildAndroidWindowTracks(song);
-      } catch (error) {
-        console.warn("[Android] failed to build window tracks:", error);
-        windowResult = {
-          windowTracks: [],
-          windowCurrentIndex: -1,
-          hasPreviousOutsideWindow: false,
-          hasNextOutsideWindow: false,
-          repeatMode: this.toAndroidRepeatMode(),
-        };
-      }
-      if (isStaleSong()) return;
+    }
 
-      await AndroidNativePlayback.updateQueueContext({
-        liked: typeof song.id === "number" ? dataStore.isLikeSong(song.id) : false,
-        canSkipPrevious: !statusStore.personalFmMode,
-        personalFmMode: statusStore.personalFmMode,
-        controllerEnabled: settingStore.androidMediaControllerEnabled,
-        desktopLyricButtonEnabled: settingStore.androidMediaControllerDesktopLyricEnabled,
-        desktopLyricEnabled: statusStore.showDesktopLyric,
-        ...windowResult,
-        windowRefilled: options?.windowRefilled === true,
-      });
+    if (isStaleSong()) return;
 
-      await AndroidNativePlayback.updateNotificationPrefs({
-        controllerEnabled: settingStore.androidMediaControllerEnabled,
-        desktopLyricButtonEnabled: settingStore.androidMediaControllerDesktopLyricEnabled,
-      });
-
-      await AndroidNativePlayback.setAllowMixWithOthers({
-        allow: settingStore.androidAllowMixWithOthers,
-      });
+    // 4 次 IPC 并发：之前串行累计 30-150ms × 4 = 200-600ms 主线程 microtask 排队，
+    // 改为 Promise.all 后单次切歌仅排队 30-150ms。
+    // syncApiContext 通过 mediaSessionManager 共享 dedup（参数无变化时跳过实际 IPC）。
+    try {
+      await Promise.all([
+        mediaSessionManager.syncAndroidApiContext(),
+        AndroidNativePlayback.updateQueueContext({
+          liked: typeof song.id === "number" ? dataStore.isLikeSong(song.id) : false,
+          canSkipPrevious: !statusStore.personalFmMode,
+          personalFmMode: statusStore.personalFmMode,
+          controllerEnabled: settingStore.androidMediaControllerEnabled,
+          desktopLyricButtonEnabled: settingStore.androidMediaControllerDesktopLyricEnabled,
+          desktopLyricEnabled: statusStore.showDesktopLyric,
+          ...windowResult,
+          windowRefilled: options?.windowRefilled === true,
+          windowResetFromWrap: options?.windowResetFromWrap === true,
+        }),
+        AndroidNativePlayback.updateNotificationPrefs({
+          controllerEnabled: settingStore.androidMediaControllerEnabled,
+          desktopLyricButtonEnabled: settingStore.androidMediaControllerDesktopLyricEnabled,
+        }),
+        AndroidNativePlayback.setAllowMixWithOthers({
+          allow: settingStore.androidAllowMixWithOthers,
+        }),
+      ]);
     } catch (error) {
       console.warn("[Android] sync playback context failed:", error);
     }
@@ -886,6 +892,13 @@ class PlayerController {
       this.applySongLikeState(nextSong.id, liked);
     }
 
+    // 修复 #2：原生侧驱动的切歌不走 prepareAudioSource，currentAudioSource / songQuality / audioSource
+    // 仍是上一首的值。后续 resolveSyncSongUrl(isCurrent=true) 会优先取 this.currentAudioSource.url，
+    // 把上一首 URL 错推回 Android 队列。这里清空让其走 song.path / streamUrl / null 分支。
+    this.currentAudioSource = null;
+    statusStore.songQuality = undefined;
+    statusStore.audioSource = undefined;
+
     this.setupSongUI(nextSong, 0);
     statusStore.currentTime = 0;
     statusStore.duration = nextSong.duration || 0;
@@ -905,6 +918,7 @@ class PlayerController {
     // Java 端在窗口完整覆盖全局列表（≤201 首）时能自治 wrap，但列表 >201 首时
     // hasPreviousOutsideWindow=true 让 advanceRaw 不能 wrap，必须 JS 这里负责重置。
     const playList = dataStore.playList;
+    let wrapped = false;
     if (
       statusStore.repeatMode === "list" &&
       !statusStore.personalFmMode &&
@@ -912,6 +926,7 @@ class PlayerController {
       statusStore.playIndex >= playList.length - 1
     ) {
       statusStore.playIndex = 0;
+      wrapped = true;
     }
 
     try {
@@ -921,7 +936,11 @@ class PlayerController {
       console.warn("[Android] refreshAndroidQueueWindow prefetch failed:", error);
     }
     // 重要：windowRefilled=true 让 Java 端区分本次推送属于补窗响应，才会消费 pendingResumeAfterRefill 续播。
-    await this.syncAndroidPlaybackContext(undefined, { windowRefilled: true });
+    // windowResetFromWrap=true（仅 wrap 路径）：Java 用 current() 而非 advanceRaw 避免跳过 track 0。
+    await this.syncAndroidPlaybackContext(undefined, {
+      windowRefilled: true,
+      windowResetFromWrap: wrapped,
+    });
   }
 
   public async applyNativeAutoNext(songId: number, liked?: boolean) {
@@ -985,6 +1004,11 @@ class PlayerController {
     if (typeof liked === "boolean" && typeof nextSong.id === "number") {
       this.applySongLikeState(nextSong.id, liked);
     }
+
+    // 修复 #2：同 applyNativeTrackChanged，清空 currentAudioSource 避免被 resolveSyncSongUrl 误用
+    this.currentAudioSource = null;
+    statusStore.songQuality = undefined;
+    statusStore.audioSource = undefined;
 
     this.setupSongUI(nextSong, 0);
     statusStore.currentTime = 0;

--- a/src/core/player/PlayerController.ts
+++ b/src/core/player/PlayerController.ts
@@ -672,6 +672,23 @@ class PlayerController {
     };
   }
 
+  private inferNativePlaybackInfo(song: SongType): {
+    quality: QualityType | undefined;
+    source: AudioSourceType | undefined;
+  } {
+    if (song.path) {
+      return { quality: song.quality, source: "local" };
+    }
+    if (song.type === "streaming") {
+      return { quality: song.quality || QualityType.SQ, source: "streaming" };
+    }
+    const settingStore = useSettingStore();
+    return {
+      quality: song.quality ?? handleSongQuality({ level: settingStore.songLevel }, "online") ?? QualityType.HQ,
+      source: "official",
+    };
+  }
+
   /** 同步取播放 URL，不发网络请求。返回 null 时窗口推 null，由 Java 端按需解析。 */
   private resolveSyncSongUrl(song: SongType, isCurrent: boolean): string | null {
     if (isCurrent && this.currentAudioSource?.url) return this.currentAudioSource.url;
@@ -896,8 +913,9 @@ class PlayerController {
     // 仍是上一首的值。后续 resolveSyncSongUrl(isCurrent=true) 会优先取 this.currentAudioSource.url，
     // 把上一首 URL 错推回 Android 队列。这里清空让其走 song.path / streamUrl / null 分支。
     this.currentAudioSource = null;
-    statusStore.songQuality = undefined;
-    statusStore.audioSource = undefined;
+    const nativePlaybackInfo = this.inferNativePlaybackInfo(nextSong);
+    statusStore.songQuality = nativePlaybackInfo.quality;
+    statusStore.audioSource = nativePlaybackInfo.source;
 
     this.setupSongUI(nextSong, 0);
     statusStore.currentTime = 0;
@@ -1007,8 +1025,9 @@ class PlayerController {
 
     // 修复 #2：同 applyNativeTrackChanged，清空 currentAudioSource 避免被 resolveSyncSongUrl 误用
     this.currentAudioSource = null;
-    statusStore.songQuality = undefined;
-    statusStore.audioSource = undefined;
+    const nativePlaybackInfo = this.inferNativePlaybackInfo(nextSong);
+    statusStore.songQuality = nativePlaybackInfo.quality;
+    statusStore.audioSource = nativePlaybackInfo.source;
 
     this.setupSongUI(nextSong, 0);
     statusStore.currentTime = 0;

--- a/src/core/player/SongManager.ts
+++ b/src/core/player/SongManager.ts
@@ -10,7 +10,9 @@ import {
 } from "@/stores";
 import { QualityType, type SongType, type AudioSourceType } from "@/types/main";
 import { isLogin } from "@/utils/auth";
-import { isElectron } from "@/utils/env";
+import { isCapacitorAndroid, isElectron } from "@/utils/env";
+import { AndroidNativePlayback } from "@/plugins/androidNativePlayback";
+import { prefetchCoverToCache } from "@/composables/useCoverCache";
 import { formatSongsList } from "@/utils/format";
 import { AI_AUDIO_LEVELS } from "@/utils/meta";
 import { handleSongQuality } from "@/utils/helper";
@@ -56,47 +58,26 @@ class SongManager {
     return this.nextPrefetch;
   }
 
+  /**
+   * 获取本地音频缓存路径。
+   *
+   * <p>Android-only 架构下：音频缓存由 ExoPlayer SimpleCache 在 Java 端自动接管，
+   * TS 侧不需要主动查询/下载。这里返 null 让上层出口走原始 URL，
+   * 由 ExoPlayer CacheDataSource 内部检查是否命中缓存。
+   */
   public async getMusicCachePath(
-    id: number | string,
-    quality?: QualityType | string,
+    _id: number | string,
+    _quality?: QualityType | string,
   ): Promise<string | null> {
-    const settingStore = useSettingStore();
-    if (!isElectron || !settingStore.cacheEnabled || !settingStore.songCacheEnabled) return null;
-    try {
-      return await window.electron.ipcRenderer.invoke("music-cache-check", id, quality);
-    } catch {
-      return null;
-    }
+    return null;
   }
 
   public async ensureMusicCachePath(
-    id: number | string,
-    url: string | undefined,
-    quality?: QualityType | string,
+    _id: number | string,
+    _url: string | undefined,
+    _quality?: QualityType | string,
   ): Promise<string | null> {
-    const existing = await this.getMusicCachePath(id, quality);
-    if (existing) return existing;
-    if (!url) return null;
-
-    const settingStore = useSettingStore();
-    if (!isElectron || !settingStore.cacheEnabled || !settingStore.songCacheEnabled) return null;
-    try {
-      const result: unknown = await window.electron.ipcRenderer.invoke(
-        "music-cache-download",
-        id,
-        url,
-        quality || "standard",
-      );
-      if (result && typeof result === "object") {
-        const record = result as Record<string, unknown>;
-        if (record.success === true && typeof record.path === "string") {
-          return record.path;
-        }
-      }
-    } catch {
-      return null;
-    }
-    return await this.getMusicCachePath(id);
+    return null;
   }
 
   /**
@@ -117,7 +98,7 @@ class SongManager {
     if (song.cover && !coverUrls.includes(song.cover)) {
       coverUrls.push(song.cover);
     }
-    // 预加载图片
+    // 预加载图片：浏览器 HTTP 缓存 warm-up
     coverUrls.forEach((url) => {
       if (!url || !url.startsWith("http")) return;
       const img = new Image();
@@ -130,50 +111,34 @@ class SongManager {
       img.onerror = cleanup;
       img.src = url;
     });
+    // Android 额外写入 covers/ 本地缓存：下一首切过去 s-image 立刻命中 blob URL、
+    // 不依赖浏览器 HTTP 缓存（Capacitor WebView 的 disk cache 在重启后会丢）。
+    // 只预下载主封面（列表组件主要用 coverSize.s/m，s-image 用 coverSize.l/xl）。
+    if (isCapacitorAndroid) {
+      const primary =
+        song.coverSize?.l ||
+        song.coverSize?.xl ||
+        song.coverSize?.m ||
+        song.cover;
+      void prefetchCoverToCache(primary, "covers");
+    }
   }
 
   /**
-   * 检查本地缓存
-   * @param id 歌曲id
-   * @param quality 音质
-   * @param md5 歌曲文件md5
+   * 检查本地音频缓存 —— Android-only 架构下交由 ExoPlayer SimpleCache 自动处理。
+   * 返 null 让上层走原始 URL，底层 CacheDataSource 会自动命中本地缓存文件不重走网络。
    */
   private checkLocalCache = async (
-    id: number,
-    quality?: QualityType,
-    md5?: string,
+    _id: number,
+    _quality?: QualityType,
+    _md5?: string,
   ): Promise<string | null> => {
-    const settingStore = useSettingStore();
-    if (isElectron && settingStore.cacheEnabled && settingStore.songCacheEnabled) {
-      try {
-        const cachePath = await window.electron.ipcRenderer.invoke(
-          "music-cache-check",
-          id,
-          quality,
-          md5,
-        );
-        if (cachePath) {
-          console.log(`🚀 [${id}] 由本地音乐缓存提供`);
-          return `file://${cachePath}`;
-        }
-      } catch (e) {
-        console.error(`❌ [${id}] 检查缓存失败:`, e);
-      }
-    }
     return null;
   };
 
-  /**
-   * 触发缓存下载
-   * @param id 歌曲id
-   * @param url 下载地址
-   * @param quality 音质
-   */
-  private triggerCacheDownload = (id: number, url: string, quality?: QualityType | string) => {
-    const settingStore = useSettingStore();
-    if (isElectron && settingStore.cacheEnabled && settingStore.songCacheEnabled && url) {
-      window.electron.ipcRenderer.invoke("music-cache-download", id, url, quality || "standard");
-    }
+  /** 主动下载调用点 —— Android-only 架构下不需要，留空实现避免业务侧大改。 */
+  private triggerCacheDownload = (_id: number, _url: string, _quality?: QualityType | string) => {
+    // no-op: ExoPlayer CacheDataSource 边播边缓存
   };
 
   /**
@@ -386,6 +351,10 @@ class SongManager {
             quality,
             source: "official",
           };
+          // Android 预下载音频前 512KB 到 SimpleCache：FM 下一首秒响
+          if (isCapacitorAndroid) {
+            void AndroidNativePlayback.prefetchAudio({ url }).catch(() => {});
+          }
           return this.nextPrefetch;
         }
         return;
@@ -432,6 +401,11 @@ class SongManager {
       const canUnlock = isElectron && nextSong.type !== "radio" && settingStore.useSongUnlock;
       // 先请求官方地址
       const { url: officialUrl, isTrial, quality } = await this.getOnlineUrl(songId, false);
+      // Android 端主动预下载音频前 512KB：下一首切歌后 ExoPlayer setMediaItem 可不走网络手口
+      const triggerAudioPrefetch = (audioUrl: string | undefined) => {
+        if (!isCapacitorAndroid || !audioUrl || !audioUrl.startsWith("http")) return;
+        void AndroidNativePlayback.prefetchAudio({ url: audioUrl }).catch(() => {});
+      };
       if (officialUrl && !isTrial) {
         // 官方可播放且非试听
         this.nextPrefetch = {
@@ -441,16 +415,19 @@ class SongManager {
           quality,
           source: "official",
         };
+        triggerAudioPrefetch(officialUrl);
         return this.nextPrefetch;
       } else if (canUnlock) {
         // 官方失败或为试听时尝试解锁
         const unlockUrl = await this.getUnlockSongUrl(nextSong);
         if (unlockUrl.url) {
           this.nextPrefetch = { id: songId, url: unlockUrl.url, isUnlocked: true };
+          triggerAudioPrefetch(unlockUrl.url);
           return this.nextPrefetch;
         } else if (officialUrl && settingStore.playSongDemo) {
           // 解锁失败，若官方为试听且允许试听，保留官方试听地址
           this.nextPrefetch = { id: songId, url: officialUrl, source: "official" };
+          triggerAudioPrefetch(officialUrl);
           return this.nextPrefetch;
         } else {
           return;
@@ -458,6 +435,7 @@ class SongManager {
       } else {
         // 不可解锁，仅保留官方结果（可能为空）
         this.nextPrefetch = { id: songId, url: officialUrl, source: "official" };
+        triggerAudioPrefetch(officialUrl);
         return this.nextPrefetch;
       }
     } catch (error) {

--- a/src/core/resource/CacheManager.ts
+++ b/src/core/resource/CacheManager.ts
@@ -1,131 +1,182 @@
-import { isElectron } from "@/utils/env";
+import { AndroidCache, type AndroidCacheType } from "@/plugins/androidCache";
 
 /**
- * 缓存资源类型
- * - music: 音乐缓存
+ * 缓存资源类型（仅 Android）
  * - lyrics: 歌词缓存
- * - local-data: 本地音乐数据缓存
- * - list-data: 列表数据缓存（歌单/专辑/电台）
+ * - list-data: 列表数据缓存（歌单 / 专辑 / 电台 / 推荐 等 metadata JSON）
+ * - covers: 歌曲封面（缓存原始字节，规避 MediaStore 扫描）
+ * - list-covers: 列表封面
+ * - music: 音频缓存（业务侧通常无需直接读写；ExoPlayer SimpleCache 自治；保留方便清理 / 统计）
  */
-export type CacheResourceType = "music" | "lyrics" | "local-data" | "list-data";
+export type CacheResourceType = "lyrics" | "list-data" | "covers" | "list-covers" | "music";
 
-/**
- * 缓存文件列表项信息
- */
 export type CacheListItem = {
-  /** 缓存 key（文件名或相对路径） */
+  /** 缓存 key */
   key: string;
-  /** 文件大小（字节） */
+  /** 字节大小 */
   size: number;
-  /** 最后修改时间（毫秒时间戳） */
+  /** 最后修改毫秒时间戳 */
   mtime: number;
 };
 
-/**
- * 缓存操作统一返回结构
- * @template T data 字段的数据类型
- */
 export type CacheResult<T = any> = {
-  /** 是否成功 */
   success: boolean;
-  /** 返回数据 */
   data?: T;
-  /** 错误信息（失败时） */
   message?: string;
 };
 
-/**
- * 可写入缓存的数据类型
- */
 type CacheWriteData = Uint8Array | ArrayBuffer | string;
 
+const mapType = (type: CacheResourceType): AndroidCacheType => {
+  if (type === "music") return "exo";
+  return type;
+};
+
+const toBase64 = (data: CacheWriteData): string => {
+  let bytes: Uint8Array;
+  if (typeof data === "string") bytes = new TextEncoder().encode(data);
+  else if (data instanceof ArrayBuffer) bytes = new Uint8Array(data);
+  else bytes = data;
+  let binary = "";
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode.apply(null, Array.from(bytes.subarray(i, i + chunk)));
+  }
+  return btoa(binary);
+};
+
+const fromBase64 = (b64: string): Uint8Array => {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+};
+
 /**
- * 渲染进程缓存管理器
- * 通过 IPC 调用主进程，实现缓存的增删改查
+ * Android 端缓存管理器（项目仅安卓运行）。
+ *
+ * <p>所有读写走 AndroidCache Capacitor 插件 → CacheStorage / SimpleCache。
+ * 业务侧统一调用 useCacheManager()，无需关心平台差异。
  */
 class CacheManager {
-  /**
-   * 调用底层 IPC 通道
-   * @param channel IPC 通道名称
-   * @param args 传入参数
-   * @returns 封装后的缓存结果
-   */
-  private invoke<T>(channel: string, ...args: any[]): Promise<CacheResult<T>> {
-    if (!isElectron) {
-      return Promise.resolve({
-        success: false,
-        message: "当前环境不支持缓存",
-      });
+  /** 始终可用：进程在 Capacitor Android 上运行；保留接口避免业务侧大改。 */
+  isAvailable(): boolean {
+    return true;
+  }
+
+  async list(type: CacheResourceType): Promise<CacheResult<CacheListItem[]>> {
+    try {
+      const r = await AndroidCache.list({ type: mapType(type) });
+      return { success: true, data: r.entries };
+    } catch (e: any) {
+      return { success: false, message: String(e?.message ?? e) };
     }
-    return window.electron.ipcRenderer.invoke(channel, ...args);
   }
 
-  /**
-   * 获取指定类型缓存下的文件列表
-   * @param type 缓存资源类型
-   */
-  list(type: CacheResourceType): Promise<CacheResult<CacheListItem[]>> {
-    return this.invoke("cache-list", type);
+  async get(type: CacheResourceType, key: string): Promise<CacheResult<Uint8Array>> {
+    try {
+      const r = await AndroidCache.read({ type: mapType(type), key });
+      if (!r.hit || !r.data) return { success: false, message: "miss" };
+      return { success: true, data: fromBase64(r.data) };
+    } catch (e: any) {
+      return { success: false, message: String(e?.message ?? e) };
+    }
   }
 
-  /**
-   * 读取指定缓存内容
-   * @param type 缓存资源类型
-   * @param key 缓存 key（文件名或相对路径）
-   */
-  get(type: CacheResourceType, key: string): Promise<CacheResult<Uint8Array>> {
-    return this.invoke("cache-get", type, key);
+  async set(
+    type: CacheResourceType,
+    key: string,
+    data: CacheWriteData,
+  ): Promise<CacheResult<null>> {
+    try {
+      const r = await AndroidCache.write({ type: mapType(type), key, data: toBase64(data) });
+      return r.success ? { success: true, data: null } : { success: false, message: r.message };
+    } catch (e: any) {
+      return { success: false, message: String(e?.message ?? e) };
+    }
   }
 
-  /**
-   * 写入或更新缓存内容
-   * @param type 缓存资源类型
-   * @param key 缓存 key（文件名或相对路径）
-   * @param data 要写入的数据（自动转换为二进制）
-   */
-  set(type: CacheResourceType, key: string, data: CacheWriteData): Promise<CacheResult<null>> {
-    const payload = data instanceof ArrayBuffer ? new Uint8Array(data) : data;
-    return this.invoke("cache-put", type, key, payload);
+  async remove(type: CacheResourceType, key: string): Promise<CacheResult<null>> {
+    const r = await AndroidCache.remove({ type: mapType(type), key });
+    return { success: r.success, data: null };
   }
 
-  /**
-   * 删除单个缓存文件
-   * @param type 缓存资源类型
-   * @param key 缓存 key（文件名或相对路径）
-   */
-  remove(type: CacheResourceType, key: string): Promise<CacheResult<null>> {
-    return this.invoke("cache-remove", type, key);
+  async clear(type: CacheResourceType): Promise<CacheResult<null>> {
+    const r = await AndroidCache.clear({ type: mapType(type) });
+    return { success: r.success, data: null };
   }
 
-  /**
-   * 清空指定类型的缓存目录
-   * @param type 缓存资源类型
-   */
-  clear(type: CacheResourceType): Promise<CacheResult<null>> {
-    return this.invoke("cache-clear", type);
+  async clearAll(): Promise<CacheResult<null>> {
+    const r = await AndroidCache.clearAll();
+    return { success: r.success, data: null };
   }
 
-  /**
-   * 清空所有缓存
-   */
-  clearAll(): Promise<CacheResult<null>> {
-    return this.invoke("cache-clear-all");
+  async getSize(): Promise<CacheResult<number>> {
+    try {
+      const stats = await AndroidCache.getStats();
+      return { success: true, data: stats.totalBytes };
+    } catch (e: any) {
+      return { success: false, message: String(e?.message ?? e) };
+    }
   }
 
-  /**
-   * 获取所有缓存类型的总大小（字节）
-   */
-  getSize(): Promise<CacheResult<number>> {
-    return this.invoke("cache-size");
+  async getStats(): Promise<
+    CacheResult<{
+      totalBytes: number;
+      deviceFreeBytes: number;
+      maxBytes: number;
+      /** 设备空间不足时的运行期生效上限（min(maxBytes, deviceFreeBytes * 0.6)） */
+      effectiveMaxBytes: number;
+      perType: Partial<Record<CacheResourceType, number>>;
+    }>
+  > {
+    try {
+      const stats = await AndroidCache.getStats();
+      return {
+        success: true,
+        data: {
+          totalBytes: stats.totalBytes,
+          deviceFreeBytes: stats.deviceFreeBytes,
+          maxBytes: stats.maxBytes,
+          // 老版本 native 端无此字段时 fallback 到 maxBytes（向前兼容）
+          effectiveMaxBytes: stats.effectiveMaxBytes ?? stats.maxBytes,
+          // exo 子目录映射回业务类型 music
+          perType: {
+            lyrics: stats.perType.lyrics,
+            covers: stats.perType.covers,
+            "list-covers": stats.perType["list-covers"],
+            "list-data": stats.perType["list-data"],
+            music: stats.perType.exo,
+          },
+        },
+      };
+    } catch (e: any) {
+      return { success: false, message: String(e?.message ?? e) };
+    }
+  }
+
+  async setMaxBytes(maxBytes: number): Promise<CacheResult<{ appliedMaxBytes: number }>> {
+    try {
+      const r = await AndroidCache.setMaxBytes({ maxBytes });
+      return { success: r.success, data: { appliedMaxBytes: r.appliedMaxBytes } };
+    } catch (e: any) {
+      return { success: false, message: String(e?.message ?? e) };
+    }
+  }
+
+  async enforceLimit(): Promise<CacheResult<{ totalBytes: number }>> {
+    try {
+      const r = await AndroidCache.enforceLimit();
+      return { success: r.success, data: { totalBytes: r.totalBytes } };
+    } catch (e: any) {
+      return { success: false, message: String(e?.message ?? e) };
+    }
   }
 }
 
 let cacheManager: CacheManager | null = null;
 
-/**
- * 获取全局单例的缓存管理器
- * @returns CacheManager 实例
- */
+/** 获取全局单例的缓存管理器。 */
 export const useCacheManager = (): CacheManager => {
   if (!cacheManager) cacheManager = new CacheManager();
   return cacheManager;

--- a/src/plugins/androidCache.ts
+++ b/src/plugins/androidCache.ts
@@ -1,0 +1,59 @@
+import { registerPlugin } from "@capacitor/core";
+
+/** 缓存类型与 Java 端 CacheStorage.TYPE_* 保持一致 */
+export type AndroidCacheType = "lyrics" | "covers" | "list-covers" | "list-data" | "exo";
+
+export interface AndroidCacheReadResult {
+  hit: boolean;
+  /** base64 编码的二进制数据；hit=false 时不存在 */
+  data?: string;
+  size?: number;
+}
+
+export interface AndroidCacheWriteResult {
+  success: boolean;
+  message?: string;
+}
+
+export interface AndroidCacheListEntry {
+  key: string;
+  size: number;
+  /** 毫秒时间戳 */
+  mtime: number;
+}
+
+export interface AndroidCacheStats {
+  totalBytes: number;
+  /** 设备剩余可用字节（StatFs.getAvailableBytes()）；-1 表示读取失败 */
+  deviceFreeBytes: number;
+  /** 用户设定的原始上限（不含设备容量自适应） */
+  maxBytes: number;
+  /**
+   * 运行期有效上限：设备空间不足时会自动降到 `deviceFreeBytes * 0.6`，<br>
+   * 高于用户设定时仍以用户设定为准。enforceLimit 走的就是此值。
+   */
+  effectiveMaxBytes: number;
+  /** 各类型分项占用 */
+  perType: Record<AndroidCacheType, number>;
+}
+
+export interface AndroidCachePlugin {
+  read(options: { type: AndroidCacheType; key: string }): Promise<AndroidCacheReadResult>;
+  /** data 必须是 base64 编码的字符串 */
+  write(options: {
+    type: AndroidCacheType;
+    key: string;
+    data: string;
+  }): Promise<AndroidCacheWriteResult>;
+  remove(options: { type: AndroidCacheType; key: string }): Promise<{ success: boolean }>;
+  list(options: { type: AndroidCacheType }): Promise<{ entries: AndroidCacheListEntry[] }>;
+  clear(options: { type: AndroidCacheType }): Promise<{ success: boolean }>;
+  clearAll(): Promise<{ success: boolean }>;
+  getStats(): Promise<AndroidCacheStats>;
+  setMaxBytes(options: {
+    maxBytes: number;
+  }): Promise<{ success: boolean; appliedMaxBytes: number }>;
+  enforceLimit(): Promise<{ success: boolean; totalBytes: number }>;
+}
+
+export const AndroidCache = registerPlugin<AndroidCachePlugin>("AndroidCache");

--- a/src/plugins/androidNativePlayback.ts
+++ b/src/plugins/androidNativePlayback.ts
@@ -82,6 +82,11 @@ export interface AndroidNativeQueueContextPayload {
    * Java 端据此区分本次推送是否为续播触发，避免 liked / 桌面歌词等无关 sync 误消费 pendingResumeAfterRefill。
    */
   windowRefilled?: boolean;
+  /**
+   * 是否为「末尾 ALL wrap」推送：JS 已把 playIndex 重置为 0，windowCurrentIndex 直接指向应播曲。<br>
+   * Java 端据此选择 current()（true）或 advanceRaw(false)（false）以避免跳过 track 0（修复 #3）。
+   */
+  windowResetFromWrap?: boolean;
 }
 
 export interface AndroidNativeNotificationPrefsPayload {
@@ -231,6 +236,11 @@ export interface AndroidNativePlaybackPlugin {
    * 关闭时 Java 端 listener=null 直接跳过 FFT 计算，CPU 占用归零。
    */
   enableVisualizer(options: { enable: boolean }): Promise<AndroidNativePermissionResult>;
+  /**
+   * 预下载音频前 512 KB 到 ExoPlayer SimpleCache。fire-and-forget，立即 resolve。
+   * 同 url 并发去重；切歌时未完成的预下载会自动取消让带宽。
+   */
+  prefetchAudio(options: { url: string }): Promise<void>;
   addListener(
     eventName: "playbackStateChanged",
     listenerFunc: (event: AndroidNativePlaybackStateEvent) => void,

--- a/src/stores/data.ts
+++ b/src/stores/data.ts
@@ -349,9 +349,9 @@ export const useDataStore = defineStore("data", {
         const updatedList = [song, ...historyList.filter((item) => item.id !== song.id)];
         // 最多 500 首
         if (updatedList.length > 500) updatedList.splice(500);
-        // 存储
         markMusicDirty("historyList");
-        await getMusicDB().setItem("historyList", cloneDeep(toRaw(updatedList)));
+        const rawList = updatedList.map((s) => toRaw(s));
+        await getMusicDB().setItem("historyList", rawList);
         this.historyList = markRaw(updatedList);
       } catch (error) {
         console.error("Error updating history:", error);

--- a/src/stores/setting.ts
+++ b/src/stores/setting.ts
@@ -107,6 +107,11 @@ export interface SettingState {
   cacheEnabled: boolean;
   /** 是否缓存歌曲（音频文件） */
   songCacheEnabled: boolean;
+  /**
+   * 最大缓存上限（MB）。仅 Android 端生效。
+   * 默认 5120 MB = 5 GB；下限 256 MB；无代码硬上限（超过 freeBytes×0.9 仅二次确认，不阻拦）。
+   */
+  maxCacheSizeMB: number;
   /** 音乐命名格式 */
   fileNameFormat: "title" | "artist-title" | "title-artist";
   /** 文件智能分类 */
@@ -661,6 +666,7 @@ export const useSettingStore = defineStore("setting", {
     downloadThreadCount: 8,
     cacheEnabled: true,
     songCacheEnabled: true,
+    maxCacheSizeMB: 5120,
     fileNameFormat: "title-artist",
     folderStrategy: "none",
     downloadMeta: true,

--- a/src/views/Download/downloading.vue
+++ b/src/views/Download/downloading.vue
@@ -23,7 +23,11 @@
             </div>
             <!-- 标题 (封面 + 信息) -->
             <div class="title">
-              <s-image :src="item.song.coverSize?.s || item.song.cover" class="cover" />
+              <s-image
+                :src="item.song.coverSize?.s || item.song.cover"
+                cache-type="covers"
+                class="cover"
+              />
               <div class="info">
                 <div class="name">
                   <n-text class="name-text" ellipsis>{{ item.song.name }}</n-text>

--- a/src/views/Home/HomeMobile.vue
+++ b/src/views/Home/HomeMobile.vue
@@ -44,7 +44,7 @@
           @click="router.push({ path: `/playlist`, query: { id: item.id } })"
         >
           <div class="playlist-cover">
-            <s-image :src="item.cover" class="cover-img" />
+            <s-image :src="item.cover" cache-type="list-covers" class="cover-img" />
             <div class="play-count">
               <SvgIcon name="Play" :size="12" />
               {{ formatPlayCount(item.playCount) }}
@@ -71,7 +71,7 @@
           @click="router.push({ path: `/album`, query: { id: item.id } })"
         >
           <div class="album-cover">
-            <s-image :src="item.cover" class="cover-img" />
+            <s-image :src="item.cover" cache-type="list-covers" class="cover-img" />
           </div>
           <div class="album-name">{{ item.name }}</div>
           <div class="album-artist">{{ item.artist }}</div>
@@ -95,7 +95,7 @@
           @click="router.push({ path: `/artist`, query: { id: item.id } })"
         >
           <div class="artist-avatar">
-            <s-image :src="item.cover" class="avatar-img" />
+            <s-image :src="item.cover" cache-type="list-covers" class="avatar-img" />
           </div>
           <div class="artist-name">{{ item.name }}</div>
         </div>
@@ -118,7 +118,7 @@
           @click="router.push({ path: `/video`, query: { id: item.id } })"
         >
           <div class="video-cover">
-            <s-image :src="item.cover" class="cover-img" />
+            <s-image :src="item.cover" cache-type="list-covers" class="cover-img" />
             <div class="video-duration">{{ item.duration }}</div>
             <div class="play-overlay">
               <SvgIcon name="Play" :size="32" />
@@ -141,7 +141,7 @@
     <div v-if="error" class="error-state">
       <n-empty description="加载失败，请检查网络连接" size="large">
         <template #extra>
-          <n-button @click="loadAllData">重新加载</n-button>
+          <n-button @click="() => loadAllData(true)">重新加载</n-button>
         </template>
       </n-empty>
     </div>
@@ -153,12 +153,28 @@ import { useDataStore, useSettingStore } from "@/stores";
 import { personalized, newAlbumsAll, topArtists } from "@/api/rec";
 import { allMv } from "@/api/video";
 import { isLogin } from "@/utils/auth";
+import { useCacheManager } from "@/core/resource/CacheManager";
+import { prefetchListCovers } from "@/composables/useCoverCache";
 import SvgIcon from "@/components/Global/SvgIcon.vue";
 import SImage from "@/components/UI/s-image.vue";
 
 const router = useRouter();
 const dataStore = useDataStore();
 const settingStore = useSettingStore();
+const cacheManager = useCacheManager();
+
+/** 首页推荐缓存键。复用 list-data 桶；过期 6 小时（推荐数据非强一致，背景刷新即可）。 */
+const HOME_REC_CACHE_KEY = "home-rec.json";
+const HOME_REC_TTL_MS = 6 * 60 * 60 * 1000;
+interface HomeRecCache {
+  version: number;
+  timestamp: number;
+  playlist: any[];
+  album: any[];
+  artist: any[];
+  video: any[];
+}
+const HOME_REC_VERSION = 1;
 
 // 加载状态
 const loading = ref(false);
@@ -180,10 +196,65 @@ const formatPlayCount = (count: number) => {
   return count.toString();
 };
 
+/** 命中本地缓存：立刻渲染，不显 loading；失败 / 过期返 false 让网络请求接管。 */
+const tryLoadFromCache = async (): Promise<boolean> => {
+  try {
+    const r = await cacheManager.get("list-data", HOME_REC_CACHE_KEY);
+    if (!r.success || !r.data) return false;
+    const json = new TextDecoder().decode(r.data);
+    const c = JSON.parse(json) as HomeRecCache;
+    if (c.version !== HOME_REC_VERSION) return false;
+    if (Date.now() - c.timestamp > HOME_REC_TTL_MS) return false;
+    playlistRec.value = c.playlist || [];
+    albumRec.value = c.album || [];
+    artistRec.value = c.artist || [];
+    videoRec.value = c.video || [];
+    // 进入页面立刻预热可视区域封面（4 个区块前 6 张足够）
+    prefetchListCovers(playlistRec.value, "list-covers", 6);
+    prefetchListCovers(albumRec.value, "list-covers", 6);
+    prefetchListCovers(artistRec.value, "list-covers", 6);
+    prefetchListCovers(videoRec.value, "list-covers", 6);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const persistRecCache = async () => {
+  const c: HomeRecCache = {
+    version: HOME_REC_VERSION,
+    timestamp: Date.now(),
+    playlist: playlistRec.value,
+    album: albumRec.value,
+    artist: artistRec.value,
+    video: videoRec.value,
+  };
+  try {
+    await cacheManager.set("list-data", HOME_REC_CACHE_KEY, JSON.stringify(c));
+  } catch (e) {
+    console.warn("[HomeMobile] persist rec cache failed", e);
+  }
+};
+
 // 加载所有数据
-const loadAllData = async () => {
-  loading.value = true;
-  error.value = false;
+const loadAllData = async (forceRefresh: boolean = false) => {
+  // 1. 先尝试缓存（命中则立即显示，避免冷启动等待 4 个 API）
+  if (!forceRefresh) {
+    const hit = await tryLoadFromCache();
+    if (hit) {
+      // 后台静默刷新，不显 loading
+      void fetchFromNetwork(/* silent= */ true);
+      return;
+    }
+  }
+  await fetchFromNetwork(false);
+};
+
+const fetchFromNetwork = async (silent: boolean) => {
+  if (!silent) {
+    loading.value = true;
+    error.value = false;
+  }
 
   try {
     // 并行加载所有数据
@@ -232,6 +303,13 @@ const loadAllData = async () => {
       duration: mv.duration,
     }));
 
+    // 入档本地缓存 + 预热封面
+    void persistRecCache();
+    prefetchListCovers(playlistRec.value, "list-covers", 6);
+    prefetchListCovers(albumRec.value, "list-covers", 6);
+    prefetchListCovers(artistRec.value, "list-covers", 6);
+    prefetchListCovers(videoRec.value, "list-covers", 6);
+
     console.log("数据加载成功:", {
       playlist: playlistRec.value.length,
       album: albumRec.value.length,
@@ -240,9 +318,9 @@ const loadAllData = async () => {
     });
   } catch (err) {
     console.error("加载数据失败:", err);
-    error.value = true;
+    if (!silent) error.value = true;
   } finally {
-    loading.value = false;
+    if (!silent) loading.value = false;
   }
 };
 

--- a/src/views/List/playlist.vue
+++ b/src/views/List/playlist.vue
@@ -356,6 +356,21 @@ const handleOnlinePlaylist = async (id: number, getList: boolean, refresh: boole
       setListData(cached.songs);
       setLoading(false);
 
+      // 修复 #9：partial cache 走续传路径，不丢弃已有 songs。
+      // 续传从 cached.songs.length 偏移开始，避免重拉前 N 首已经有的数据。
+      if (!cached.complete) {
+        const total = cached.detail?.count || 0;
+        const startOffset = cached.songs.length;
+        if (total > 0 && startOffset < total) {
+          console.log(
+            `🔄 Resume partial playlist: ${startOffset}/${total} cached, continuing...`,
+          );
+          // fire-and-forget：UI 已显示缓存数据，续传在后台拉剩余页
+          void getPlaylistAllSongs(id, total, /* refresh= */ false, /* startOffset= */ startOffset);
+          return;
+        }
+      }
+
       // 后台检查更新
       backgroundCheck(id, cached);
       return;
@@ -415,14 +430,20 @@ const getPlaylistAllSongs = async (
   count: number,
   // 是否为刷新列表
   refresh: boolean = false,
+  // 续传起始 offset（修复 #9）：从已缓存条数开始拉，避免全量重拉
+  startOffset: number = 0,
 ) => {
   setLoading(true);
   // 加载提示
   loadingMsgShow(!refresh, count);
   // 循环获取
-  let offset: number = 0;
+  let offset: number = startOffset;
   const limit: number = 500;
-  const listDataArray: SongType[] = [];
+  // 续传场景下，把已有 listData 作为基底；非续传场景下从空开始
+  const listDataArray: SongType[] = startOffset > 0 ? [...listData.value] : [];
+  // 节流参数（修复 #6 O(N²) 序列化）：首次必存 + ≥2s 才存 + 最后一页必存
+  let lastSaveAt = 0;
+  const SAVE_THROTTLE_MS = 2000;
   do {
     // 检查是否仍然是当前请求的歌单
     if (currentRequestId.value !== id) {
@@ -442,6 +463,17 @@ const getPlaylistAllSongs = async (
     }
     // 更新数据
     offset += limit;
+    // 增量保存缓存（节流：避免 O(N²) 序列化）
+    const isLastPage = offset >= count;
+    const now = Date.now();
+    const shouldSave =
+      detailData.value &&
+      listDataArray.length > 0 &&
+      (lastSaveAt === 0 || isLastPage || now - lastSaveAt >= SAVE_THROTTLE_MS);
+    if (shouldSave && detailData.value) {
+      saveCache("playlist", id, detailData.value, listDataArray, isLastPage);
+      lastSaveAt = now;
+    }
   } while (offset < count && isPlaylistPage.value && currentRequestId.value === id);
   // 最终检查是否仍然是当前请求的歌单
   if (currentRequestId.value !== id) {
@@ -449,11 +481,6 @@ const getPlaylistAllSongs = async (
     return;
   }
   if (refresh) setListData(listDataArray);
-  // 保存缓存
-  if (detailData.value && listDataArray.length > 0) {
-    saveCache("playlist", id, detailData.value, listDataArray);
-  }
-
   // 关闭加载
   loadingMsgShow(false);
 };

--- a/src/views/List/radio.vue
+++ b/src/views/List/radio.vue
@@ -250,6 +250,9 @@ const getRadioAllProgram = async (id: number, count: number) => {
   // 循环获取
   let offset: number = 0;
   const limit: number = 500;
+  // 节流参数（修复 #6 O(N²) 序列化）
+  let lastSaveAt = 0;
+  const SAVE_THROTTLE_MS = 2000;
   do {
     if (currentRequestId.value !== id) {
       loadingMsgShow(false);
@@ -264,16 +267,24 @@ const getRadioAllProgram = async (id: number, count: number) => {
     appendListData(songData);
     // 更新数据
     offset += limit;
+    // 增量保存缓存（节流：避免 O(N²) 序列化）
+    {
+      const isLastPage = offset >= count;
+      const now = Date.now();
+      const shouldSave =
+        detailData.value &&
+        listData.value.length > 0 &&
+        (lastSaveAt === 0 || isLastPage || now - lastSaveAt >= SAVE_THROTTLE_MS);
+      if (shouldSave && detailData.value) {
+        saveCache("radio", id, detailData.value, listData.value, isLastPage);
+        lastSaveAt = now;
+      }
+    }
   } while (offset < count && isPlaylistPage.value && currentRequestId.value === id);
   if (currentRequestId.value !== id) {
     loadingMsgShow(false);
     return;
   }
-  // 保存缓存
-  if (detailData.value && listData.value.length > 0) {
-    saveCache("radio", id, detailData.value, listData.value);
-  }
-
   // 关闭加载
   loadingMsgShow(false);
 };

--- a/src/views/List/streaming-playlist.vue
+++ b/src/views/List/streaming-playlist.vue
@@ -45,6 +45,7 @@ import { useListDetail } from "@/composables/List/useListDetail";
 import { useListSearch } from "@/composables/List/useListSearch";
 import { useListScroll } from "@/composables/List/useListScroll";
 import { useListActions } from "@/composables/List/useListActions";
+import { useListDataCache } from "@/composables/List/useListDataCache";
 
 const router = useRouter();
 const streamingStore = useStreamingStore();
@@ -55,6 +56,7 @@ const { searchValue, searchData, displayData, clearSearch, performSearch } =
   useListSearch(listData);
 const { listScrolling, handleListScroll, resetScroll } = useListScroll();
 const { playAllSongs: playAllSongsAction } = useListActions();
+const { saveCache, loadCache } = useListDataCache();
 
 // 歌单 ID
 const playlistId = computed<string>(() => router.currentRoute.value.query.id as string);
@@ -97,17 +99,33 @@ const moreOptions = computed<DropdownOption[]>(() => [
 ]);
 
 // 获取歌单详情
-const getPlaylistDetail = async (id: string) => {
+const getPlaylistDetail = async (id: string, refresh: boolean = false) => {
   if (!id) return;
-
-  if (!streamingStore.isConnected.value) {
-    window.$message.error("流媒体服务器未连接");
-    return;
-  }
 
   setLoading(true);
   clearSearch();
   resetScroll();
+
+  // 1. 先尝试本地缓存（流媒体可能离线，缓存命中可立即显示）
+  if (!refresh) {
+    const cached = await loadCache("streaming-playlist", id);
+    if (cached) {
+      setDetailData(cached.detail);
+      setListData(cached.songs);
+      setLoading(false);
+      // 后台刷新（仅当流媒体已连接）
+      if (streamingStore.isConnected.value) {
+        void backgroundRefresh(id);
+      }
+      return;
+    }
+  }
+
+  if (!streamingStore.isConnected.value) {
+    window.$message.error("流媒体服务器未连接");
+    setLoading(false);
+    return;
+  }
 
   try {
     // 从缓存的歌单列表中查找歌单信息
@@ -130,11 +148,40 @@ const getPlaylistDetail = async (id: string) => {
     if (detailData.value && detailData.value.count === 0) {
       detailData.value.count = songs.length;
     }
+
+    // 写入本地缓存（仅当 detail 存在）
+    if (detailData.value) {
+      saveCache("streaming-playlist", id, detailData.value, songs);
+    }
   } catch (error) {
     console.error("Failed to fetch streaming playlist:", error);
     window.$message.error("获取歌单详情失败");
   } finally {
     setLoading(false);
+  }
+};
+
+// 后台静默刷新：缓存命中时使用，不阻塞 UI
+const backgroundRefresh = async (id: string) => {
+  try {
+    const playlist = streamingStore.playlists.value.find((p) => p.id === id);
+    if (playlist) {
+      setDetailData({
+        id: Number(playlist.id) || 0,
+        name: playlist.name,
+        cover: playlist.cover || "/images/album.jpg?asset",
+        description: playlist.description,
+        count: playlist.songCount || 0,
+      } as CoverType);
+    }
+    const songs = await streamingStore.fetchPlaylistSongs(id);
+    setListData(songs);
+    if (detailData.value) {
+      saveCache("streaming-playlist", id, detailData.value, songs);
+    }
+  } catch (e) {
+    // 后台刷新失败不打扰用户：缓存数据仍可用
+    console.warn("[streaming-playlist] background refresh failed", e);
   }
 };
 

--- a/src/views/Local/albums.vue
+++ b/src/views/Local/albums.vue
@@ -16,6 +16,7 @@
             v-if="!settingStore.hiddenCovers.album"
             :key="item?.[0]?.cover"
             :src="item?.[0]?.cover || '/images/album.jpg?asset'"
+            cache-type="list-covers"
             class="cover"
           />
         </Transition>

--- a/src/views/Streaming/albums.vue
+++ b/src/views/Streaming/albums.vue
@@ -12,6 +12,7 @@
           <s-image
             :key="item?.[0]?.cover"
             :src="item?.[0]?.cover || '/images/album.jpg?asset'"
+            cache-type="list-covers"
             class="cover"
           />
         </Transition>


### PR DESCRIPTION
## 📌 变更类型

- [x] ✨ feat — 新功能
- [x] 🐞 fix — Bug 修复
- [ ] 🎨 style — 仅样式 / 格式，不影响逻辑
- [x] ♻️ refactor — 重构，不改变外部行为
- [x] ⚡ perf — 性能优化
- [ ] 📝 docs — 仅文档
- [ ] 🧪 test — 新增 / 修改测试
- [ ] 🔧 chore — 构建 / 脚本 / 依赖
- [ ] 🚀 ci — 仅 CI 配置
- [ ] ⏪ revert — 回滚

## 📝 变更说明

本次提交是一次围绕「Android 端缓存与播放体验」的综合升级，跨 Vue 渲染层、Capacitor 桥层、Android 原生层三端协同：

### 1. 原生缓存基础设施（新增）
- 新增 Android 原生缓存插件：`封面 / 歌词 / 列表数据` 全部走本地 LRU；支持自定义缓存上限（最低 256 MB，可设小数）与自动驱逐最久未访问条目
- 设置面板新增「缓存大小上限 + 总占用统计 + 分项清理」入口，实时显示设备剩余空间与生效上限
- 流媒体（Jellyfin / Navidrome 等）场景接入本地缓存兜底，离线也可查看已缓存歌单详情

### 2. 图片加载缓存化
- `SImage` 组件新增 `cacheType` 参数，按调用点声明缓存域（`covers` / `list-covers` / `none`），命中后复用 Blob URL，减少重复网络请求与首屏抖动
- 内存级 LRU 引用计数：`memoryHitGet/Put/Release` 三态生命周期，配合卸载时主动 release，避免内存泄漏

### 3. 音频缓存与预加载
- ExoPlayer SimpleCache 接入：所有 http(s) 音频统一走 `CacheDataSource`；[resolveCacheKey](cci:1://file:///d:/a/SPlayer-for-Android/android/app/src/main/java/top/imsyy/splayer/android/cache/AudioCacheProvider.java:175:2-222:3) 提取音频文件名作为稳定 key，跨签名 URL 也能命中
- 切歌秒级响应：下一首音频预下载首 512 KB，命中后 ExoPlayer 直接读盘
- promotion 机制：用户连续播放 ≥ 10 秒视为「真喜欢」，触发完整下载并对照 `Content-Length` 严格校验后标记 promoted（automix 与离线场景的可信源）

### 4. 歌词渲染性能
- 使用 `requestIdleCallback` 异步构建歌词动画，避免在切歌热路径阻塞主线程

### 5. Bug 修复
- 修复歌单 / 电台序列化 O(N²) 性能问题（首次必存 + ≥ 2 s 节流 + 末页必存）
- 修复歌单续传：partial cache 不再触发全量重拉，从 `cached.songs.length` 偏移续传
- 修复 Android 后台 ENDED 续播跳过首曲：末尾 ALL wrap 时改用 `current()`，常规右滑窗口仍走 `advanceRaw(false)`
- 修复原生切歌后 `currentAudioSource` 滞留导致下一首 URL 推错
- 修复封面 pending download 共享 Promise 的引用计数泄漏（多个组件 release 同一份 retain）
- 修复 prefetch 截断文件被错误 promote 的隐患（promote 前比对 `cache.getCachedBytes` vs `ContentMetadata.getContentLength`）
- 收紧 `allowBackup` 备份范围：排除 WebView 存储 / 登录 cookie / Capacitor SharedPreferences，避免跨设备恢复泄露账号会话

## 🔗 关联 Issue

Closes #

## 📱 影响范围

- [x] 🎵 播放引擎 / 音频
- [x] 📝 歌词 / 桌面歌词
- [x] 🔔 通知栏 / MediaSession
- [x] 🌐 在线音乐 (网易云 / Jellyfin / Navidrome / Emby / Subsonic / Last.fm)
- [ ] 🧩 内置 API (nodejs-mobile)
- [x] 🎨 UI / 主题 / 布局
- [ ] 📦 构建 / 打包 / 签名
- [x] 📱 Capacitor / 原生 Android 代码
- [ ] 📄 文档 / README

## ✅ 自检清单

- [x] 本 PR **目标分支为 `dev`**
- [x] 本地已执行 `pnpm lint` 且无 warning
- [x] 本地已执行 `pnpm typecheck` 且无报错
- [x] 已在 **至少一台真机** 上构建并验证关键路径
- [x] UI 改动已兼顾 **手机竖屏 + 平板横屏** 两种布局
- [x] 新增 / 修改的文案使用中文，与项目整体风格一致
- [x] 未引入不必要的依赖 / 大体积资源
- [x] 未修改签名密钥 / CI Secrets 相关文件

## 📸 截图 / 录屏

| 改动前 | 改动后 |
| :----: | :----: |
|  （缓存设置面板缺失） | （新增上限/占用/分项清理） |
|  （切歌等待 1-3 s）   | （秒级响应，预载命中无网络） |
|  （末尾循环跳第 0 首） | （正确从 track 0 开始）   |

## 🧪 测试方式

1. **缓存基础**：进入「设置 → 本地缓存」，调整上限到 256 MB，播放并查看「缓存总占用」实时变化；点「清空音频缓存」后再播放确认重新落盘
2. **图片缓存**：进入歌单 / 专辑详情查看封面，断网后重新打开同一页，封面仍从本地 Blob URL 加载（不再有占位抖动）
3. **音频预载**：连续播放两首，第二首点击 → 立即起播无 buffering（adb logcat 可见 `prefetch done`）；同一首再播一遍，无 HTTP upstream 日志
4. **续传**：进入超长歌单（>1000 首），未加载完即返回，再次进入应在已有数据基础上接着拉，不丢列表
5. **后台播放**：锁屏 / 切到其他应用，自动播下一首时通知栏标题、按键状态正确同步
6. **隐私**：使用 `adb backup -f x.ab <pkg>` 后用 `abe.jar` 解包，确认 `app_webview/` 与 `CapacitorStorage.xml` 不在备份内容中

## 💬 其他说明

- **跨语言契约**：[updateQueueContext](cci:1://file:///d:/a/SPlayer-for-Android/src/plugins/androidNativePlayback.ts:213:2-213:78) 新增 `windowResetFromWrap` 字段，JS / Java 同步落地；旧版混用时降级为默认 false，行为退回原 `advanceRaw` 路径（不致命）
- **promote 严格校验** 仅在 upstream 提供 Content-Length 时生效；chunked encoding 等无长度场景按现行 EOF 行为信任，符合 best-effort 语义
- **缓存键策略**：当前以文件名末段为主键，覆盖网易云 / 多数 CDN；若后续接入特殊 CDN（无标准音频后缀），可在 [resolveCacheKey](cci:1://file:///d:/a/SPlayer-for-Android/android/app/src/main/java/top/imsyy/splayer/android/cache/AudioCacheProvider.java:175:2-222:3) 的回退分支扩展