### PR TITLE
refactor: 移动端适配、Android播放优化与本地功能完善

### DIFF
--- a/android/app/src/main/java/top/imsyy/splayer/android/cache/AudioCacheProvider.java
+++ b/android/app/src/main/java/top/imsyy/splayer/android/cache/AudioCacheProvider.java
@@ -5,10 +5,13 @@ import android.net.Uri;
 import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.media3.common.C;
 import androidx.media3.database.StandaloneDatabaseProvider;
 import androidx.media3.datasource.DataSource;
 import androidx.media3.datasource.DataSpec;
+import androidx.media3.datasource.DefaultDataSource;
 import androidx.media3.datasource.DefaultHttpDataSource;
+import androidx.media3.datasource.TransferListener;
 import androidx.media3.datasource.cache.CacheDataSink;
 import androidx.media3.datasource.cache.CacheDataSource;
 import androidx.media3.datasource.cache.CacheSpan;
@@ -128,24 +131,36 @@ public final class AudioCacheProvider {
   public static DataSource.Factory buildCachedDataSourceFactory(@NonNull Context appContext) {
     SimpleCache cache = getOrCreate(appContext);
 
-    DataSource.Factory upstreamFactory =
+    DataSource.Factory httpFactory =
         new DefaultHttpDataSource.Factory()
             .setAllowCrossProtocolRedirects(true)
             .setConnectTimeoutMs(15_000)
-            .setReadTimeoutMs(15_000)
-            .setUserAgent("SPlayer-Android/1.0");
+            .setReadTimeoutMs(15_000);
 
-    // 写入器：把 upstream 拉到的字节落到 SimpleCache。fragmentSize=MAX 让单首歌只产生 1 个文件
+    // http(s) 走 CacheDataSource；本地 file:// / content:// 直接 DefaultDataSource，
+    // 避免本地文件被复制一份到 cacheDir/exo/。
+    DataSource.Factory httpCacheFactory = buildHttpCacheFactory(appContext, httpFactory, cache);
+    DataSource.Factory localFactory = new DefaultDataSource.Factory(appContext);
+
+    return () -> new SchemeRoutingDataSource(httpCacheFactory, localFactory);
+  }
+
+  /**
+   * 构造仅用于 http(s) 的 CacheDataSource 工厂；prefetch 路径直接使用此工厂，
+   * 以便 {@code (CacheDataSource) ds} 强转保持有效。
+   */
+  @NonNull
+  private static DataSource.Factory buildHttpCacheFactory(
+      @NonNull Context appContext,
+      @NonNull DataSource.Factory httpFactory,
+      @NonNull SimpleCache cache) {
     CacheDataSink.Factory cacheSinkFactory =
         new CacheDataSink.Factory().setCache(cache).setFragmentSize(Long.MAX_VALUE);
-
-    // 包装为动态 Factory：每次 createDataSource 重新判断是否低磁盘，
-    // 低磁盘时不传 sinkFactory → CacheDataSource 只读不写，已缓存仍可命中，新字节不落盘。
     return () -> {
       CacheDataSource.Factory cf =
           new CacheDataSource.Factory()
               .setCache(cache)
-              .setUpstreamDataSourceFactory(upstreamFactory)
+              .setUpstreamDataSourceFactory(httpFactory)
               .setCacheKeyFactory(spec -> resolveCacheKey(spec.uri))
               .setFlags(
                   CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR
@@ -157,6 +172,104 @@ public final class AudioCacheProvider {
       }
       return cf.createDataSource();
     };
+  }
+
+  /**
+   * 内部使用：prefetch / CacheWriter 路径专用的 CacheDataSource 工厂。
+   * 始终返回 CacheDataSource 实例（http 上游 + cache 落盘），不做 scheme 路由。
+   */
+  @NonNull
+  static DataSource.Factory buildHttpCacheFactoryForPrefetch(@NonNull Context appContext) {
+    SimpleCache cache = getOrCreate(appContext);
+    DataSource.Factory httpFactory =
+        new DefaultHttpDataSource.Factory()
+            .setAllowCrossProtocolRedirects(true)
+            .setConnectTimeoutMs(15_000)
+            .setReadTimeoutMs(15_000);
+    return buildHttpCacheFactory(appContext, httpFactory, cache);
+  }
+
+  /**
+   * 根据首次 open 的 DataSpec scheme 选择 http cache 或本地直读。<br>
+   * 同一实例的多次 open 不应跨 scheme（ExoPlayer 不会复用 DataSource 跨 MediaItem），
+   * 这里仍按每次 open 重新选择以稳健处理边界情况。
+   */
+  private static final class SchemeRoutingDataSource implements DataSource {
+    private final DataSource.Factory httpCacheFactory;
+    private final DataSource.Factory localFactory;
+    private final java.util.List<TransferListener> pendingListeners = new java.util.ArrayList<>();
+    private final Object routeLock = new Object();
+    @Nullable private volatile DataSource current;
+
+    SchemeRoutingDataSource(
+        @NonNull DataSource.Factory httpCacheFactory, @NonNull DataSource.Factory localFactory) {
+      this.httpCacheFactory = httpCacheFactory;
+      this.localFactory = localFactory;
+    }
+
+    @Override
+    public void addTransferListener(@NonNull TransferListener transferListener) {
+      DataSource ds;
+      synchronized (routeLock) {
+        ds = current;
+        if (ds == null) {
+          pendingListeners.add(transferListener);
+        }
+      }
+      if (ds != null) ds.addTransferListener(transferListener);
+    }
+
+    @Override
+    public long open(@NonNull DataSpec dataSpec) throws java.io.IOException {
+      DataSource previous;
+      synchronized (routeLock) {
+        previous = current;
+        current = null;
+      }
+      if (previous != null) {
+        try {
+          previous.close();
+        } catch (java.io.IOException ignored) {
+        }
+      }
+      String scheme = dataSpec.uri.getScheme();
+      boolean isHttp = "http".equals(scheme) || "https".equals(scheme);
+      DataSource ds = isHttp ? httpCacheFactory.createDataSource() : localFactory.createDataSource();
+      synchronized (routeLock) {
+        for (TransferListener listener : pendingListeners) {
+          ds.addTransferListener(listener);
+        }
+        pendingListeners.clear();
+        current = ds;
+      }
+      return ds.open(dataSpec);
+    }
+
+    @Override
+    public int read(@NonNull byte[] buffer, int offset, int length) throws java.io.IOException {
+      DataSource ds = current;
+      if (ds == null) return C.RESULT_END_OF_INPUT;
+      return ds.read(buffer, offset, length);
+    }
+
+    @Nullable
+    @Override
+    public Uri getUri() {
+      DataSource ds = current;
+      return ds == null ? null : ds.getUri();
+    }
+
+    @Override
+    public void close() throws java.io.IOException {
+      DataSource ds;
+      synchronized (routeLock) {
+        ds = current;
+        current = null;
+      }
+      if (ds != null) {
+        ds.close();
+      }
+    }
   }
 
   /** 已知的临时签名 / 过期参数：仅这些会被剔除以保证同曲目缓存命中。其余 query 参与 key 防碰撞。 */
@@ -384,7 +497,7 @@ public final class AudioCacheProvider {
       final Object writerLock = cacheKeyWriterLocks.computeIfAbsent(cacheKey, k -> new Object());
       try {
         synchronized (writerLock) {
-          DataSource.Factory factory = buildCachedDataSourceFactory(appContext);
+          DataSource.Factory factory = buildHttpCacheFactoryForPrefetch(appContext);
           DataSource ds = factory.createDataSource();
           DataSpec.Builder specBuilder =
               new DataSpec.Builder().setUri(uri).setKey(cacheKey).setPosition(0);

--- a/android/app/src/main/java/top/imsyy/splayer/android/download/AndroidDownloadPlugin.java
+++ b/android/app/src/main/java/top/imsyy/splayer/android/download/AndroidDownloadPlugin.java
@@ -4,6 +4,8 @@ import android.app.DownloadManager;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.database.Cursor;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.media.MediaMetadataRetriever;
 import android.net.Uri;
 import android.os.Environment;
@@ -19,6 +21,9 @@ import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.annotation.ActivityCallback;
 import android.content.Intent;
 import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -26,6 +31,7 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ConcurrentHashMap;
@@ -44,6 +50,7 @@ public class AndroidDownloadPlugin extends Plugin {
 
   private final ExecutorService executor = Executors.newFixedThreadPool(2);
   private final ConcurrentHashMap<Long, PluginCall> activeDownloads = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, Object> coverWriteLocks = new ConcurrentHashMap<>();
 
   @Override
   protected void handleOnDestroy() {
@@ -416,6 +423,8 @@ public class AndroidDownloadPlugin extends Plugin {
     String artist = fallbackArtist;
     String album = "未知专辑";
     long duration = 0L;
+    long bitrate = 0L;
+    String cover = "";
 
     // 尝试用 MediaMetadataRetriever 读取标签信息
     MediaMetadataRetriever retriever = null;
@@ -427,6 +436,7 @@ public class AndroidDownloadPlugin extends Plugin {
       String mArtist = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ARTIST);
       String mAlbum = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ALBUM);
       String mDuration = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION);
+      String mBitrate = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_BITRATE);
 
       if (mTitle != null && !mTitle.trim().isEmpty()) title = mTitle.trim();
       if (mArtist != null && !mArtist.trim().isEmpty()) artist = mArtist.trim();
@@ -436,6 +446,19 @@ public class AndroidDownloadPlugin extends Plugin {
           duration = Long.parseLong(mDuration);
         } catch (NumberFormatException ignored) {
         }
+      }
+      if (mBitrate != null) {
+        try {
+          bitrate = Long.parseLong(mBitrate);
+        } catch (NumberFormatException ignored) {
+        }
+      }
+
+      // 提取嵌入封面，压缩后写入 cacheDir/local-covers/<idHash>.jpg 并返回 file:// URI。
+      // 用 file:// 而非 base64 data URL：避免上千首歌每首 ~30KB 字符串经 Capacitor 桥响应造成 IPC 肨胀 / OOM。
+      byte[] embeddedPicture = retriever.getEmbeddedPicture();
+      if (embeddedPicture != null) {
+        cover = writeEmbeddedCoverToCache(uri, embeddedPicture);
       }
     } catch (Exception ignored) {
       // 文件不可解析，使用文件名兜底
@@ -458,11 +481,116 @@ public class AndroidDownloadPlugin extends Plugin {
     song.put("album", album);
     song.put("duration", duration);
     song.put("size", size);
+    song.put("quality", bitrate);
     song.put("path", uri);
     song.put("fileName", fileName);
     song.put("ext", extension);
     song.put("lastModified", lastModified);
+    song.put("cover", cover);
     return song;
+  }
+
+  /**
+   * 嵌入封面落盘：按源 URI hash 成名，写入 {@code cacheDir/local-covers/}。返回 file:// URI。
+   * 已存在则复用。压缩到 1024px 内 JPEG quality 80。完全失败返回 ""。
+   */
+  private String writeEmbeddedCoverToCache(String sourceUri, byte[] pictureBytes) {
+    Context ctx = getContext();
+    if (ctx == null) return "";
+    Bitmap original = null;
+    Bitmap scaled = null;
+    try {
+      File coverDir = new File(ctx.getCacheDir(), "local-covers");
+      if (!coverDir.exists() && !coverDir.mkdirs()) {
+        return "";
+      }
+      String idHash = sha256Hex(sourceUri);
+      if (idHash.isEmpty()) return "";
+      File coverFile = new File(coverDir, idHash + ".jpg");
+      Object writeLock = coverWriteLocks.computeIfAbsent(idHash, key -> new Object());
+      try {
+        synchronized (writeLock) {
+          if (coverFile.isFile() && coverFile.length() > 0) {
+            return "file://" + coverFile.getAbsolutePath();
+          }
+          BitmapFactory.Options boundsOptions = new BitmapFactory.Options();
+          boundsOptions.inJustDecodeBounds = true;
+          BitmapFactory.decodeByteArray(pictureBytes, 0, pictureBytes.length, boundsOptions);
+          int maxSize = 1024;
+          BitmapFactory.Options decodeOptions = new BitmapFactory.Options();
+          decodeOptions.inSampleSize = calculateInSampleSize(boundsOptions, maxSize);
+          original = BitmapFactory.decodeByteArray(pictureBytes, 0, pictureBytes.length, decodeOptions);
+          if (original == null) return "";
+          int w = original.getWidth();
+          int h = original.getHeight();
+          float scale = Math.min((float) maxSize / w, (float) maxSize / h);
+          scaled = original;
+          if (scale < 1.0f) {
+            scaled = Bitmap.createScaledBitmap(original, Math.round(w * scale), Math.round(h * scale), true);
+          }
+          try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            scaled.compress(Bitmap.CompressFormat.JPEG, 80, baos);
+            byte[] jpegBytes = baos.toByteArray();
+            // 原子写：tmp → rename，避免进程被杀产生半截断文件
+            File tmp = new File(coverDir, idHash + ".jpg.tmp");
+            try (FileOutputStream fos = new FileOutputStream(tmp)) {
+              fos.write(jpegBytes);
+              fos.getFD().sync();
+            } catch (IOException e) {
+              // noinspection ResultOfMethodCallIgnored
+              tmp.delete();
+              return "";
+            }
+            if (coverFile.exists()) {
+              // noinspection ResultOfMethodCallIgnored
+              coverFile.delete();
+            }
+            if (!tmp.renameTo(coverFile)) {
+              // noinspection ResultOfMethodCallIgnored
+              tmp.delete();
+              return "";
+            }
+          }
+        }
+      } finally {
+        coverWriteLocks.remove(idHash, writeLock);
+      }
+      return "file://" + coverFile.getAbsolutePath();
+    } catch (Throwable ignored) {
+      return "";
+    } finally {
+      if (scaled != null && scaled != original) {
+        scaled.recycle();
+      }
+      if (original != null) {
+        original.recycle();
+      }
+    }
+  }
+
+  private String sha256Hex(String value) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+      StringBuilder builder = new StringBuilder(hash.length * 2);
+      for (byte b : hash) {
+        builder.append(String.format("%02x", b));
+      }
+      return builder.toString();
+    } catch (Exception ignored) {
+      return "";
+    }
+  }
+
+  private int calculateInSampleSize(BitmapFactory.Options options, int maxSize) {
+    int height = options.outHeight;
+    int width = options.outWidth;
+    if (height <= 0 || width <= 0) return maxSize;
+    int inSampleSize = 1;
+    while (height / inSampleSize > maxSize || width / inSampleSize > maxSize) {
+      inSampleSize *= 2;
+    }
+    return inSampleSize;
   }
 
   private boolean isAudioFile(String name) {

--- a/android/app/src/main/java/top/imsyy/splayer/android/playback/PlaybackManager.java
+++ b/android/app/src/main/java/top/imsyy/splayer/android/playback/PlaybackManager.java
@@ -4,6 +4,7 @@ import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
@@ -18,6 +19,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.PowerManager;
+import android.util.Base64;
 import android.util.Log;
 import android.view.KeyEvent;
 import androidx.annotation.NonNull;
@@ -60,7 +62,10 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import top.imsyy.splayer.android.MainActivity;
@@ -83,6 +88,7 @@ public final class PlaybackManager {
   private static final long FAVORITE_REQUEST_RETRY_DELAY_MS = 350L;
   private static final long SEEK_STATE_GRACE_MS = 4000L;
   private static final long SEEK_POSITION_TOLERANCE_MS = 1500L;
+  private static final int CONTENT_MIME_CACHE_MAX_SIZE = 1024;
   private static volatile PlaybackManager instance;
 
   private final Context appContext;
@@ -101,7 +107,7 @@ public final class PlaybackManager {
   /** 暴露给 MediaSession 的包装 Player：覆写 availableCommands，让系统媒体面板始终展示上一/下一首。 */
   private Player sessionPlayer;
   private MediaSession mediaSession;
-  private PlaybackService service;
+  private volatile PlaybackService service;
   /** PlaybackService 是否已通过 onCreate→attachService 启动并保持运行；用于 ensureServiceRunning 节流。 */
   private volatile boolean serviceStarted;
   private AndroidNativePlaybackPlugin plugin;
@@ -130,6 +136,9 @@ public final class PlaybackManager {
   /** Java 端 URL 解析器：WebView 冻结时仍可自治取地址。 */
   private final PlaybackUrlResolver urlResolver = new PlaybackUrlResolver();
   private TrackMetadata currentMetadata = new TrackMetadata();
+  private static final int NATIVE_ERROR_RECOVERY_MAX_ATTEMPTS = 2;
+  private long nativeRecoverySongId = 0L;
+  private int nativeRecoveryAttempts = 0;
   /**
    * Java 端自治播放队列（滑动窗口）。
    *
@@ -582,6 +591,8 @@ public final class PlaybackManager {
           windowResetFromWrap ? playbackQueue.current() : playbackQueue.advanceRaw(false);
       if (resume != null) {
         resolveAndPlayAsync(resume, "auto", true, 5);
+      } else {
+        emitCustomAction("next", null, null, null, null, true, null);
       }
     }
   }
@@ -899,6 +910,9 @@ public final class PlaybackManager {
 
           @Override
           public void onPlayerError(PlaybackException error) {
+            if (recoverCurrentTrackAfterError(error)) {
+              return;
+            }
             emitError(error.errorCode, error.getMessage());
             updateNotification();
           }
@@ -1026,10 +1040,44 @@ public final class PlaybackManager {
   private MediaItem buildMediaItem(String url) {
     MediaItem.Builder builder = new MediaItem.Builder();
     if (url != null && !url.isEmpty()) {
-      builder.setUri(Uri.parse(url));
+      Uri uri = Uri.parse(url);
+      builder.setUri(uri);
+      if ("content".equals(uri.getScheme())) {
+        builder.setMimeType(resolveContentMimeType(uri));
+      }
     }
     builder.setMediaMetadata(buildMediaMetadata());
     return builder.build();
+  }
+
+  /** content:// MIME 缓存：避免 buildMediaItem 在主线程对未冷启的 ContentProvider 做同步 IPC。 */
+  private final Map<String, String> contentMimeCache =
+      Collections.synchronizedMap(
+          new LinkedHashMap<String, String>(CONTENT_MIME_CACHE_MAX_SIZE, 0.75f, true) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<String, String> eldest) {
+              return size() > CONTENT_MIME_CACHE_MAX_SIZE;
+            }
+          });
+
+  @Nullable
+  private String resolveContentMimeType(Uri uri) {
+    String key = uri.toString();
+    String cached = contentMimeCache.get(key);
+    if (cached != null) {
+      // 空字符串 sentinel：曾经查到过 null（未知 MIME），不再重复查
+      return cached.isEmpty() ? null : cached;
+    }
+    try {
+      ContentResolver resolver = appContext.getContentResolver();
+      String mime = resolver.getType(uri);
+      contentMimeCache.put(key, mime == null ? "" : mime);
+      return mime;
+    } catch (Exception error) {
+      Log.w(TAG, "resolveContentMimeType failed", error);
+      contentMimeCache.put(key, "");
+      return null;
+    }
   }
 
   private MediaMetadata buildMediaMetadata() {
@@ -1247,6 +1295,8 @@ public final class PlaybackManager {
     // 切歌即失效旧 async 回调 + 清 pending，防止旧 URL 覆盖 / 补窗误消费
     resolveTokenCounter.incrementAndGet();
     pendingResumeAfterRefill = false;
+    nativeRecoverySongId = 0L;
+    nativeRecoveryAttempts = 0;
     TrackMetadata metadata = trackToMetadata(track);
     startTrackFromState(track.url, metadata, track.liked, true);
 
@@ -1265,6 +1315,72 @@ public final class PlaybackManager {
 
     // 窗口边缘提前补 URL
     requestUrlsIfWindowExhausted();
+  }
+
+  private boolean recoverCurrentTrackAfterError(PlaybackException error) {
+    long songId = currentMetadata.songId;
+    if (songId <= 0 || !currentMetadata.canLike) return false;
+    if (currentSource == null || currentSource.isEmpty()) return false;
+    if (!isRecoverablePlaybackError(error)) return false;
+    if (nativeRecoverySongId != songId) {
+      nativeRecoverySongId = songId;
+      nativeRecoveryAttempts = 0;
+    }
+    if (nativeRecoveryAttempts >= NATIVE_ERROR_RECOVERY_MAX_ATTEMPTS) return false;
+    nativeRecoveryAttempts++;
+    long positionMs = Math.max(0L, getPositionMs());
+    TrackMetadata metadataSnapshot = currentMetadata.copy();
+    boolean likedSnapshot = liked;
+    Log.w(TAG, "native recover playback error code=" + error.errorCode + " songId=" + songId);
+    final long myToken = resolveTokenCounter.incrementAndGet();
+    urlResolver.clear(songId);
+    urlResolver.submitResolve(
+        songId,
+        url ->
+            mainHandler.post(
+                () -> {
+                  if (player == null) return;
+                  if (myToken != resolveTokenCounter.get()) return;
+                  if (url == null || url.isEmpty()) {
+                    emitError(error.errorCode, error.getMessage());
+                    updateNotification();
+                    return;
+                  }
+                  metadataSnapshot.url = url;
+                  currentSource = url;
+                  currentMetadata = metadataSnapshot.copy();
+                  playbackQueue.updateTrackUrl(songId, url);
+                  liked = likedSnapshot;
+                  clearPendingSeek();
+                  durationCalibratedForSource = "";
+                  player.setMediaItem(buildMediaItem(url));
+                  player.prepare();
+                  if (positionMs > 0) {
+                    player.seekTo(positionMs);
+                    beginPendingSeek(positionMs);
+                  }
+                  player.play();
+                  updateNotification();
+                  emitPlaybackState(true);
+                  emitProgressChanged();
+                  nativeRecoverySongId = 0L;
+                  nativeRecoveryAttempts = 0;
+                  prefetchUpcomingUrls();
+                }));
+    return true;
+  }
+
+  private boolean isRecoverablePlaybackError(PlaybackException error) {
+    int code = error.errorCode;
+    return code == PlaybackException.ERROR_CODE_IO_UNSPECIFIED
+        || code == PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED
+        || code == PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT
+        || code == PlaybackException.ERROR_CODE_IO_INVALID_HTTP_CONTENT_TYPE
+        || code == PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS
+        || code == PlaybackException.ERROR_CODE_IO_FILE_NOT_FOUND
+        || code == PlaybackException.ERROR_CODE_IO_NO_PERMISSION
+        || code == PlaybackException.ERROR_CODE_IO_CLEARTEXT_NOT_PERMITTED
+        || code == PlaybackException.ERROR_CODE_IO_READ_POSITION_OUT_OF_RANGE;
   }
 
   /** 转换 PlaybackQueue.Track → TrackMetadata（复用现有切歌路径） */
@@ -1452,10 +1568,20 @@ public final class PlaybackManager {
     } catch (IllegalStateException error) {
       // Android 12+ ForegroundServiceStartNotAllowedException 继承 IllegalStateException，
       // 在 Doze 边缘 / 系统极限场景偶发。仅记录，让通知降级为普通通知，避免崩溃。
+      if (!isForegroundServiceStartNotAllowed(error)) {
+        throw error;
+      }
       Log.w(TAG, "Failed to enter foreground service from background", error);
       NotificationManagerCompat.from(appContext)
           .notify(PlaybackConstants.NOTIFICATION_ID, notification);
     }
+  }
+
+  private boolean isForegroundServiceStartNotAllowed(IllegalStateException error) {
+    String className = error.getClass().getName();
+    String message = error.getMessage();
+    return className.contains("ForegroundServiceStartNotAllowedException")
+        || (message != null && message.contains("ForegroundService"));
   }
 
   private Notification buildNotification() {
@@ -1867,7 +1993,23 @@ public final class PlaybackManager {
           HttpURLConnection connection = null;
 
           try {
-            if (coverUrl.startsWith("http://") || coverUrl.startsWith("https://")) {
+            if (coverUrl.startsWith("data:")) {
+              // 仅支持 data:image/*;base64,xxx 形式；非 base64 / 非 image 的 data URL 直接忽略
+              int commaIdx = coverUrl.indexOf(',');
+              int base64MarkerIdx = coverUrl.indexOf(";base64");
+              if (commaIdx > 0
+                  && base64MarkerIdx > 0
+                  && base64MarkerIdx < commaIdx
+                  && coverUrl.startsWith("data:image/")) {
+                String base64Data = coverUrl.substring(commaIdx + 1);
+                try {
+                  byte[] decoded = Base64.decode(base64Data, Base64.DEFAULT);
+                  bitmap = BitmapFactory.decodeByteArray(decoded, 0, decoded.length);
+                } catch (IllegalArgumentException ignored) {
+                  // 非法 base64：忽略
+                }
+              }
+            } else if (coverUrl.startsWith("http://") || coverUrl.startsWith("https://")) {
               connection = (HttpURLConnection) new URL(coverUrl).openConnection();
               connection.setConnectTimeout(8000);
               connection.setReadTimeout(8000);
@@ -1875,6 +2017,12 @@ public final class PlaybackManager {
               connection.connect();
               inputStream = connection.getInputStream();
               bitmap = BitmapFactory.decodeStream(inputStream);
+            } else if (coverUrl.startsWith("content://")) {
+              ContentResolver resolver = appContext.getContentResolver();
+              inputStream = resolver.openInputStream(Uri.parse(coverUrl));
+              if (inputStream != null) {
+                bitmap = BitmapFactory.decodeStream(inputStream);
+              }
             } else if (coverUrl.startsWith("file://")) {
               bitmap = BitmapFactory.decodeFile(Uri.parse(coverUrl).getPath());
             }

--- a/android/app/src/main/java/top/imsyy/splayer/android/playback/PlaybackQueue.java
+++ b/android/app/src/main/java/top/imsyy/splayer/android/playback/PlaybackQueue.java
@@ -46,7 +46,7 @@ public final class PlaybackQueue {
 
   /** 单首曲目元数据 + 已解析 URL。 */
   public static final class Track {
-    /** 网易云 songId。必须 long：2024+ 部分 ID 超过 Integer.MAX_VALUE，int 会溢出为负。 */
+    /** 内部 songId。必须 long：2024+ 部分 ID 超过 Integer.MAX_VALUE，int 会溢出为负。 */
     public long songId;
     public long durationMs;
     public boolean canLike;

--- a/android/app/src/main/java/top/imsyy/splayer/android/playback/PlaybackUrlResolver.java
+++ b/android/app/src/main/java/top/imsyy/splayer/android/playback/PlaybackUrlResolver.java
@@ -87,6 +87,17 @@ public final class PlaybackUrlResolver {
     }
   }
 
+  public void clear(long songId) {
+    if (songId <= 0) return;
+    String prefix = songId + ":";
+    synchronized (cache) {
+      cache.entrySet().removeIf(entry -> entry.getKey().startsWith(prefix));
+    }
+    synchronized (negativeCache) {
+      negativeCache.entrySet().removeIf(entry -> entry.getKey().startsWith(prefix));
+    }
+  }
+
   /** 阻塞解析 songId 的 URL；命中缓存 / 失败 / 未配置返 null。 */
   @Nullable
   public String resolveSync(long songId) {

--- a/src/components/Card/SongCard.vue
+++ b/src/components/Card/SongCard.vue
@@ -23,7 +23,7 @@
         <s-image
           v-if="!hiddenCover"
           :key="song.cover"
-          :src="song.path ? song.cover : song.coverSize?.s || song.cover"
+          :src="song.coverSize?.s || song.cover"
           cache-type="covers"
           class="cover"
         />

--- a/src/components/List/CoverList.vue
+++ b/src/components/List/CoverList.vue
@@ -469,6 +469,9 @@ const getListData = async (id: number | string): Promise<SongType[]> => {
       border: 2px solid rgba(var(--primary), 0.12);
       padding: 0;
       overflow: hidden;
+      @media (max-width: 767px) and (orientation: portrait) {
+        min-height: 72px;
+      }
       &:hover {
         border-color: rgba(var(--primary), 0.58);
       }
@@ -478,6 +481,12 @@ const getListData = async (id: number | string): Promise<SongType[]> => {
         .name {
           font-size: 18px;
           font-weight: bold;
+        }
+        @media (max-width: 767px) and (orientation: portrait) {
+          padding: 10px 12px;
+          .name {
+            font-size: 15px;
+          }
         }
       }
     }

--- a/src/components/List/SongList.vue
+++ b/src/components/List/SongList.vue
@@ -552,6 +552,9 @@ onBeforeUnmount(() => {
 <style lang="scss" scoped>
 .song-list {
   height: 100%;
+  @media (max-width: 767px) and (orientation: portrait) {
+    min-height: 360px;
+  }
   border-radius: 12px 0 0 12px;
   overflow: hidden;
   // 离场时脱离文档流，避免新旧内容同时存在时布局跳动

--- a/src/components/UI/s-image.vue
+++ b/src/components/UI/s-image.vue
@@ -30,6 +30,8 @@
 </template>
 
 <script setup lang="ts">
+import { Capacitor } from "@capacitor/core";
+import { isCapacitorAndroid } from "@/utils/env";
 import { useCoverCache } from "@/composables/useCoverCache";
 
 const props = withDefaults(
@@ -80,7 +82,20 @@ const props = withDefaults(
 
 // Android 端命中本地封面缓存返回 blob URL，未命中时后台下载并保存；其他平台直接透传 src。
 // cacheType="none" 时退化为透传，避免大图（背景模糊）走 base64 IPC 浪费 CPU/内存。
-const srcRef = computed(() => props.src);
+const srcRef = computed(() => {
+  const url = props.src;
+  if (!url) return undefined;
+  // Capacitor WebView 禁止 <img src="file://"> / <img src="content://">，
+  // 必须用 convertFileSrc 转成 https://localhost/_capacitor_file_/... 代理。
+  if (isCapacitorAndroid && (url.startsWith("file://") || url.startsWith("content://"))) {
+    try {
+      return Capacitor.convertFileSrc(url);
+    } catch {
+      return url;
+    }
+  }
+  return url;
+});
 const cachedSrc =
   props.cacheType === "none"
     ? srcRef

--- a/src/composables/useCoverCache.ts
+++ b/src/composables/useCoverCache.ts
@@ -1,4 +1,5 @@
 import { ref, watch, onBeforeUnmount, type Ref } from "vue";
+import { Capacitor } from "@capacitor/core";
 import { useCacheManager, type CacheResourceType } from "@/core/resource/CacheManager";
 import { isCapacitorAndroid } from "@/utils/env";
 import { useSettingStore } from "@/stores";
@@ -304,7 +305,21 @@ export const useCoverCache = (
         resolved.value = undefined;
         return;
       }
-      // 非 http(s) 直接透传：本地路径 / data URI / blob URL / capacitor://
+      // Capacitor WebView 禁止 <img src="file://">，先做代理转换
+      if (isCapacitorAndroid && (url.startsWith("file://") || url.startsWith("content://"))) {
+        try {
+          resolved.value = Capacitor.convertFileSrc(url);
+        } catch {
+          resolved.value = url;
+        }
+        return;
+      }
+      // 已是代理 URL 的直接透传，不需要再走缓存 IPC
+      if (url.includes("_capacitor_file_")) {
+        resolved.value = url;
+        return;
+      }
+      // 非 http(s) 直接透传：data URI / blob URL / 其他 scheme
       if (!url.startsWith("http")) {
         resolved.value = url;
         return;
@@ -321,7 +336,7 @@ export const useCoverCache = (
         if (cached.startsWith("blob:")) {
           // resolveCachedCover 已 pre-retain（修复 #2），这里只需记录 url 等卸载时 release
           retainedUrls.push(url);
-        } else if (cached.startsWith("blob:") === false) {
+        } else {
           // 极少见：返回非 blob URL（透传场景），不持有引用
         }
       } else if (cached && cached.startsWith("blob:")) {

--- a/src/core/audio-player/AndroidNativeAudioPlayer.ts
+++ b/src/core/audio-player/AndroidNativeAudioPlayer.ts
@@ -356,7 +356,8 @@ export class AndroidNativeAudioPlayer extends EventTarget implements IPlaybackEn
         ) {
           return;
         }
-        this.lastEndedSrc = this._src;
+        const endedSrc = this._src;
+        this.lastEndedSrc = endedSrc;
         this.lastEndedEventAt = now;
 
         const endDuration = Math.max(0, event.durationMs) / 1000;
@@ -365,6 +366,9 @@ export class AndroidNativeAudioPlayer extends EventTarget implements IPlaybackEn
         this._paused = true;
         this.lastTimeSyncAt = performance.now();
         this.dispatchEvent(new Event(AUDIO_EVENTS.TIME_UPDATE));
+        // 同步比对 _src 与事件捕获的 endedSrc：若已切换说明 ENDED 来自旧轨，丢弃。
+        // 不再走异步 getState()，避免 IPC 期间用户切歌导致 legitimate 自然终止被吞掉。
+        if (this._src !== endedSrc) return;
         this.dispatchEvent(new Event(AUDIO_EVENTS.ENDED));
       }),
     );

--- a/src/core/player/LyricManager.ts
+++ b/src/core/player/LyricManager.ts
@@ -1,4 +1,5 @@
 import { qqMusicMatch } from "@/api/qqmusic";
+import { searchResult, SearchTypes } from "@/api/search";
 import { songLyric, songLyricTTML } from "@/api/song";
 import { keywords as defaultKeywords, regexes as defaultRegexes } from "@/assets/data/exclude";
 import { useCacheManager } from "@/core/resource/CacheManager";
@@ -29,6 +30,35 @@ interface LyricFetchResult {
     usingTTMLLyric: boolean;
     usingQRCLyric: boolean;
   };
+}
+
+interface SearchSongArtist {
+  name?: string;
+}
+
+interface SearchSongAlbum {
+  name?: string;
+}
+
+interface SearchSongCandidate {
+  id?: number;
+  name?: string;
+  ar?: SearchSongArtist[];
+  artists?: SearchSongArtist[];
+  al?: SearchSongAlbum;
+  album?: SearchSongAlbum;
+  dt?: number;
+  duration?: number;
+}
+
+interface ElectronLyricResult {
+  lyric?: string;
+  format?: "lrc" | "ttml" | "yrc";
+}
+
+interface LocalLyricOverrideResult {
+  lrc?: unknown;
+  ttml?: unknown;
 }
 
 /**
@@ -76,6 +106,16 @@ class LyricManager {
    * @param type 缓存类型
    * @returns 缓存数据
    */
+  private getArtistsText(song: SongType): string {
+    return Array.isArray(song.artists)
+      ? song.artists.map((artist) => artist.name).join("/")
+      : String(song.artists || "");
+  }
+
+  private getAlbumText(song: SongType): string {
+    return typeof song.album === "string" ? song.album : song.album?.name || "";
+  }
+
   private async getRawLyricCache(id: number, type: "lrc" | "ttml" | "qrc"): Promise<string | null> {
     const settingStore = useSettingStore();
     const cacheManager = useCacheManager();
@@ -119,9 +159,7 @@ class LyricManager {
    */
   private async fetchQQMusicLyric(song: SongType): Promise<SongLyric | null> {
     // 构建歌手字符串
-    const artistsStr = Array.isArray(song.artists)
-      ? song.artists.map((a) => a.name).join("/")
-      : String(song.artists || "");
+    const artistsStr = this.getArtistsText(song);
     // 判断本地/在线，生成缓存 key
     const isLocal = Boolean(song.path);
     const cacheKey = isLocal ? `local_${song.id}` : String(song.id);
@@ -208,6 +246,218 @@ class LyricManager {
     if (!result.lrcData.length && !result.yrcData.length) {
       return null;
     }
+    return result;
+  }
+
+  /** 本地歌曲在线匹配缓存 TTL：成功 30 天 / 失败 1 天，避免反复打云搜索。 */
+  private static readonly LOCAL_MATCH_TTL_OK_MS = 30 * 24 * 60 * 60 * 1000;
+  private static readonly LOCAL_MATCH_TTL_NEG_MS = 24 * 60 * 60 * 1000;
+
+  /** 进程内 in-flight 去重：同一首歌的并发查询合并。 */
+  private localMatchInFlight = new Map<string, Promise<number | null>>();
+
+  private async readLocalMatchCache(cacheKey: string): Promise<number | null | undefined> {
+    const settingStore = useSettingStore();
+    const cacheManager = useCacheManager();
+    if (!cacheManager.isAvailable() || !settingStore.cacheEnabled) return undefined;
+    try {
+      const result = await cacheManager.get("lyrics", `${cacheKey}.match.v2.json`);
+      if (!result.success || !result.data) return undefined;
+      const decoder = new TextDecoder();
+      const parsed = JSON.parse(decoder.decode(result.data));
+      const ts = Number(parsed?.ts || 0);
+      const onlineId = parsed?.onlineId;
+      const ttl =
+        onlineId === null
+          ? LyricManager.LOCAL_MATCH_TTL_NEG_MS
+          : LyricManager.LOCAL_MATCH_TTL_OK_MS;
+      if (Date.now() - ts > ttl) return undefined;
+      return typeof onlineId === "number" ? onlineId : null;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async writeLocalMatchCache(cacheKey: string, onlineId: number | null): Promise<void> {
+    const settingStore = useSettingStore();
+    const cacheManager = useCacheManager();
+    if (!cacheManager.isAvailable() || !settingStore.cacheEnabled) return;
+    try {
+      await cacheManager.set(
+        "lyrics",
+        `${cacheKey}.match.v2.json`,
+        JSON.stringify({ onlineId, ts: Date.now() }),
+      );
+    } catch {
+      // 忽略写入失败
+    }
+  }
+
+  /** 本地歌曲常见的占位元数据：识别后视为"无元数据"。 */
+  private static readonly METADATA_SENTINELS = new Set([
+    "未知歌手",
+    "未知艺术家",
+    "未知专辑",
+    "未知",
+    "unknown",
+    "unknownartist",
+    "unknownalbum",
+    "various",
+    "variousartists",
+    "n/a",
+    "na",
+  ]);
+
+  private static normalizeMetadataField(value: string): string {
+    const normalized = value
+      .toLowerCase()
+      .replace(/[（(].*?[）)]/g, "")
+      .replace(/\s+/g, "")
+      .trim();
+    if (!normalized) return "";
+    if (LyricManager.METADATA_SENTINELS.has(normalized)) return "";
+    return normalized;
+  }
+
+  private async findOnlineSongIdForLocal(song: SongType): Promise<number | null> {
+    const artistsText = this.getArtistsText(song);
+    const targetName = LyricManager.normalizeMetadataField(song.name || "");
+    const targetArtists = LyricManager.normalizeMetadataField(artistsText);
+    const targetAlbum = LyricManager.normalizeMetadataField(this.getAlbumText(song));
+    const duration = Number(song.duration || 0);
+    const hasReliableDuration = duration > 5_000;
+
+    // 元数据过弱：title 太短直接放弃；
+    // 缺 artist 时，需要 title 稳定 + 时长可比对，否则极易错配
+    if (!targetName || targetName.length < 2) return null;
+    if (!targetArtists && (!hasReliableDuration || targetName.length < 4)) return null;
+
+    const cacheKey = `local_${song.id}`;
+    const cached = await this.readLocalMatchCache(cacheKey);
+    if (cached !== undefined) return cached;
+
+    const inFlight = this.localMatchInFlight.get(cacheKey);
+    if (inFlight) return inFlight;
+
+    const task = (async (): Promise<number | null> => {
+      const keyword = artistsText && targetArtists ? `${song.name} ${artistsText}` : song.name;
+      try {
+        const response = await searchResult(keyword, 8, 0, SearchTypes.Single);
+        const songs = response?.result?.songs as SearchSongCandidate[] | undefined;
+        if (!Array.isArray(songs)) {
+          await this.writeLocalMatchCache(cacheKey, null);
+          return null;
+        }
+        const sorted = songs
+          .map((candidate) => {
+            const candidateName = LyricManager.normalizeMetadataField(candidate.name || "");
+            const candidateArtists = LyricManager.normalizeMetadataField(
+              Array.isArray(candidate.ar)
+                ? candidate.ar.map((artist) => artist?.name).join("/")
+                : Array.isArray(candidate.artists)
+                  ? candidate.artists.map((artist) => artist?.name).join("/")
+                  : "",
+            );
+            const candidateAlbum = LyricManager.normalizeMetadataField(
+              candidate.al?.name || candidate.album?.name || "",
+            );
+            const candidateDuration = Number(candidate.dt || candidate.duration || 0);
+
+            // title 评分
+            let titleScore = 0;
+            if (candidateName === targetName) titleScore = 5;
+            else if (candidateName.includes(targetName) || targetName.includes(candidateName)) {
+              titleScore = 2;
+            }
+
+            // artist 评分：仅 target 与 candidate 都非空时才参与
+            let artistScore = 0;
+            let artistAgrees = false;
+            if (targetArtists && candidateArtists) {
+              if (candidateArtists === targetArtists) {
+                artistScore = 4;
+                artistAgrees = true;
+              } else if (
+                candidateArtists.includes(targetArtists) ||
+                targetArtists.includes(candidateArtists)
+              ) {
+                artistScore = 2;
+                artistAgrees = true;
+              }
+            }
+
+            // album 评分
+            let albumScore = 0;
+            if (targetAlbum && candidateAlbum && targetAlbum === candidateAlbum) albumScore = 2;
+
+            // duration 评分
+            let durationScore = 0;
+            let durationAgrees = false;
+            if (duration > 0 && candidateDuration > 0) {
+              const diff = Math.abs(candidateDuration - duration);
+              if (diff <= 3000) {
+                durationScore = 3;
+                durationAgrees = true;
+              } else if (diff > 8000) durationScore = -4;
+            }
+
+            const score = titleScore + artistScore + albumScore + durationScore;
+            return {
+              id: candidate.id,
+              score,
+              titleScore,
+              artistAgrees,
+              durationAgrees,
+              candidateArtists,
+            };
+          })
+          .filter(
+            (
+              candidate,
+            ): candidate is {
+              id: number;
+              score: number;
+              titleScore: number;
+              artistAgrees: boolean;
+              durationAgrees: boolean;
+              candidateArtists: string;
+            } => typeof candidate.id === "number",
+          )
+          .sort((a, b) => b.score - a.score);
+
+        const best = sorted[0];
+        // 命中条件分两类：
+        //   (a) 有可靠 artist 元数据：要求 title 至少有重合 + artist 互相包含 + score>=7
+        //   (b) artist 缺失但 title 长度>=4 + 时长接近：score>=8 且 title 是精确匹配
+        let ok = false;
+        if (best) {
+          if (targetArtists) {
+            ok = best.score >= 7 && best.titleScore > 0 && best.artistAgrees;
+          } else {
+            ok = best.score >= 8 && best.titleScore === 5 && best.durationAgrees;
+          }
+        }
+        const onlineId = ok && best ? best.id : null;
+        await this.writeLocalMatchCache(cacheKey, onlineId);
+        return onlineId;
+      } catch (error) {
+        console.warn("本地歌曲在线歌词匹配失败:", error);
+        await this.writeLocalMatchCache(cacheKey, null);
+        return null;
+      } finally {
+        this.localMatchInFlight.delete(cacheKey);
+      }
+    })();
+    this.localMatchInFlight.set(cacheKey, task);
+    return task;
+  }
+
+  private async fetchMatchedOnlineLyricForLocal(song: SongType): Promise<LyricFetchResult | null> {
+    const onlineId = await this.findOnlineSongIdForLocal(song);
+    if (!onlineId) return null;
+    const matchedSong: SongType = { ...song, id: onlineId, path: undefined };
+    const result = await this.fetchOnlineLyric(matchedSong);
+    if (!result.data.lrcData.length && !result.data.yrcData.length) return null;
     return result;
   }
 
@@ -344,7 +594,7 @@ class LyricManager {
           yrcLines = alignLyrics(yrcLines, parseLrc(data.yromalrc.lyric), "romanLyric");
       }
       if (lrcLines.length) result.lrcData = lrcLines;
-      // 如果没有 TTML 且没有 QM YRC，则采用 网易云 YRC
+      // 如果没有 TTML 且没有 QM YRC，则采用在线 YRC
       if (!result.yrcData.length && yrcLines.length) {
         // 再次确认优先级，如果是 TTML 优先但 TTML 没结果，这里可以用 YRC
         result.yrcData = yrcLines;
@@ -460,7 +710,9 @@ class LyricManager {
           // sidecar 查找失败，继续后续流程
         }
 
-        // 无本地歌词，尝试在线 QQ 匹配
+        // 无本地歌词，尝试在线匹配
+        const matchedOnline = await this.fetchMatchedOnlineLyricForLocal(song);
+        if (matchedOnline) return matchedOnline;
         if (settingStore.localLyricQQMusicMatch && song) {
           const qqLyric = await this.fetchQQMusicLyric(song);
           if (qqLyric && (qqLyric.lrcData.length > 0 || qqLyric.yrcData.length > 0)) {
@@ -474,9 +726,16 @@ class LyricManager {
       }
 
       // Electron 端：使用原有 IPC 逻辑
-      const { lyric, format }: { lyric?: string; format?: "lrc" | "ttml" | "yrc" } =
-        await window.electron.ipcRenderer.invoke("get-music-lyric", song.path);
-      if (!lyric) return defaultResult;
+      const electron = window.electron;
+      if (!electron) return defaultResult;
+      const { lyric, format } = await electron.ipcRenderer.invoke<ElectronLyricResult>(
+        "get-music-lyric",
+        song.path,
+      );
+      if (!lyric) {
+        const matchedOnline = await this.fetchMatchedOnlineLyricForLocal(song);
+        return matchedOnline || defaultResult;
+      }
       // YRC 直接解析
       if (format === "yrc") {
         let lines: LyricLine[] = [];
@@ -558,7 +817,9 @@ class LyricManager {
 
       const lyricDirs = Array.isArray(localLyricPath) ? localLyricPath.map((p) => String(p)) : [];
       // 读取本地歌词
-      const { lrc, ttml } = await window.electron.ipcRenderer.invoke(
+      const electron = window.electron;
+      if (!electron) return defaultResult;
+      const { lrc, ttml } = await electron.ipcRenderer.invoke<LocalLyricOverrideResult>(
         "read-local-lyric",
         lyricDirs,
         id,
@@ -798,7 +1059,7 @@ class LyricManager {
           return false;
         }
         // ttml 特有属性
-        if (newLine.isBG !== oldLine.isBG) return false;
+        if (!!newLine.isBG !== !!oldLine.isBG) return false;
       }
       return true;
     };
@@ -861,8 +1122,9 @@ class LyricManager {
       // 仅更新加载状态，不更新歌词数据
       statusStore.lyricLoading = false;
       // 单曲循环时，歌词数据未变，需通知桌面歌词取消加载状态
-      if (isElectron) {
-        window.electron.ipcRenderer.send("desktop-lyric:update-data", {
+      const electron = window.electron;
+      if (isElectron && electron) {
+        electron.ipcRenderer.send("desktop-lyric:update-data", {
           lyricLoading: false,
         });
       }
@@ -965,7 +1227,7 @@ class LyricManager {
 
     try {
       // 判断歌词来源
-      const isLocal = Boolean(song.path) || false;
+      const isLocal = Boolean(song.path);
       if (isStreaming) {
         fetchResult = await this.fetchStreamingLyric(song);
       } else {

--- a/src/core/player/MediaSessionManager.ts
+++ b/src/core/player/MediaSessionManager.ts
@@ -332,12 +332,20 @@ class MediaSessionManager {
 
     if (isCapacitorAndroid) {
       await this.syncAndroidApiContext();
+      // 本地歌曲封面：JS 侧 metadata.coverUrl 已经被 Capacitor.convertFileSrc 转成
+      // https://localhost/_capacitor_file_/...，原生 HttpURLConnection 拿不到自签证书。
+      // 这里优先取 song.cover 的原始 file:// 路径交给 Java，Java 侧的 file:// 分支可直接 decodeFile。
+      const rawCover = typeof song.cover === "string" ? song.cover : "";
+      const nativeCoverUrl =
+        song.path && (rawCover.startsWith("file://") || rawCover.startsWith("content://"))
+          ? rawCover
+          : metadata.coverUrl;
       await AndroidNativePlayback.updateMetadata({
         songId: typeof song.id === "number" ? song.id : undefined,
         title: metadata.title,
         artist: metadata.artist,
         album: metadata.album,
-        coverUrl: metadata.coverUrl,
+        coverUrl: nativeCoverUrl,
         durationMs: song.duration || 0,
         canLike: !song.path && song.type !== "streaming",
       });

--- a/src/core/player/PlayerController.ts
+++ b/src/core/player/PlayerController.ts
@@ -1,7 +1,7 @@
 import { toRaw } from "vue";
 import { AudioErrorCode } from "@/core/audio-player/BaseAudioPlayer";
 import { useDataStore, useMusicStore, useSettingStore, useStatusStore } from "@/stores";
-import type { AudioSourceType, QualityType, SongType } from "@/types/main";
+import { QualityType, type AudioSourceType, type SongType } from "@/types/main";
 import type { RepeatModeType, ShuffleModeType } from "@/types/shared/play-mode";
 import { type AudioAnalysis } from "@/types/audio/automix";
 import { calculateLyricIndex } from "@/utils/calc";
@@ -613,7 +613,7 @@ class PlayerController {
     ).requestIdleCallback;
     const runSync = () => void this.syncAndroidPlaybackContext(song);
     if (typeof ric === "function") {
-      ric(runSync, { timeout: 500 });
+      this.runIdleWithTimeout(runSync);
     } else {
       setTimeout(runSync, 0);
     }
@@ -1044,6 +1044,8 @@ class PlayerController {
       if (musicStore.playSong.type === "streaming") return;
       // Android: 没有 Electron IPC，跳过封面/元数据 IPC，仅做媒体会话刷新
       if (typeof window === "undefined" || !window.electron?.ipcRenderer) {
+        const statusStore = useStatusStore();
+        statusStore.songQuality = musicStore.playSong.quality;
         getCoverColor(musicStore.playSong.cover);
         mediaSessionManager.updateMetadata();
         await this.syncAndroidPlaybackContext(musicStore.playSong);
@@ -1153,11 +1155,11 @@ class PlayerController {
       // 同步状态到 Android 通知栏（仅在非原生 ExoPlayer 引擎下）
       if (isCapacitorAndroid) {
         if (useAudioManager().engineType !== "android-native") {
-          // statusStore 单位为秒，原生 API 用 ms
+          // statusStore 单位为 ms，原生 API 用 ms
           void AndroidNativePlayback.syncRemoteState({
             playing: true,
-            positionMs: Math.max(0, Math.round(statusStore.currentTime * 1000)),
-            durationMs: Math.max(0, Math.round(statusStore.duration * 1000)),
+            positionMs: Math.max(0, Math.round(statusStore.currentTime)),
+            durationMs: Math.max(0, Math.round(statusStore.duration)),
           });
         }
         this.syncFloatingLyricProgress(statusStore.currentTime, true);
@@ -1179,11 +1181,11 @@ class PlayerController {
       // 同步状态到 Android 通知栏（仅在非原生 ExoPlayer 引擎下）
       if (isCapacitorAndroid) {
         if (useAudioManager().engineType !== "android-native") {
-          // statusStore 单位为秒，原生 API 用 ms
+          // statusStore 单位为 ms，原生 API 用 ms
           void AndroidNativePlayback.syncRemoteState({
             playing: false,
-            positionMs: Math.max(0, Math.round(statusStore.currentTime * 1000)),
-            durationMs: Math.max(0, Math.round(statusStore.duration * 1000)),
+            positionMs: Math.max(0, Math.round(statusStore.currentTime)),
+            durationMs: Math.max(0, Math.round(statusStore.duration)),
           });
         }
         this.syncFloatingLyricProgress(statusStore.currentTime, false);
@@ -2133,10 +2135,23 @@ class PlayerController {
     const ric = (window as Window & { requestIdleCallback?: typeof requestIdleCallback })
       .requestIdleCallback;
     if (typeof ric === "function") {
-      ric(() => run(), { timeout: 500 });
+      this.runIdleWithTimeout(run);
     } else {
       setTimeout(run, 0);
     }
+  }
+
+  private runIdleWithTimeout(callback: () => void, timeout = 500) {
+    let done = false;
+    const runOnce = () => {
+      if (done) return;
+      done = true;
+      callback();
+    };
+    const ric = (window as Window & { requestIdleCallback?: typeof requestIdleCallback })
+      .requestIdleCallback;
+    ric?.(runOnce, { timeout });
+    setTimeout(runOnce, timeout);
   }
 
   /**

--- a/src/core/player/SongManager.ts
+++ b/src/core/player/SongManager.ts
@@ -52,6 +52,15 @@ class SongManager {
   /** 预载下一首歌曲播放信息 */
   private nextPrefetch: AudioSource | undefined;
 
+  private encodeLocalFilePath(path: string): string {
+    const safePath = path.replace(/%(?![0-9a-fA-F]{2})/g, "%25");
+    return encodeURI(safePath)
+      .replace(/#/g, "%23")
+      .replace(/\?/g, "%3F")
+      .replace(/\[/g, "%5B")
+      .replace(/\]/g, "%5D");
+  }
+
   public peekPrefetch(id: number): AudioSource | undefined {
     if (!this.nextPrefetch) return;
     if (this.nextPrefetch.id !== id) return;
@@ -464,8 +473,21 @@ class SongManager {
     // 本地文件直接返回
     if (song.path && song.type !== "streaming") {
       // Android SAF URI 直接交给 ExoPlayer，无需 file:// 前缀
-      if (song.path.startsWith("content://")) {
-        return { id: song.id, url: song.path, source: "local" };
+      if (isCapacitorAndroid) {
+        if (song.path.startsWith("content://")) {
+          return { id: song.id, url: song.path, quality: song.quality, source: "local" };
+        }
+        if (song.path.startsWith("file://")) {
+          // file:// 路径仍需转义 # / ?，否则 Uri.parse 会截断为 fragment/query
+          const rawPath = song.path.slice("file://".length);
+          const encodedPath = this.encodeLocalFilePath(rawPath);
+          return {
+            id: song.id,
+            url: `file://${encodedPath}`,
+            quality: song.quality,
+            source: "local",
+          };
+        }
       }
       // 检查本地文件是否存在
       const result = await window.electron.ipcRenderer.invoke("file-exists", song.path);
@@ -474,8 +496,8 @@ class SongManager {
         console.error("❌ 本地文件不存在");
         return { id: song.id, url: undefined };
       }
-      const encodedPath = song.path.replace(/#/g, "%23").replace(/\?/g, "%3F");
-      return { id: song.id, url: `file://${encodedPath}`, source: "local" };
+      const encodedPath = this.encodeLocalFilePath(song.path);
+      return { id: song.id, url: `file://${encodedPath}`, quality: song.quality, source: "local" };
     }
 
     // Stream songs (Subsonic / Jellyfin)

--- a/src/stores/music.ts
+++ b/src/stores/music.ts
@@ -1,4 +1,5 @@
 import { defineStore } from "pinia";
+import { Capacitor } from "@capacitor/core";
 import type { SongType } from "@/types/main";
 import { isCapacitorAndroid, isElectron } from "@/utils/env";
 import { cloneDeep } from "lodash-es";
@@ -69,9 +70,7 @@ export const useMusicStore = defineStore("music", {
     },
     /** 歌曲封面 */
     songCover(state): string {
-      return state.playSong.path
-        ? state.playSong.cover
-        : state.playSong.coverSize?.s || state.playSong.cover;
+      return resolveCoverForWebView(state.playSong.coverSize?.s || state.playSong.cover);
     },
     // 私人FM播放歌曲
     personalFMSong(state): SongType {
@@ -134,11 +133,7 @@ export const useMusicStore = defineStore("music", {
     },
     // 获取歌曲封面
     getSongCover(size: "s" | "m" | "l" | "xl" | "cover" = "s") {
-      return this.playSong.path
-        ? this.playSong.cover
-        : size === "cover"
-          ? this.playSong.cover
-          : this.playSong.coverSize?.[size] || this.playSong.cover;
+      return resolveCoverForWebView(size === "cover" ? this.playSong.cover : this.playSong.coverSize?.[size] || this.playSong.cover);
     },
   },
   // 持久化
@@ -151,3 +146,13 @@ export const useMusicStore = defineStore("music", {
     pick: ["playSong", "playPlaylistId", "personalFM", "dailySongsData"],
   },
 });
+
+const resolveCoverForWebView = (url?: string) => {
+  if (!url) return "";
+  if (!isCapacitorAndroid || (!url.startsWith("file://") && !url.startsWith("content://"))) return url;
+  try {
+    return Capacitor.convertFileSrc(url);
+  } catch {
+    return url;
+  }
+};

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,3 +1,4 @@
+import { Capacitor } from "@capacitor/core";
 import { useDataStore, useMusicStore, useStatusStore } from "@/stores";
 import type { ArtistType, CatType, CommentType, CoverType, MetaData, SongType } from "@/types/main";
 import { flatMap, isArray, uniqBy } from "lodash-es";
@@ -283,6 +284,17 @@ const getCoverUrl = (item: any): CoverDataType => {
 const getCoverSizeUrl = (url: string, size: number | null = null) => {
   try {
     if (!url) return "/images/song.jpg?asset";
+    // 本地 / SAF 来源的封面：Capacitor WebView 不允许直接 file:// / content:// 加载，
+    // 需经 Capacitor.convertFileSrc 转成 https://localhost/_capacitor_file_/... 代理。
+    // 同时不能拼 ?param= 参数（仅在线服务 CDN 支持）。data: URL 直接返回。
+    if (url.startsWith("data:")) return url;
+    if (url.startsWith("file://") || url.startsWith("content://")) {
+      try {
+        return Capacitor.convertFileSrc(url);
+      } catch {
+        return url;
+      }
+    }
     const sizeUrl = size
       ? typeof size === "number"
         ? `?param=${size}y${size}`

--- a/src/views/Local/albums.vue
+++ b/src/views/Local/albums.vue
@@ -117,8 +117,11 @@ watch(
 .local-albums {
   display: flex;
   height: calc((var(--layout-height) - 80) * 1px);
+  min-height: 0;
   :deep(.album-list) {
+    flex: 0 0 260px;
     width: 260px;
+    height: 100%;
     .n-scrollbar-content {
       padding: 0 5px 0 0 !important;
     }
@@ -183,7 +186,55 @@ watch(
   .song-list {
     width: 100%;
     flex: 1;
+    min-width: 0;
     margin-left: 15px;
+  }
+  @media (max-width: 767px) and (orientation: portrait) {
+    flex-direction: column;
+    height: auto;
+    min-height: 100%;
+    :deep(.album-list) {
+      flex: 0 0 auto;
+      width: 100%;
+      height: auto;
+      max-height: 260px;
+      margin-bottom: 12px;
+      .n-scrollbar-content {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 8px;
+        padding: 0 0 4px 0 !important;
+      }
+    }
+    .album-item {
+      margin-bottom: 0;
+      :deep(.n-card__content) {
+        padding: 10px;
+      }
+      &:last-child {
+        margin-bottom: 0;
+      }
+      .cover {
+        width: 42px;
+        height: 42px;
+        margin-right: 10px;
+        border-radius: 10px;
+      }
+      .data {
+        min-width: 0;
+      }
+      .name {
+        font-size: 14px;
+      }
+      .num {
+        font-size: 12px;
+      }
+    }
+    .song-list {
+      flex: 1;
+      width: 100%;
+      margin-left: 0;
+    }
   }
 }
 </style>

--- a/src/views/Local/artists.vue
+++ b/src/views/Local/artists.vue
@@ -116,8 +116,11 @@ watch(
 .local-artists {
   display: flex;
   height: calc((var(--layout-height) - 80) * 1px);
+  min-height: 0;
   :deep(.artist-list) {
+    flex: 0 0 200px;
     width: 200px;
+    height: 100%;
     .n-scrollbar-content {
       padding: 0 5px 0 0 !important;
     }
@@ -159,7 +162,46 @@ watch(
   .song-list {
     width: 100%;
     flex: 1;
+    min-width: 0;
     margin-left: 15px;
+  }
+  @media (max-width: 767px) and (orientation: portrait) {
+    flex-direction: column;
+    height: auto;
+    min-height: 100%;
+    :deep(.artist-list) {
+      flex: 0 0 auto;
+      width: 100%;
+      height: auto;
+      max-height: 220px;
+      margin-bottom: 12px;
+      .n-scrollbar-content {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 8px;
+        padding: 0 0 4px 0 !important;
+      }
+    }
+    .artist-item {
+      margin-bottom: 0;
+      :deep(.n-card__content) {
+        padding: 10px 12px;
+      }
+      &:last-child {
+        margin-bottom: 0;
+      }
+      .name {
+        font-size: 14px;
+      }
+      .num {
+        font-size: 12px;
+      }
+    }
+    .song-list {
+      flex: 1;
+      width: 100%;
+      margin-left: 0;
+    }
   }
 }
 </style>

--- a/src/views/Local/folders.vue
+++ b/src/views/Local/folders.vue
@@ -99,14 +99,18 @@ const treeData = computed<TreeOption[]>(() => {
   sortedPaths.forEach((fullPath) => {
     const isWindows = fullPath.includes("\\");
     const sep = isWindows ? "\\" : "/";
-    const segments = fullPath.split(/[/\\]/).filter(Boolean);
+    // 提取 scheme://（如 content://、file://），避免 filter(Boolean) 吃掉空串导致双斜杠变单斜杠
+    const schemeMatch = fullPath.match(/^([a-zA-Z][a-zA-Z0-9+.-]*:\/+)/);
+    const scheme = schemeMatch ? schemeMatch[1] : "";
+    const rest = scheme ? fullPath.slice(scheme.length) : fullPath;
+    const segments = rest.split(/[/\\]/).filter(Boolean);
 
-    let currentPath = "";
-    if (fullPath.startsWith(sep)) currentPath = sep;
+    let currentPath = scheme;
+    if (!scheme && fullPath.startsWith(sep)) currentPath = sep;
 
     segments.forEach((segment, index) => {
       const prevPath = currentPath;
-      if (index === 0 && !fullPath.startsWith(sep)) {
+      if (index === 0 && !scheme && !fullPath.startsWith(sep)) {
         currentPath = segment;
       } else {
         currentPath = currentPath.endsWith(sep)
@@ -288,8 +292,10 @@ onDeactivated(() => {
 .local-folders {
   display: flex;
   height: calc((var(--layout-height) - 80) * 1px);
+  min-height: 0;
 
   :deep(.folder-list) {
+    flex: 0 0 280px;
     width: 280px;
     height: 100%;
     background-color: var(--surface-container-hex);
@@ -305,7 +311,29 @@ onDeactivated(() => {
   .song-list {
     width: 100%;
     flex: 1;
+    min-width: 0;
     margin-left: 15px;
+  }
+
+  @media (max-width: 767px) and (orientation: portrait) {
+    flex-direction: column;
+    height: auto;
+    min-height: 100%;
+
+    :deep(.folder-list) {
+      flex: 0 0 auto;
+      width: 100%;
+      height: auto;
+      max-height: 240px;
+      margin-bottom: 12px;
+      padding: 8px;
+    }
+
+    .song-list {
+      flex: 1;
+      width: 100%;
+      margin-left: 0;
+    }
   }
 }
 </style>

--- a/src/views/Local/layout.vue
+++ b/src/views/Local/layout.vue
@@ -135,13 +135,22 @@
         <KeepAlive v-if="settingStore.useKeepAlive">
           <component
             :is="Component"
+            :key="routeKey"
             :data="listData"
             :loading="loading"
             :list-version="listVersion"
             class="router-view"
           />
         </KeepAlive>
-        <component v-else :is="Component" :data="listData" :loading="loading" class="router-view" />
+        <component
+          v-else
+          :is="Component"
+          :key="routeKey"
+          :data="listData"
+          :loading="loading"
+          :list-version="listVersion"
+          class="router-view"
+        />
       </Transition>
     </RouterView>
     <!-- 空状态 -->
@@ -188,6 +197,7 @@ const localEventBus = useEventBus("local");
 
 // 本地歌曲路由
 const localType = ref<string>((router.currentRoute.value?.name as string) || "local-songs");
+const routeKey = computed(() => (router.currentRoute.value?.name as string) || "local-songs");
 
 // 选中的文件夹
 const selectedFolder = ref<string>("all");
@@ -385,6 +395,14 @@ interface SyncCompleteData {
   tracks?: Record<string, unknown>[];
 }
 
+const isSyncCompleteData = (value: unknown): value is SyncCompleteData => {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { success?: unknown }).success === "boolean"
+  );
+};
+
 // 获取全部路径歌曲（流式接收）
 const getAllLocalMusic = debounce(
   async (showTip: boolean = false) => {
@@ -513,7 +531,7 @@ const getAllLocalMusic = debounce(
       // 触发同步
       const res = await window.electron.ipcRenderer.invoke("local-music-sync", allPath);
       // 检查返回值，如果是扫描正在进行中
-      if (res && !res.success) {
+      if (isSyncCompleteData(res) && !res.success) {
         isCompleted = true;
         loading.value = false;
         loadingMsg.value?.destroy();
@@ -705,7 +723,10 @@ onUnmounted(() => {
     overflow: hidden;
     max-height: calc((var(--layout-height) - 132) * 1px);
   }
-  @media (max-width: 768px) {
+  @media (max-width: 767px) and (orientation: portrait) {
+    height: 100%;
+    min-height: calc(100dvh - var(--app-header-height) - var(--phone-nav-total-height) - 16px);
+
     .title {
       margin-top: 8px;
       margin-bottom: 16px;
@@ -749,8 +770,8 @@ onUnmounted(() => {
     }
 
     .router-view {
-      max-height: none;
       min-height: 0;
+      max-height: none;
     }
   }
   @media (max-width: 512px) {

--- a/src/views/Local/playlists.vue
+++ b/src/views/Local/playlists.vue
@@ -49,5 +49,19 @@ const playlistData = computed<CoverType[]>(() => {
   .empty {
     margin-top: 100px;
   }
+  @media (max-width: 767px) and (orientation: portrait) {
+    max-height: none;
+    min-height: 100%;
+    overflow: visible;
+    :deep(.n-scrollbar) {
+      max-height: none;
+    }
+    .cover-list {
+      padding: 0 2px 12px;
+    }
+    .empty {
+      margin-top: 48px;
+    }
+  }
 }
 </style>


### PR DESCRIPTION
## 📌 变更类型

- [x] ✨ feat — 新功能
- [x] 🐞 fix — Bug 修复
- [ ] 🎨 style — 仅样式 / 格式，不影响逻辑
- [x] ♻️ refactor — 重构，不改变外部行为
- [x] ⚡ perf — 性能优化

## 📝 变更说明

本 PR 聚焦 Android 端播放稳定性、本地音乐能力和移动端界面适配，主要完成以下改动：

1. 优化移动端竖屏响应式布局，改善 `SongList` 以及本地音乐的列表、歌手、专辑、文件夹页面在手机竖屏下的显示效果，同时兼顾平板横屏布局。
2. 修复 Android 端播放异常问题，完善 MediaSession 封面路径处理、本地文件路径转义、播放错误后的原生恢复机制，降低后台播放、URL 过期或网络波动导致的播放失败概率。
3. 完善本地音乐功能，新增本地歌曲嵌入封面提取与缓存，修复文件夹路径解析问题，并补充播放缓存清理相关接口。
4. 修复播放器状态同步问题，统一 Android 原生播放器与前端状态同步的时间单位，避免远程通知栏进度异常，并减少重复触发 `ENDED` 事件导致的状态错乱。
5. 优化图片组件和封面缓存链路，适配 Android 原生 `file://` / `content://` 协议图片加载，避免 WebView 直接加载本地资源失败。

## 🔗 关联 Issue

Closes #

## 📱 影响范围

- [x] 🎵 播放引擎 / 音频
- [ ] 📝 歌词 / 桌面歌词
- [x] 🔔 通知栏 / MediaSession
- [ ] 🌐 在线音乐 (网易云 / Jellyfin / Navidrome / Emby / Subsonic / Last.fm)
- [ ] 🧩 内置 API (nodejs-mobile)
- [ ] 🎨 UI / 主题 / 布局
- [ ] 📦 构建 / 打包 / 签名
- [x] 📱 Capacitor / 原生 Android 代码
- [ ] 📄 文档 / README

## ✅ 自检清单

- [x] 本 PR **目标分支为 `dev`**
- [x] 本地已执行 `pnpm lint` 且无 warning
- [x] 本地已执行 `pnpm typecheck` 且无报错
- [x] 已在 **至少一台真机** 上构建并验证关键路径
- [x] UI 改动已兼顾 **手机竖屏 + 平板横屏** 两种布局
- [x] 新增 / 修改的文案使用中文，与项目整体风格一致
- [x] 未引入不必要的依赖 / 大体积资源
- [x] 未修改签名密钥 / CI Secrets 相关文件

## 🧪 测试方式

1. 在 Android 真机上安装应用，验证在线歌曲、本地歌曲、后台播放、锁屏/通知栏控制、上一首/下一首切换均可正常工作。
2. 扫描本地音乐目录，检查本地歌曲列表、歌手、专辑、文件夹页面展示是否正常，并确认本地歌曲封面可正确显示。
3. 在手机竖屏和平板横屏下分别进入歌曲列表、本地音乐页面、播放器页面，确认布局没有遮挡、溢出或错位。
4. 将应用切到后台或锁屏一段时间后继续播放，验证播放不中断，通知栏进度、封面、歌曲信息和 MediaSession 控制状态正确。
5. 执行 `pnpm lint`、`pnpm typecheck`，并完成 Android 真机构建安装验证。

## 💬 其他说明

- Android WebView 不能直接加载应用私有目录下的 `file://` 资源，本 PR 对本地封面路径做了兼容处理。
- 原生播放错误恢复仅作为后台播放和网络波动场景的兜底，若多次恢复失败仍会回退到现有前端重试/跳过逻辑。
- 本次未修改签名、CI Secrets 或构建密钥相关文件。