### PR TITLE
优化UI页面操作方式，为用户提供更加便捷的操作

### DIFF
--- a/src/components/Layout/Nav.vue
+++ b/src/components/Layout/Nav.vue
@@ -143,7 +143,7 @@ import { isDev, isElectron } from "@/utils/env";
 const router = useRouter();
 const settingStore = useSettingStore();
 const statusStore = useStatusStore();
-const { isPad, isPhone, isLandscape } = useDevice();
+const { isPad, isPhone, isLandscape, isPhonePortrait } = useDevice();
 
 // 更新按钮提示
 const updateBtnTitle = computed(() => {
@@ -230,7 +230,7 @@ const setOptions = computed<DropdownOption[]>(() => [
     key: "zoom",
     label: "界面缩放",
     icon: renderIcon("ZoomIn"),
-    show: isElectron,
+    show: isElectron || isPad.value || isPhonePortrait.value,
   },
   {
     key: "divider-1",

--- a/src/components/Layout/Sider.vue
+++ b/src/components/Layout/Sider.vue
@@ -8,7 +8,9 @@
     </div>
     <n-scrollbar
       :style="{
-        maxHeight: `calc(100vh - ${musicStore.isHasPlayer && statusStore.showPlayBar ? 150 : 70}px)`,
+        maxHeight: `calc(var(--page-zoom-100vh, 100vh) - ${
+          musicStore.isHasPlayer && statusStore.showPlayBar ? 150 : 70
+        }px)`,
       }"
     >
       <Menu />

--- a/src/components/List/SongPlayList.vue
+++ b/src/components/List/SongPlayList.vue
@@ -25,8 +25,8 @@
           :default-scroll-index="statusStore.playIndex"
           class="playlist-list"
           :class="{ 'is-dragging-global': isDragging }"
-          style="max-height: calc(100dvh - 142px)"
-          :height="`calc(100dvh - 142px)`"
+          style="max-height: calc(var(--page-zoom-100dvh, 100dvh) - 142px)"
+          :height="`calc(var(--page-zoom-100dvh, 100dvh) - 142px)`"
         >
           <template #default="{ item: songData, index }">
             <div class="song-node">

--- a/src/components/Modal/ScalingModal.vue
+++ b/src/components/Modal/ScalingModal.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="scaling-modal">
     <div class="tip">
-      <n-text depth="3" class="value">可调节范围：50% - 200%</n-text>
+      <n-text depth="3" class="value">{{ modeLabel }}：50% - 200%</n-text>
     </div>
     <n-input-number
       v-model:value="zoomPercentage"
@@ -14,17 +14,76 @@
       <template #suffix>%</template>
     </n-input-number>
     <n-button size="small" secondary type="primary" @click="resetZoom"> 恢复默认 </n-button>
+    <n-card
+      v-if="showFullscreenOptimize"
+      :bordered="false"
+      embedded
+      size="small"
+      class="fullscreen-optimize"
+    >
+      <n-flex :wrap="false" align="center" justify="space-between">
+        <div class="fullscreen-optimize__text">
+          <n-text class="fullscreen-optimize__title">全面屏优化</n-text>
+          <n-text depth="3" class="fullscreen-optimize__desc">
+            避免底部按钮被系统返回按钮遮挡
+          </n-text>
+        </div>
+        <n-switch v-model:value="settingStore.androidFullscreenSafeAreaOptimize" :round="false" />
+      </n-flex>
+    </n-card>
   </div>
 </template>
 
 <script setup lang="ts">
+import { useSettingStore } from "@/stores";
+import { useDevice } from "@/composables/useDevice";
+import { isCapacitorAndroid, isElectron } from "@/utils/env";
+
+const settingStore = useSettingStore();
+const { isPad, isPhonePortrait } = useDevice();
 const zoomPercentage = ref(100);
+// 首次从 store / IPC 同步当前值不应回写：避免一次无意义的 persist + apply
+const isReady = ref(false);
+
+const modeLabel = computed(() => {
+  if (isElectron) return "桌面缩放";
+  if (isPad.value) return "平板模式缩放";
+  if (isPhonePortrait.value) return "手机竖屏缩放";
+  return "页面缩放";
+});
+
+const showFullscreenOptimize = computed(() => isCapacitorAndroid && isPhonePortrait.value);
+
+const getZoom = () => {
+  // Electron 走原生 zoom-factor IPC，不应回读移动端字段（防御：onMounted 已先短路到 IPC 分支）
+  if (isElectron) return 100;
+  if (isPad.value) return settingStore.padPageZoom;
+  if (isPhonePortrait.value) return settingStore.phonePortraitPageZoom;
+  return 100;
+};
+
+const setZoom = (value: number) => {
+  // Electron 走原生 zoom-factor IPC，不应写入移动端字段（防御：watcher 已先短路到 IPC 分支）
+  if (isElectron) return;
+  if (isPad.value) {
+    settingStore.padPageZoom = value;
+    return;
+  }
+  if (isPhonePortrait.value) {
+    settingStore.phonePortraitPageZoom = value;
+    return;
+  }
+  // 其他模式（如手机横屏）没有对应缩放路径，丢弃写入避免静默落到无效字段
+};
 
 watch(zoomPercentage, (newVal) => {
-  if (newVal) {
-    const factor = newVal / 100;
-    window.electron.ipcRenderer.invoke("set-zoom-factor", factor);
+  if (!isReady.value) return;
+  if (!newVal) return;
+  if (isElectron) {
+    window.electron.ipcRenderer.invoke("set-zoom-factor", newVal / 100);
+    return;
   }
+  setZoom(newVal);
 });
 
 const resetZoom = () => {
@@ -32,8 +91,15 @@ const resetZoom = () => {
 };
 
 onMounted(async () => {
-  const currentZoom = await window.electron.ipcRenderer.invoke("get-zoom-factor");
-  zoomPercentage.value = Math.round(currentZoom * 100);
+  if (isElectron) {
+    const currentZoom = (await window.electron.ipcRenderer.invoke("get-zoom-factor")) as number;
+    zoomPercentage.value = Math.round(currentZoom * 100);
+  } else {
+    zoomPercentage.value = getZoom() || 100;
+  }
+  // 等当前帧 watcher 被同步触发完再放开写入
+  await nextTick();
+  isReady.value = true;
 });
 </script>
 
@@ -61,6 +127,25 @@ onMounted(async () => {
     gap: 8px;
     .value {
       font-size: 13px;
+    }
+  }
+
+  .fullscreen-optimize {
+    width: 100%;
+
+    &__text {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      min-width: 0;
+    }
+
+    &__title {
+      font-size: 14px;
+    }
+
+    &__desc {
+      font-size: 12px;
     }
   }
 }

--- a/src/components/Player/FullPlayer.vue
+++ b/src/components/Player/FullPlayer.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport to="#app">
     <Transition
       :name="useCompactMobilePlayer ? 'mobile-card' : settingStore.playerExpandAnimation"
       :css="!useCompactMobilePlayer"
@@ -121,7 +121,7 @@ const onMobileEnter = (el: Element, done: () => void) => {
     parent.style.transformOrigin = "50% 0";
     parent.style.willChange = "transform";
     parent.style.transition = "none";
-    parent.style.transform = "translate3d(0, 100vh, 0) scale(0.92)";
+    parent.style.transform = "translate3d(0, var(--page-zoom-100vh, 100vh), 0) scale(0.92)";
     parent.style.borderRadius = "28px";
     parent.style.backfaceVisibility = "hidden";
     done();
@@ -131,7 +131,7 @@ const onMobileEnter = (el: Element, done: () => void) => {
   parent.style.transformOrigin = "50% 0";
   parent.style.willChange = "transform";
   parent.style.transition = "none";
-  parent.style.transform = "translate3d(0, 100vh, 0) scale(0.92)";
+  parent.style.transform = "translate3d(0, var(--page-zoom-100vh, 100vh), 0) scale(0.92)";
   parent.style.borderRadius = "28px";
   parent.style.backfaceVisibility = "hidden";
   // 强制重排，确保起始状态生效
@@ -162,7 +162,7 @@ const onMobileLeave = (el: Element, done: () => void) => {
   parent.style.borderRadius = "28px";
   parent.style.backfaceVisibility = "hidden";
   requestAnimationFrame(() => {
-    parent.style.transform = "translate3d(0, 100vh, 0) scale(0.92)";
+    parent.style.transform = "translate3d(0, var(--page-zoom-100vh, 100vh), 0) scale(0.92)";
   });
   window.setTimeout(() => {
     done();
@@ -383,7 +383,7 @@ onBeforeUnmount(() => {
     justify-content: center;
     align-items: center;
     width: 100%;
-    height: calc(100dvh - 160px);
+    height: calc(var(--page-zoom-100dvh, 100dvh) - 160px);
     transition:
       opacity 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
       transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
@@ -455,7 +455,8 @@ onBeforeUnmount(() => {
           .player-data {
             width: 100%;
             max-width: 100%;
-            transform: translateY(30vh);
+            // 30vh 表示相对屏幕高度的初始偏移，需走 --page-zoom-100vh 防止 transform 二次缩放
+            transform: translateY(calc(var(--page-zoom-100vh, 100vh) * 0.3));
           }
         }
       }

--- a/src/components/Player/FullPlayer.vue
+++ b/src/components/Player/FullPlayer.vue
@@ -97,6 +97,7 @@
 import { useDevice } from "@/composables/useDevice";
 import { useStatusStore, useMusicStore, useSettingStore } from "@/stores";
 import { isElectron } from "@/utils/env";
+import { PLAYER_META_HOLD_KEY, type PlayerMetaHold } from "@/composables/usePlayerMetaHold";
 
 const musicStore = useMusicStore();
 const statusStore = useStatusStore();
@@ -279,14 +280,18 @@ const instantLyrics = computed(() => {
   return { content: contentStr, tran: settingStore.showTran && content?.translatedLyric };
 });
 
+/** 由 popover 等弹层 acquire / release 的引用计数，hold > 0 期间禁止自动隐藏 */
+const playerMetaHoldCount = ref(0);
+
 const {
   isPending,
   start: startShow,
   stop: stopShow,
 } = useTimeoutFn(() => {
-  if (settingStore.autoHidePlayerMeta) {
-    statusStore.playerMetaShow = false;
-  }
+  if (!settingStore.autoHidePlayerMeta) return;
+  // 有弹层 hold 时不隐藏，避免 popover trigger DOM 消失导致定位错乱
+  if (playerMetaHoldCount.value > 0) return;
+  statusStore.playerMetaShow = false;
 }, 3000);
 
 /** 鼠标是否在操作区域（菜单/控制栏） */
@@ -311,17 +316,39 @@ const stopHide = () => {
 
 const resumeHide = () => {
   inControlArea.value = false;
-  if (settingStore.autoHidePlayerMeta) {
+  if (settingStore.autoHidePlayerMeta && playerMetaHoldCount.value === 0) {
     startShow();
   }
 };
 
 const playerLeave = () => {
-  if (settingStore.autoHidePlayerMeta) {
+  if (settingStore.autoHidePlayerMeta && playerMetaHoldCount.value === 0) {
     statusStore.playerMetaShow = false;
     stopShow();
   }
 };
+
+// 弹层 hold：popover 打开期间 acquire，关闭后 release
+const playerMetaHold: PlayerMetaHold = {
+  acquire: () => {
+    playerMetaHoldCount.value++;
+    // autoHide 关闭时无自动隐藏可阻止，hold 仅记账，不主动写 playerMetaShow
+    if (!settingStore.autoHidePlayerMeta) return;
+    stopShow();
+    statusStore.playerMetaShow = true;
+  },
+  release: () => {
+    playerMetaHoldCount.value = Math.max(0, playerMetaHoldCount.value - 1);
+    if (
+      playerMetaHoldCount.value === 0 &&
+      settingStore.autoHidePlayerMeta &&
+      !inControlArea.value
+    ) {
+      startShow();
+    }
+  },
+};
+provide(PLAYER_META_HOLD_KEY, playerMetaHold);
 
 watch(
   () => statusStore.mainColor,

--- a/src/components/Player/FullPlayerMobile.vue
+++ b/src/components/Player/FullPlayerMobile.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
-let savedPageIndex = 0;
+type MobilePageType = "comment" | "info" | "lyric";
+let savedPageType: MobilePageType = "info";
 </script>
 
 <template>
@@ -24,9 +25,13 @@ let savedPageIndex = 0;
 
     <div
       :class="['mobile-content', { swiping: isHorizontalSwipe }]"
-      :style="{ transform: contentTransform }"
+      :style="{ transform: contentTransform, '--page-count': totalPages }"
       @click.stop
     >
+      <div v-if="hasComment" class="page comment-page">
+        <PlayerComment :active="pageIndex === commentIdx" embedded class="mobile-comment" />
+      </div>
+
       <div class="page info-page">
         <div class="cover-section">
           <PlayerCover :no-lyric="true" />
@@ -122,7 +127,7 @@ let savedPageIndex = 0;
         </div>
       </div>
 
-      <div class="page lyric-page">
+      <div v-if="hasLyric" class="page lyric-page">
         <div class="lyric-header">
           <s-image :src="musicStore.getSongCover('s')" cache-type="covers" class="lyric-cover" />
           <div class="lyric-info">
@@ -155,9 +160,9 @@ let savedPageIndex = 0;
       </div>
     </div>
 
-    <div v-if="hasLyric" class="pagination">
+    <div v-if="totalPages > 1" class="pagination">
       <div
-        v-for="i in 2"
+        v-for="i in totalPages"
         :key="i"
         :class="['dot', { active: pageIndex === i - 1 }]"
         @click="pageIndex = i - 1"
@@ -196,24 +201,56 @@ const LYRIC_HEADER_MAX_PADDING = 60;
 const mobileStart = ref<HTMLElement | null>(null);
 const topBarRef = ref<HTMLElement | null>(null);
 const dragHandleRef = ref<HTMLElement | null>(null);
-// 当前歌曲无歌词时强制初始化为信息页，否则恢复模块级缓存
-// 避免「上次停在歌词页 → 切到无歌词歌曲再打开」时 watch 不触发导致空白歌词页
-const pageIndex = ref(
-  musicStore.isHasLrc && musicStore.playSong.type !== "radio" ? savedPageIndex : 0,
-);
+
+// 歌词/评论可用性
+const hasLyric = computed(() => musicStore.isHasLrc && musicStore.playSong.type !== "radio");
+const hasComment = computed(() => {
+  if (musicStore.playSong.path) return false;
+  if (statusStore.pureLyricMode) return false;
+  if (settingStore.fullscreenPlayerElements?.comments === false) return false;
+  const id = musicStore.playSong.id;
+  return typeof id === "number" && id > 0;
+});
+
+// 总页数（信息页恒存在，评论/歌词按需）
+const totalPages = computed(() => 1 + (hasComment.value ? 1 : 0) + (hasLyric.value ? 1 : 0));
+// 页面顺序: [评论 | 信息 | 歌词]
+// 评论页索引（恒为 0，若不存在则 -1）
+const commentIdx = computed(() => (hasComment.value ? 0 : -1));
+// 信息页索引（评论存在则后移一位）
+const infoIdx = computed(() => (hasComment.value ? 1 : 0));
+// 歌词页索引（在信息页之后）
+const lyricIdx = computed(() => (hasLyric.value ? infoIdx.value + 1 : -1));
+
+// 上次访问的页面类型 → 当前布局下的实际索引；不存在则回退到信息页
+const resolveSavedPageIndex = (type: MobilePageType): number => {
+  if (type === "comment" && hasComment.value) return commentIdx.value;
+  if (type === "lyric" && hasLyric.value) return lyricIdx.value;
+  return infoIdx.value;
+};
+
+// 默认落在「信息」页，并尽量恢复上次浏览的页面类型
+const pageIndex = ref(resolveSavedPageIndex(savedPageType));
 
 const lyricHeaderHorizontalPadding = computed(() => {
   const padding = Math.max(0, settingStore.lyricHorizontalOffset);
   return `${Math.min(padding, LYRIC_HEADER_MAX_PADDING)}px`;
 });
 
-// 下拉关闭手势捕获区高度：信息页仅覆盖顶栏 + 封面上半段，避免遮挡下方按钮
-// 歌词页含顶栏 + 歌曲信息条
-const dragHandleHeight = computed(() =>
-  pageIndex.value === 0
-    ? "calc(40px + var(--mobile-safe-top) + 32vh)"
-    : "calc(140px + var(--mobile-safe-top))",
-);
+// 当前页面类型
+const currentPageType = computed<MobilePageType>(() => {
+  if (pageIndex.value === commentIdx.value) return "comment";
+  if (pageIndex.value === lyricIdx.value) return "lyric";
+  return "info";
+});
+
+// 下拉关闭手势捕获区高度：信息页覆盖顶栏 + 封面区域；歌词页含顶栏 + 歌曲信息条；
+// 评论页仅顶栏（让出滚动空间给评论列表）
+const dragHandleHeight = computed(() => {
+  if (currentPageType.value === "info") return "calc(40px + var(--mobile-safe-top) + 32vh)";
+  if (currentPageType.value === "lyric") return "calc(140px + var(--mobile-safe-top))";
+  return "calc(56px + var(--mobile-safe-top))";
+});
 
 // 顶部区域下拉关闭：整个全屏播放器（含背景蒙层）跟手下移，露出底部主页面
 let dragValue = 0;
@@ -381,8 +418,6 @@ onBeforeUnmount(() => {
   resetInlineStyles();
 });
 
-const hasLyric = computed(() => musicStore.isHasLrc && musicStore.playSong.type !== "radio");
-
 const artistName = computed(() => {
   const artists = musicStore.playSong.artists;
   if (Array.isArray(artists)) {
@@ -391,25 +426,35 @@ const artistName = computed(() => {
   return (artists as string) || "未知艺术家";
 });
 
-watch(hasLyric, (value) => {
-  if (!value) pageIndex.value = 0;
+// 页面可用性变化时按页面语义迁移 pageIndex
+watch([hasComment, hasLyric], (_n, [prevHasComment, prevHasLyric]) => {
+  const prevCommentIdx = prevHasComment ? 0 : -1;
+  const prevInfoIdx = prevHasComment ? 1 : 0;
+  const prevLyricIdx = prevHasLyric ? prevInfoIdx + 1 : -1;
+
+  let prevType: MobilePageType = "info";
+  if (pageIndex.value === prevCommentIdx) prevType = "comment";
+  else if (pageIndex.value === prevLyricIdx) prevType = "lyric";
+
+  pageIndex.value = resolveSavedPageIndex(prevType);
 });
 
-watch(pageIndex, (value) => {
-  savedPageIndex = value;
+// 同步缓存页面语义
+watch(currentPageType, (t) => {
+  savedPageType = t;
 });
 
 const { direction, isSwiping, lengthX, lengthY } = useSwipe(mobileStart, {
   threshold: 5,
   onSwipeEnd: () => {
-    if (!hasLyric.value) return;
-    // 仅在主方向为水平时触发翻页，避免上下滑动歌词误触
+    if (totalPages.value <= 1) return;
+    // 仅在主方向为水平时触发翻页，避免上下滑动歌词/评论误触
     if (Math.abs(lengthX.value) <= Math.abs(lengthY.value)) return;
 
     if (direction.value === "left" && lengthX.value > 100) {
-      pageIndex.value = 1;
+      pageIndex.value = Math.min(pageIndex.value + 1, totalPages.value - 1);
     } else if (direction.value === "right" && lengthX.value < -100) {
-      pageIndex.value = 0;
+      pageIndex.value = Math.max(pageIndex.value - 1, 0);
     }
   },
 });
@@ -420,8 +465,9 @@ const isHorizontalSwipe = computed(
 );
 
 const contentTransform = computed(() => {
-  const baseOffset = pageIndex.value * 50;
-  if (!isHorizontalSwipe.value || !hasLyric.value) {
+  const pageWidthPct = 100 / totalPages.value;
+  const baseOffset = pageIndex.value * pageWidthPct;
+  if (!isHorizontalSwipe.value || totalPages.value <= 1) {
     return `translateX(-${baseOffset}%)`;
   }
 
@@ -429,7 +475,7 @@ const contentTransform = computed(() => {
   if (pageIndex.value === 0 && pixelOffset < 0) {
     pixelOffset *= 0.3;
   }
-  if (pageIndex.value === 1 && pixelOffset > 0) {
+  if (pageIndex.value === totalPages.value - 1 && pixelOffset > 0) {
     pixelOffset *= 0.3;
   }
 
@@ -500,18 +546,20 @@ const contentTransform = computed(() => {
   .mobile-content {
     flex: 1;
     display: flex;
-    width: 200%;
+    width: calc(var(--page-count, 1) * 100%);
     height: 100%;
     transition: transform 0.3s cubic-bezier(0.25, 1, 0.5, 1);
+    // 横滑交给 useSwipe
+    touch-action: pan-y;
 
     &.swiping {
       transition: none;
     }
 
     .page {
-      width: 50%;
+      width: calc(100% / var(--page-count, 1));
+      flex: 0 0 calc(100% / var(--page-count, 1));
       height: 100%;
-      flex-shrink: 0;
       position: relative;
     }
   }
@@ -761,6 +809,67 @@ const contentTransform = computed(() => {
     }
   }
 
+  .comment-page {
+    padding: calc(56px + var(--mobile-safe-top)) 0 calc(24px + var(--mobile-safe-bottom));
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+
+    // 小屏视觉调优
+    :deep(.mobile-comment) {
+      .song-data {
+        height: 80px;
+        margin: 0 16px 12px;
+        padding: 0 14px;
+
+        .cover-img {
+          width: 56px;
+          height: 56px;
+          border-radius: 10px;
+        }
+
+        .title {
+          font-size: 17px;
+        }
+
+        .artist {
+          font-size: 12px;
+        }
+
+        .actions {
+          gap: 8px;
+
+          .close {
+            width: 36px;
+            height: 36px;
+          }
+        }
+      }
+
+      .comment-scroll .n-scrollbar-content {
+        padding: 0 16px;
+      }
+
+      .placeholder {
+        height: 56px;
+        padding-bottom: 10px;
+
+        &:last-child {
+          height: 0;
+          padding-top: 24px;
+        }
+
+        .title {
+          font-size: 18px;
+
+          .n-icon {
+            margin-right: 4px;
+          }
+        }
+      }
+    }
+  }
+
   .pagination {
     position: absolute;
     left: 0;
@@ -818,6 +927,23 @@ const contentTransform = computed(() => {
 
       .lyric-header {
         gap: 12px;
+      }
+    }
+
+    .comment-page {
+      padding: calc(52px + var(--mobile-safe-top)) 0 calc(20px + var(--mobile-safe-bottom));
+
+      :deep(.mobile-comment) {
+        .song-data {
+          margin: 0 12px 10px;
+          padding: 0 12px;
+        }
+
+        .comment-scroll {
+          .n-scrollbar-content {
+            padding: 0 12px;
+          }
+        }
       }
     }
   }

--- a/src/components/Player/FullPlayerMobile.vue
+++ b/src/components/Player/FullPlayerMobile.vue
@@ -64,6 +64,8 @@ let savedPageType: MobilePageType = "info";
               >
                 <SvgIcon name="AddList" :size="26" />
               </div>
+              <!-- 快捷操作菜单 -->
+              <PlayerQuickActionsMenu />
             </div>
           </div>
 

--- a/src/components/Player/FullPlayerMobile.vue
+++ b/src/components/Player/FullPlayerMobile.vue
@@ -247,7 +247,10 @@ const currentPageType = computed<MobilePageType>(() => {
 // 下拉关闭手势捕获区高度：信息页覆盖顶栏 + 封面区域；歌词页含顶栏 + 歌曲信息条；
 // 评论页仅顶栏（让出滚动空间给评论列表）
 const dragHandleHeight = computed(() => {
-  if (currentPageType.value === "info") return "calc(40px + var(--mobile-safe-top) + 32vh)";
+  if (currentPageType.value === "info") {
+    // 32vh 表示相对屏幕高度的比例热区，需走 --page-zoom-100vh 防止被 transform 二次缩放
+    return "calc(40px + var(--mobile-safe-top) + var(--page-zoom-100vh, 100vh) * 0.32)";
+  }
   if (currentPageType.value === "lyric") return "calc(140px + var(--mobile-safe-top))";
   return "calc(56px + var(--mobile-safe-top))";
 });
@@ -486,7 +489,7 @@ const contentTransform = computed(() => {
 <style lang="scss" scoped>
 .full-player-mobile {
   --mobile-safe-top: max(env(safe-area-inset-top), 0px);
-  --mobile-safe-bottom: max(env(safe-area-inset-bottom), 0px);
+  --mobile-safe-bottom: var(--safe-area-bottom);
   width: 100%;
   height: 100%;
   position: relative;

--- a/src/components/Player/PlayerComponents/PlayerComment.vue
+++ b/src/components/Player/PlayerComponents/PlayerComment.vue
@@ -1,6 +1,6 @@
 <!-- 播放器 - 评论 -->
 <template>
-  <div class="player-comment" :class="{ 'no-song-data': hideSongData }">
+  <div class="player-comment" :class="{ 'no-song-data': hideSongData, embedded }">
     <n-flex v-if="!hideSongData" :wrap="false" align="center" class="song-data">
       <n-image
         :src="musicStore.songCover"
@@ -33,12 +33,7 @@
         <n-flex class="close" align="center" justify="center" @click="openExcludeComment">
           <SvgIcon name="Tag" :size="20" />
         </n-flex>
-        <n-flex
-          class="close"
-          align="center"
-          justify="center"
-          @click="statusStore.showPlayerComment = false"
-        >
+        <n-flex v-if="!embedded" class="close" align="center" justify="center" @click="handleClose">
           <SvgIcon name="Music" :size="24" />
         </n-flex>
       </div>
@@ -97,13 +92,19 @@ import { NScrollbar } from "naive-ui";
 import { coverLoaded } from "@/utils/helper";
 import { openExcludeComment } from "@/utils/modal";
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     /** 隐藏顶部歌曲卡片 */
     hideSongData?: boolean;
+    /** 嵌入模式下是否激活 */
+    active?: boolean;
+    /** 嵌入式布局 */
+    embedded?: boolean;
   }>(),
-  { hideSongData: false },
+  { hideSongData: false, embedded: false },
 );
+
+const emit = defineEmits<{ (e: "close"): void }>();
 
 const musicStore = useMusicStore();
 const statusStore = useStatusStore();
@@ -112,7 +113,16 @@ const settingStore = useSettingStore();
 const commentScroll = ref<InstanceType<typeof NScrollbar> | null>(null);
 
 // 是否展示
-const isShowComment = computed<boolean>(() => statusStore.showPlayerComment);
+const isShowComment = computed<boolean>(() =>
+  props.embedded ? !!props.active : statusStore.showPlayerComment,
+);
+
+const handleClose = () => {
+  emit("close");
+  if (!props.embedded) {
+    statusStore.showPlayerComment = false;
+  }
+};
 
 // 歌曲 id
 const songId = computed<number | string>(() => musicStore.playSong.id);
@@ -123,7 +133,7 @@ const songType = computed<0 | 1 | 7 | 2 | 3 | 4 | 5 | 6>(() =>
 );
 
 // 评论数据
-const commentLoading = ref<boolean>(true);
+const commentLoading = ref<boolean>(props.embedded ? !!props.active : true);
 const commentData = ref<CommentType[]>([]);
 const commentHotData = ref<CommentType[] | null>(null);
 const commentPage = ref<number>(1);
@@ -282,6 +292,23 @@ onMounted(() => {
   width: 100%;
   height: calc(100vh - 160px);
   overflow: hidden;
+  // 嵌入式布局
+  &.embedded {
+    position: relative;
+    right: auto;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    .song-data {
+      flex: 0 0 auto;
+    }
+    :deep(.comment-scroll) {
+      flex: 1 1 auto;
+      min-height: 0;
+      height: auto;
+    }
+  }
   :deep(.n-text),
   :deep(.n-icon),
   :deep(.n-button) {

--- a/src/components/Player/PlayerComponents/PlayerComment.vue
+++ b/src/components/Player/PlayerComponents/PlayerComment.vue
@@ -290,7 +290,7 @@ onMounted(() => {
   width: 60%;
   flex: 1;
   width: 100%;
-  height: calc(100vh - 160px);
+  height: calc(var(--page-zoom-100vh, 100vh) - 160px);
   overflow: hidden;
   // 嵌入式布局
   &.embedded {
@@ -353,11 +353,11 @@ onMounted(() => {
 
   &.no-song-data {
     :deep(.comment-scroll) {
-      height: calc(100vh - 160px);
+      height: calc(var(--page-zoom-100vh, 100vh) - 160px);
     }
   }
   :deep(.comment-scroll) {
-    height: calc(100vh - 262px);
+    height: calc(var(--page-zoom-100vh, 100vh) - 262px);
     filter: drop-shadow(0px 4px 6px rgba(0, 0, 0, 0.2));
     mask: linear-gradient(
       180deg,

--- a/src/components/Player/PlayerControl.vue
+++ b/src/components/Player/PlayerControl.vue
@@ -54,6 +54,8 @@
               <SvgIcon :depth="statusStore.showPlayerComment ? 1 : 3" name="Message" />
             </div>
           </n-badge>
+          <!-- 快捷操作菜单：频谱 / AMLL / 动态封面 / 音量 / 桌面歌词 / 逐词 / TTML -->
+          <PlayerQuickActionsMenu variant="control" />
         </n-flex>
         <div class="center">
           <div class="btn">

--- a/src/components/Player/PlayerLyric/AMLyric.vue
+++ b/src/components/Player/PlayerLyric/AMLyric.vue
@@ -1,7 +1,7 @@
 <template>
   <Transition name="fade" mode="out-in">
     <div
-      :key="amLyricsData?.[0]?.words?.length"
+      :key="`${musicStore.playSong?.id ?? 'no-song'}|${settingStore.showWordLyrics ? 'yrc' : 'lrc'}`"
       :class="[
         'lyric-am',
         {

--- a/src/components/Player/PlayerMeta/PlayerCover.vue
+++ b/src/components/Player/PlayerMeta/PlayerCover.vue
@@ -385,8 +385,8 @@ onBeforeUnmount(() => {
   position: fixed;
   left: 0;
   top: 0;
-  height: 100vh;
-  width: 60vw;
+  height: var(--page-zoom-100vh, 100vh);
+  width: var(--page-zoom-60vw, 60vw);
   z-index: 0;
   mask-image: linear-gradient(to right, #000 var(--gradient-percent), transparent 100%);
   -webkit-mask-image: linear-gradient(to right, #000 var(--gradient-percent), transparent 100%);

--- a/src/components/Player/PlayerQuickActionsMenu.vue
+++ b/src/components/Player/PlayerQuickActionsMenu.vue
@@ -1,0 +1,398 @@
+<template>
+  <n-popover
+    placement="bottom-end"
+    trigger="click"
+    :show-arrow="false"
+    :z-index="11000"
+    :style="{ padding: '6px', borderRadius: '10px' }"
+    class="quick-actions-popover"
+    @update:show="handlePopoverShow"
+  >
+    <template #trigger>
+      <!-- 同时挂 menu-icon 让 PlayerControl 的 :deep(.menu-icon) 风格命中 -->
+      <div :class="triggerClass" aria-label="更多快捷操作">
+        <SvgIcon name="More" :size="triggerIconSize" />
+      </div>
+    </template>
+
+    <div class="quick-actions-panel" @click.stop>
+      <!-- 快捷开关分组 -->
+      <div class="qa-group">
+        <div class="qa-group-title">快捷开关</div>
+
+        <!-- 音频频谱 -->
+        <div class="qa-item">
+          <div class="qa-item-label">
+            <SvgIcon name="Eq" :size="18" />
+            <span class="qa-item-text">音频频谱</span>
+          </div>
+          <n-switch
+            :value="settingStore.showSpectrums"
+            :disabled="settingStore.playbackEngine === 'mpv'"
+            :round="false"
+            size="small"
+            @update:value="(v: boolean) => (settingStore.showSpectrums = v)"
+          />
+        </div>
+
+        <!-- 动态封面 -->
+        <div class="qa-item">
+          <div class="qa-item-label">
+            <SvgIcon name="Album" :size="18" />
+            <span class="qa-item-text">动态封面</span>
+          </div>
+          <n-switch v-model:value="settingStore.dynamicCover" :round="false" size="small" />
+        </div>
+
+        <!-- 桌面歌词 -->
+        <div v-if="canUseDesktopLyric" class="qa-item">
+          <div class="qa-item-label">
+            <SvgIcon name="DesktopLyric" :size="18" />
+            <span class="qa-item-text">桌面歌词</span>
+          </div>
+          <n-switch
+            :value="statusStore.showDesktopLyric"
+            :round="false"
+            size="small"
+            @update:value="(v: boolean) => player.setDesktopLyricShow(v)"
+          />
+        </div>
+
+        <!-- 逐词效果 -->
+        <div class="qa-item">
+          <div class="qa-item-label">
+            <SvgIcon name="TextPlay" :size="18" />
+            <span class="qa-item-text">逐词效果</span>
+          </div>
+          <n-switch v-model:value="settingStore.showWordLyrics" :round="false" size="small" />
+        </div>
+
+        <!-- 在线 TTML 歌词 -->
+        <div class="qa-item">
+          <div class="qa-item-label">
+            <SvgIcon name="Cloud" :size="18" />
+            <span class="qa-item-text">在线 TTML 歌词</span>
+          </div>
+          <n-switch
+            v-model:value="settingStore.enableOnlineTTMLLyric"
+            :round="false"
+            size="small"
+          />
+        </div>
+
+        <!-- 音量 -->
+        <div class="qa-item qa-volume">
+          <div class="qa-item-label">
+            <SvgIcon :name="statusStore.playVolumeIcon" :size="18" />
+            <span class="qa-item-text">音量</span>
+            <span class="qa-volume-value">{{ statusStore.playVolumePercent }}%</span>
+          </div>
+          <n-slider
+            :value="statusStore.playVolume"
+            :min="0"
+            :max="1"
+            :step="0.01"
+            :tooltip="false"
+            class="qa-volume-slider"
+            @update:value="(v: number) => player.setVolume(v)"
+          />
+        </div>
+      </div>
+
+      <!-- AMLL 效果分组 -->
+      <div class="qa-group">
+        <div class="qa-group-title">AMLL 效果</div>
+
+        <!-- AMLL 逐词渲染：开启时提示发热与耗电 -->
+        <div class="qa-item">
+          <div class="qa-item-label">
+            <SvgIcon name="Lyrics" :size="18" />
+            <span class="qa-item-text">AMLL 逐词渲染</span>
+          </div>
+          <n-switch
+            :value="settingStore.useAMLyrics"
+            :round="false"
+            size="small"
+            @update:value="onToggleAMLyrics"
+          />
+        </div>
+
+        <!-- 弹簧效果 -->
+        <div class="qa-item">
+          <div class="qa-item-label">
+            <SvgIcon name="AutoFix" :size="18" />
+            <span class="qa-item-text">弹簧效果</span>
+          </div>
+          <n-switch
+            v-model:value="settingStore.useAMSpring"
+            :disabled="!settingStore.useAMLyrics"
+            :round="false"
+            size="small"
+          />
+        </div>
+
+        <!-- AMLL 动态背景：独立于逐词渲染，关闭时回退到上次非 animation 背景 -->
+        <div class="qa-item">
+          <div class="qa-item-label">
+            <SvgIcon name="Palette" :size="18" />
+            <span class="qa-item-text">AMLL 动态背景</span>
+          </div>
+          <n-switch v-model:value="amllAnimationBg" :round="false" size="small" />
+        </div>
+
+        <!-- 隐藏已播放歌词 -->
+        <div class="qa-item">
+          <div class="qa-item-label">
+            <SvgIcon name="EyeLock" :size="18" />
+            <span class="qa-item-text">隐藏已播放</span>
+          </div>
+          <n-switch
+            v-model:value="settingStore.hidePassedLines"
+            :disabled="!settingStore.useAMLyrics"
+            :round="false"
+            size="small"
+          />
+        </div>
+
+        <!-- 歌词模糊 -->
+        <div class="qa-item">
+          <div class="qa-item-label">
+            <SvgIcon name="AutoTheme" :size="18" />
+            <span class="qa-item-text">歌词模糊</span>
+          </div>
+          <n-switch v-model:value="settingStore.lyricsBlur" :round="false" size="small" />
+        </div>
+      </div>
+    </div>
+  </n-popover>
+</template>
+
+<script setup lang="ts">
+import { computed, inject, onBeforeUnmount } from "vue";
+import { useSettingStore, useStatusStore } from "@/stores";
+import { usePlayerController } from "@/core/player/PlayerController";
+import { isElectron, isCapacitorAndroid } from "@/utils/env";
+import { PLAYER_META_HOLD_KEY } from "@/composables/usePlayerMetaHold";
+
+// 触发器外观：mobile 用 40px 圆形，control 与 PlayerControl 其他 menu-icon 一致
+const props = withDefaults(defineProps<{ variant?: "mobile" | "control" }>(), {
+  variant: "mobile",
+});
+const triggerIconSize = computed(() => (props.variant === "control" ? 24 : 26));
+// 同时挂 menu-icon class 让父级 :deep(.menu-icon) 选择器也能命中
+const triggerClass = computed(() => ["qa-trigger", `qa-trigger--${props.variant}`, "menu-icon"]);
+
+const settingStore = useSettingStore();
+const statusStore = useStatusStore();
+const player = usePlayerController();
+
+// 桌面歌词仅在桌面端 / 安卓端可用
+const canUseDesktopLyric = computed(() => isElectron || isCapacitorAndroid);
+
+// 开启 AMLL 逐词渲染时提示发热与耗电；关闭则静默
+const onToggleAMLyrics = (v: boolean) => {
+  settingStore.useAMLyrics = v;
+  if (v) {
+    window.$message?.warning("使用此模式将增加发热与耗电", { duration: 3000 });
+  }
+};
+
+// AMLL 动态背景开关：playerBackgroundType === 'animation' ↔ 上次非 animation 值
+// 上次值持久化在 settingStore.lastNonAnimationPlayerBg，跨组件 mount / 跨页面切换都保留
+const amllAnimationBg = computed<boolean>({
+  get: () => settingStore.playerBackgroundType === "animation",
+  set: (v) => {
+    if (v) {
+      // 切换到 animation 之前先把当前非 animation 值持久化，避免丢失用户偏好
+      if (
+        settingStore.playerBackgroundType !== "animation" &&
+        (settingStore.playerBackgroundType === "none" ||
+          settingStore.playerBackgroundType === "blur" ||
+          settingStore.playerBackgroundType === "color")
+      ) {
+        settingStore.lastNonAnimationPlayerBg = settingStore.playerBackgroundType;
+      }
+      // 首次激活动态背景时默认开启背景跳动；后续激活尊重用户偏好
+      if (!settingStore.amllAnimationBgEverActivated) {
+        settingStore.playerBackgroundLowFreqVolume = true;
+        settingStore.amllAnimationBgEverActivated = true;
+      }
+      settingStore.playerBackgroundType = "animation";
+    } else {
+      settingStore.playerBackgroundType = settingStore.lastNonAnimationPlayerBg;
+    }
+  },
+});
+
+// 注入 FullPlayer 提供的 hold 接口；FullPlayerMobile 路径下父级未 provide 时 inject 为 null 即可
+const playerMetaHold = inject(PLAYER_META_HOLD_KEY, null);
+let popoverHoldAcquired = false;
+const handlePopoverShow = (show: boolean) => {
+  if (!playerMetaHold) return;
+  if (show && !popoverHoldAcquired) {
+    playerMetaHold.acquire();
+    popoverHoldAcquired = true;
+  } else if (!show && popoverHoldAcquired) {
+    playerMetaHold.release();
+    popoverHoldAcquired = false;
+  }
+};
+
+// 组件卸载时若仍持有 hold，保底释放，避免计数泄漏
+onBeforeUnmount(() => {
+  if (popoverHoldAcquired && playerMetaHold) {
+    playerMetaHold.release();
+    popoverHoldAcquired = false;
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.qa-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+// 移动端：与 FullPlayerMobile 的 .info-actions 风格一致
+.qa-trigger--mobile {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  transition: background-color 0.2s;
+
+  &:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+  }
+
+  &:active {
+    background-color: rgba(255, 255, 255, 0.15);
+  }
+}
+
+// 控制中心：与 PlayerControl 其他 menu-icon 风格保持一致
+.qa-trigger--control {
+  padding: 8px;
+  border-radius: 8px;
+  transition:
+    background-color 0.3s,
+    transform 0.3s;
+
+  :deep(.n-icon) {
+    color: rgb(var(--main-cover-color));
+  }
+
+  &:hover {
+    transform: scale(1.1);
+    background-color: rgba(var(--main-cover-color), 0.14);
+  }
+
+  &:active {
+    transform: scale(1);
+  }
+}
+
+// 紧凑菜单：背景 / 文字 / 边框 / 阴影由 Naive UI popover 主题接管，
+// 这里只负责内部布局，避免在浅色模式下因自定义颜色对比度不足看不清
+.quick-actions-panel {
+  width: 220px;
+  // 适当限制最大高度，避免菜单过高遮挡播放器；超出后内部滚动浏览
+  max-height: min(48vh, 360px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  font-size: 13px;
+  line-height: 1.4;
+
+  // 细滚动条，减少视觉干扰（移动端默认隐藏，触控滚动即可）
+  scrollbar-width: thin;
+  scrollbar-color: var(--n-scrollbar-color, rgba(0, 0, 0, 0.2)) transparent;
+
+  &::-webkit-scrollbar {
+    width: 4px;
+  }
+  &::-webkit-scrollbar-thumb {
+    border-radius: 2px;
+    background-color: var(--n-scrollbar-color, rgba(0, 0, 0, 0.2));
+  }
+  &::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+}
+
+.qa-group {
+  display: flex;
+  flex-direction: column;
+
+  & + .qa-group {
+    margin-top: 4px;
+    padding-top: 4px;
+    border-top: 1px solid var(--n-divider-color);
+  }
+}
+
+.qa-group-title {
+  padding: 4px 8px 2px;
+  font-size: 11px;
+  font-weight: 600;
+  // text-color-3 在明暗模式下都是次要文字色（对比度合适）
+  color: var(--n-text-color-3);
+  letter-spacing: 0.4px;
+}
+
+.qa-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 34px;
+  padding: 0 8px;
+  border-radius: 6px;
+  transition: background-color 0.15s;
+  color: var(--n-text-color);
+
+  &:hover {
+    background-color: var(--n-action-color);
+  }
+}
+
+.qa-item-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  flex: 1;
+}
+
+.qa-item-text {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+// 音量行：标签在上、滑块在下，整体保持紧凑
+.qa-volume {
+  flex-direction: column;
+  align-items: stretch;
+  height: auto;
+  padding: 6px 8px 8px;
+  gap: 4px;
+
+  .qa-item-label {
+    width: 100%;
+  }
+
+  .qa-volume-value {
+    font-size: 11px;
+    color: var(--n-text-color-3);
+    flex-shrink: 0;
+    min-width: 32px;
+    text-align: right;
+  }
+
+  .qa-volume-slider {
+    width: 100%;
+  }
+}
+</style>

--- a/src/components/Search/SearchDefault.vue
+++ b/src/components/Search/SearchDefault.vue
@@ -144,7 +144,7 @@ onMounted(() => {
     transition-delay: 0.25s;
   }
   :deep(.scrollbar) {
-    max-height: calc(100vh - 160px);
+    max-height: calc(var(--page-zoom-100vh, 100vh) - 160px);
     .n-scrollbar-content {
       padding: 10px;
     }

--- a/src/components/Search/SearchSuggest.vue
+++ b/src/components/Search/SearchSuggest.vue
@@ -233,14 +233,14 @@ watchDebounced(
   width: 300px;
   border-radius: 8px;
   overflow: hidden;
-  max-height: calc(100vh - 160px);
+  max-height: calc(var(--page-zoom-100vh, 100vh) - 160px);
   z-index: 101;
   transition:
     height 0.3s ease,
     opacity 0.3s ease,
     transform 0.3s ease;
   :deep(.scrollbar) {
-    max-height: calc(100vh - 160px);
+    max-height: calc(var(--page-zoom-100vh, 100vh) - 160px);
     .n-scrollbar-content {
       padding: 10px;
     }

--- a/src/components/Setting/config/appearance.ts
+++ b/src/components/Setting/config/appearance.ts
@@ -10,14 +10,42 @@ import {
   openFullscreenPlayerManager,
   openCoverManager,
   openContextMenuManager,
+  openScalingModal,
 } from "@/utils/modal";
 import { SettingConfig } from "@/types/settings";
 import { computed, ref } from "vue";
 import { isLogin } from "@/utils/auth";
+import { useDevice } from "@/composables/useDevice";
 
 export const useAppearanceSettings = (): SettingConfig => {
   const settingStore = useSettingStore();
   const statusStore = useStatusStore();
+  const { isPad, isPhonePortrait } = useDevice();
+  // useDevice 的 isPad 仅按 shortestSide 判断，桌面 Electron 大窗口也会满足；
+  // 缩放路径仅对 Capacitor / 真机移动端生效，因此入口判定必须先排除 Electron，
+  // 否则桌面设置里会出现移动端缩放入口，且写入字段与 usePageZoom 的消费路径不一致
+  const showMobileZoom = computed(() => !isElectron && (isPhonePortrait.value || isPad.value));
+  const activePageZoom = computed({
+    get: () => {
+      if (isElectron) return 100;
+      if (isPad.value) return settingStore.padPageZoom;
+      if (isPhonePortrait.value) return settingStore.phonePortraitPageZoom;
+      return 100;
+    },
+    set: (v) => {
+      // Electron 走原生 zoom-factor IPC，不应写入移动端字段
+      if (isElectron) return;
+      if (isPad.value) {
+        settingStore.padPageZoom = v;
+        return;
+      }
+      if (isPhonePortrait.value) {
+        settingStore.phonePortraitPageZoom = v;
+        return;
+      }
+      // 其他模式（如手机横屏）没有对应缩放路径，丢弃写入
+    },
+  });
 
   // --- Window / Borderless Logic (from general.ts) ---
   const useBorderless = ref(true);
@@ -72,6 +100,17 @@ export const useAppearanceSettings = (): SettingConfig => {
             description: "更改主题色或自定义图片",
             buttonLabel: "配置",
             action: openThemeConfig,
+          },
+          {
+            key: "pageScalingOptimize",
+            label: "页面缩放优化",
+            type: "button",
+            show: showMobileZoom,
+            description: computed(() =>
+              isPad.value ? "调整平板模式缩放比例" : "调整手机竖屏缩放比例",
+            ),
+            buttonLabel: "调整",
+            action: openScalingModal,
           },
           {
             key: "useBorderless",
@@ -193,27 +232,23 @@ export const useAppearanceSettings = (): SettingConfig => {
             key: "pageZoom",
             label: "页面缩放",
             type: "slider",
-            show: computed(() => statusStore.isDeveloperMode),
-            description:
-              "整体界面缩放比例。缩小后等效视口变宽，达到阈值会切换到 Pad 布局（底栏变侧栏，列表显示更多列）",
+            show: computed(() => statusStore.isDeveloperMode && showMobileZoom.value),
+            description: "调整当前模式界面缩放比例",
             min: 50,
-            max: 150,
+            max: 200,
             step: 5,
             marks: { 100: "默认" },
             formatTooltip: (v) => `${v}%`,
-            value: computed({
-              get: () => settingStore.pageZoom,
-              set: (v) => (settingStore.pageZoom = v),
-            }),
+            value: activePageZoom,
             extraButton: {
               label: "重置",
               type: "primary",
               secondary: true,
               strong: true,
               action: () => {
-                settingStore.pageZoom = 100;
+                activePageZoom.value = 100;
               },
-              show: computed(() => settingStore.pageZoom !== 100),
+              show: computed(() => activePageZoom.value !== 100),
             },
           },
         ],

--- a/src/composables/useDevice.ts
+++ b/src/composables/useDevice.ts
@@ -1,44 +1,36 @@
-import { computed, ref, watchEffect } from "vue";
-import { useSettingStore } from "@/stores";
+import { computed, ref } from "vue";
 
 export const ANDROID_PAD_BREAKPOINT = 768;
 
+// 模块级单例：所有 useDevice() 共用同一份 viewport 状态与监听器，避免重复注册造成内存泄漏
+const hasWindow = typeof window !== "undefined";
+const rawWidth = ref(hasWindow ? window.innerWidth : 0);
+const rawHeight = ref(hasWindow ? window.innerHeight : 0);
+
+const refreshSize = () => {
+  if (!hasWindow) return;
+  rawWidth.value = window.innerWidth;
+  rawHeight.value = window.innerHeight;
+};
+
+if (hasWindow) {
+  window.addEventListener("resize", refreshSize);
+  window.addEventListener("orientationchange", () => setTimeout(refreshSize, 300));
+}
+
+// 设备视口
+const effectiveWidth = computed(() => rawWidth.value);
+const effectiveHeight = computed(() => rawHeight.value);
+
+const shortestSide = computed(() => Math.min(effectiveWidth.value, effectiveHeight.value));
+const isLandscape = computed(() => effectiveWidth.value > effectiveHeight.value);
+const isPad = computed(() => shortestSide.value >= ANDROID_PAD_BREAKPOINT);
+const isPhone = computed(() => shortestSide.value < ANDROID_PAD_BREAKPOINT);
+const isPhonePortrait = computed(() => isPhone.value && !isLandscape.value);
+const isPhoneLandscape = computed(() => isPhone.value && isLandscape.value);
+const shellMode = computed(() => (isPad.value ? "pad" : "phone"));
+
 export const useDevice = () => {
-  const settingStore = useSettingStore();
-
-  const rawWidth = ref(window.innerWidth);
-  const rawHeight = ref(window.innerHeight);
-
-  const refreshSize = () => {
-    rawWidth.value = window.innerWidth;
-    rawHeight.value = window.innerHeight;
-  };
-
-  // viewport 缩放变化时，innerWidth 会变，需要主动刷新
-  watchEffect(() => {
-    const _ = settingStore.pageZoom;
-    refreshSize();
-    requestAnimationFrame(refreshSize);
-    setTimeout(refreshSize, 200);
-  });
-
-  if (typeof window !== "undefined") {
-    window.addEventListener("resize", refreshSize);
-    window.addEventListener("orientationchange", () => setTimeout(refreshSize, 300));
-  }
-
-  // 等效视口（viewport meta 的 initial-scale 已把缩放反映在 innerWidth 里，无需再除）
-  const effectiveWidth = computed(() => rawWidth.value);
-  const effectiveHeight = computed(() => rawHeight.value);
-
-  const shortestSide = computed(() => Math.min(effectiveWidth.value, effectiveHeight.value));
-  const isLandscape = computed(() => effectiveWidth.value > effectiveHeight.value);
-  const isPad = computed(() => shortestSide.value >= ANDROID_PAD_BREAKPOINT);
-  const isPhone = computed(() => shortestSide.value < ANDROID_PAD_BREAKPOINT);
-  const isPhonePortrait = computed(() => isPhone.value && !isLandscape.value);
-  const isPhoneLandscape = computed(() => isPhone.value && isLandscape.value);
-  const shellMode = computed(() => (isPad.value ? "pad" : "phone"));
-
   return {
     width: rawWidth,
     height: rawHeight,

--- a/src/composables/usePageZoom.ts
+++ b/src/composables/usePageZoom.ts
@@ -1,50 +1,75 @@
-import { onMounted, watch } from "vue";
+import { computed, onMounted, watch } from "vue";
 import { useSettingStore } from "@/stores";
+import { useDevice } from "@/composables/useDevice";
+import { isCapacitorAndroid, isElectron } from "@/utils/env";
 
-/**
- * 页面缩放
- *
- * 通过动态修改 viewport meta 的 initial-scale 实现：
- * - WebView 会按新 scale 重新计算视口，window.innerWidth / vw / media query 都会正确反映
- * - 比 CSS zoom 更可靠，不会出现 vw 单位不跟随导致的内容裁切或留白
- */
+/** 页面缩放 */
 export const usePageZoom = () => {
   const settingStore = useSettingStore();
+  const { isPad, isPhonePortrait } = useDevice();
 
+  const activeZoom = computed(() => {
+    if (isElectron) return 100;
+    if (isPad.value) return settingStore.padPageZoom;
+    if (isPhonePortrait.value) return settingStore.phonePortraitPageZoom;
+    return 100;
+  });
+
+  const fullscreenSafeBottom = computed(() => {
+    if (!isCapacitorAndroid || !isPhonePortrait.value) return 0;
+    return settingStore.androidFullscreenSafeAreaOptimize ? 32 : 0;
+  });
+
+  // 节流：合并同一帧内的多次调用，避免连发 resize
+  let resizePending = false;
   const notifyResize = () => {
-    // 视口变化后主动触发 resize，让 VueUse / Naive UI 等库重算布局
+    if (resizePending) return;
+    resizePending = true;
     const fire = () => window.dispatchEvent(new Event("resize"));
-    fire();
-    requestAnimationFrame(fire);
+    requestAnimationFrame(() => {
+      fire();
+      resizePending = false;
+    });
+    // 一次延迟兜底，处理 CSS 变量在某些场景下延迟生效后的二次布局
     setTimeout(fire, 150);
   };
 
-  const apply = (zoom: number) => {
+  const apply = (zoom: number, safeBottom: number) => {
     const safe = Math.max(50, Math.min(200, Number(zoom) || 100));
     const ratio = safe / 100;
 
-    // 动态更新 viewport meta，替代 CSS zoom
+    // 固定 viewport
     let viewport = document.querySelector('meta[name="viewport"]') as HTMLMetaElement | null;
     if (!viewport) {
       viewport = document.createElement("meta");
       viewport.name = "viewport";
       document.head.appendChild(viewport);
     }
-    viewport.setAttribute(
-      "content",
-      `width=device-width, initial-scale=${ratio}, viewport-fit=cover`,
-    );
+    viewport.setAttribute("content", "width=device-width, initial-scale=1, viewport-fit=cover");
 
-    // 清除之前可能残留的 CSS zoom，避免双重缩放
+    // 缩放变量挂到 #app，避免 teleport 到 body 的弹出层继承到反向补偿值
+    const appEl = (document.getElementById("app") || document.documentElement) as HTMLElement;
+    appEl.style.setProperty("--page-zoom-ratio", String(ratio));
+    appEl.style.setProperty("--page-zoom-width", `${100 / ratio}%`);
+    appEl.style.setProperty("--page-zoom-height", `${100 / ratio}%`);
+    appEl.style.setProperty("--page-zoom-100vw", `${100 / ratio}vw`);
+    appEl.style.setProperty("--page-zoom-100vh", `${100 / ratio}vh`);
+    appEl.style.setProperty("--page-zoom-100dvh", `${100 / ratio}dvh`);
+    appEl.style.setProperty("--page-zoom-60vw", `${60 / ratio}vw`);
+    appEl.style.setProperty("--android-fullscreen-safe-bottom", `${safeBottom / ratio}px`);
+
+    // 仅在 ratio !== 1 时设置 transform：scale(1) 也会触发 stacking context 与
+    // fixed containing block 切换，影响 Electron / 100% 缩放路径的 fixed 后代定位
+    if (ratio === 1) {
+      appEl.style.removeProperty("transform");
+    } else {
+      appEl.style.transform = `scale(${ratio})`;
+    }
     (document.documentElement.style as CSSStyleDeclaration & { zoom?: string }).zoom = "";
-    document.documentElement.style.removeProperty("--zoom-ratio");
 
     notifyResize();
   };
 
-  onMounted(() => apply(settingStore.pageZoom));
-  watch(
-    () => settingStore.pageZoom,
-    (val) => apply(val),
-  );
+  onMounted(() => apply(activeZoom.value, fullscreenSafeBottom.value));
+  watch([activeZoom, fullscreenSafeBottom], ([zoom, safeBottom]) => apply(zoom, safeBottom));
 };

--- a/src/composables/usePlayerMetaHold.ts
+++ b/src/composables/usePlayerMetaHold.ts
@@ -1,0 +1,19 @@
+import type { InjectionKey } from "vue";
+
+/**
+ * 控制全屏播放器顶部 / 底部控制栏自动隐藏的 hold 接口
+ *
+ * 用于：弹层（如快捷菜单 popover）打开期间，鼠标离开 PlayerControl 移动到 body 下
+ * 的 popover panel 时，需要保持 playerMetaShow=true，避免控制栏隐藏导致 trigger
+ * DOM 消失、popover 定位失效。
+ *
+ * 使用引用计数模式，支持多个 hold 持有者并存。
+ */
+export interface PlayerMetaHold {
+  /** 获取 hold：计数 +1，立即取消任何 pending 的隐藏定时器 */
+  acquire: () => void;
+  /** 释放 hold：计数 -1，若清零且开启了 autoHide 则重启隐藏定时器 */
+  release: () => void;
+}
+
+export const PLAYER_META_HOLD_KEY: InjectionKey<PlayerMetaHold> = Symbol("PlayerMetaHold");

--- a/src/layout/AppLayout.vue
+++ b/src/layout/AppLayout.vue
@@ -55,7 +55,9 @@
           id="main-sider"
           :style="{
             height:
-              musicStore.isHasPlayer && statusStore.showPlayBar ? 'calc(100dvh - 80px)' : '100dvh',
+              musicStore.isHasPlayer && statusStore.showPlayBar
+                ? 'calc(var(--page-zoom-100dvh, 100dvh) - 80px)'
+                : 'var(--page-zoom-100dvh, 100dvh)',
           }"
           :content-style="{
             overflow: 'hidden',
@@ -309,7 +311,7 @@ onBeforeUnmount(() => {
 <style lang="scss" scoped>
 #app-layout {
   --safe-area-top: max(env(safe-area-inset-top), 0px);
-  --safe-area-bottom: max(env(safe-area-inset-bottom), 0px);
+  --safe-area-bottom: max(env(safe-area-inset-bottom), var(--android-fullscreen-safe-bottom, 0px));
   --app-header-height: calc(72px + var(--safe-area-top));
   --phone-nav-height: 56px;
   --phone-nav-total-height: calc(var(--phone-nav-height) + var(--safe-area-bottom));

--- a/src/stores/migrations/settingMigrations.ts
+++ b/src/stores/migrations/settingMigrations.ts
@@ -6,7 +6,7 @@ import type { SettingState } from "../setting";
 /**
  * 当前设置 Schema 版本号
  */
-export const CURRENT_SETTING_SCHEMA_VERSION = 17;
+export const CURRENT_SETTING_SCHEMA_VERSION = 19;
 
 /**
  * 迁移函数类型
@@ -228,6 +228,20 @@ export const settingMigrations: Record<number, MigrationFunction> = {
   17: () => {
     return {
       pageZoom: 100,
+    };
+  },
+  18: () => {
+    // 旧版 pageZoom 在 Android 是通过 viewport initial-scale 改 innerWidth 来切换布局，
+    // 新版 phonePortraitPageZoom / padPageZoom 是 CSS 缩放，语义完全不同；
+    // 若直接迁移旧值会导致老用户升级后 UI 被等比缩小，故强制重置为 100。
+    return {
+      phonePortraitPageZoom: 100,
+      padPageZoom: 100,
+    };
+  },
+  19: () => {
+    return {
+      androidFullscreenSafeAreaOptimize: true,
     };
   },
 };

--- a/src/stores/migrations/settingMigrations.ts
+++ b/src/stores/migrations/settingMigrations.ts
@@ -6,7 +6,7 @@ import type { SettingState } from "../setting";
 /**
  * 当前设置 Schema 版本号
  */
-export const CURRENT_SETTING_SCHEMA_VERSION = 19;
+export const CURRENT_SETTING_SCHEMA_VERSION = 20;
 
 /**
  * 迁移函数类型
@@ -242,6 +242,17 @@ export const settingMigrations: Record<number, MigrationFunction> = {
   19: () => {
     return {
       androidFullscreenSafeAreaOptimize: true,
+    };
+  },
+  20: (state) => {
+    // 初始化动态背景记忆字段：
+    //  - 若用户当前背景不是 animation，就记录作为上次非 animation 值；
+    //  - 否则默认 blur（与 store 默认一致）。
+    // amllAnimationBgEverActivated 默认 false，老用户首次从快捷菜单打开动态背景时仍会被默认激活低频脉动。
+    const cur = state.playerBackgroundType;
+    return {
+      lastNonAnimationPlayerBg: cur && cur !== "animation" ? cur : "blur",
+      amllAnimationBgEverActivated: false,
     };
   },
 };

--- a/src/stores/setting.ts
+++ b/src/stores/setting.ts
@@ -272,8 +272,14 @@ export interface SettingState {
   androidDownloadDirectoryUri: string;
   /** Android 本地音乐目录列表（SAF URI） */
   androidLocalMusicDirectories: { uri: string; name: string }[];
-  /** 页面缩放（百分比，70-150，默认 100） */
+  /** 桌面页面缩放 */
   pageZoom: number;
+  /** 手机竖屏页面缩放 */
+  phonePortraitPageZoom: number;
+  /** 平板模式页面缩放 */
+  padPageZoom: number;
+  /** 安卓全面屏优化 */
+  androidFullscreenSafeAreaOptimize: boolean;
   /** 本地文件分隔符 */
   localSeparators: string[];
   /** 显示本地封面 */
@@ -640,6 +646,9 @@ export const useSettingStore = defineStore("setting", {
     androidDownloadDirectoryUri: "",
     androidLocalMusicDirectories: [],
     pageZoom: 100,
+    phonePortraitPageZoom: 100,
+    padPageZoom: 100,
+    androidFullscreenSafeAreaOptimize: true,
     showDefaultLocalPath: true,
     localFolderDisplayMode: "tab",
     localSeparators: ["/", "&"],

--- a/src/stores/setting.ts
+++ b/src/stores/setting.ts
@@ -205,6 +205,10 @@ export interface SettingState {
   playerBackgroundLowFreqVolume: boolean;
   /** 背景动画渲染比例 */
   playerBackgroundRenderScale: number;
+  /** 上次非 animation 背景类型，用于快捷菜单关闭动态背景时回退 */
+  lastNonAnimationPlayerBg: "none" | "blur" | "color";
+  /** AMLL 动态背景是否已被首次激活过（首次默认启动低频脉动） */
+  amllAnimationBgEverActivated: boolean;
   /** 播放器元素自动隐藏 */
   autoHidePlayerMeta: boolean;
   /** 记忆最后进度 */
@@ -578,6 +582,8 @@ export const useSettingStore = defineStore("setting", {
     playerBackgroundPause: false,
     playerBackgroundLowFreqVolume: false,
     playerBackgroundRenderScale: 0.5,
+    lastNonAnimationPlayerBg: "blur",
+    amllAnimationBgEverActivated: false,
     autoHidePlayerMeta: true,
     memoryLastSeek: true,
     progressTooltipShow: true,

--- a/src/style/animate.scss
+++ b/src/style/animate.scss
@@ -236,7 +236,7 @@
 }
 .mobile-card-enter-from,
 .mobile-card-leave-to {
-  transform: translate3d(0, 100vh, 0) scale(0.92);
+  transform: translate3d(0, var(--page-zoom-100vh, 100vh), 0) scale(0.92);
   border-radius: 28px;
 }
 

--- a/src/style/main.scss
+++ b/src/style/main.scss
@@ -100,10 +100,15 @@ audio {
 }
 
 #app {
-  width: 100%;
-  height: 100%;
+  width: var(--page-zoom-width, 100%);
+  height: var(--page-zoom-height, 100%);
   display: flex;
   flex-direction: column;
+  transform-origin: 0 0;
+  // transform 由 usePageZoom 在 ratio !== 1 时按需设置，避免 scale(1) 引入额外
+  // stacking context / fixed containing block 切换；100% 缩放路径保持原生行为
+  // 在缩放容器内补偿安卓全面屏底部，弹出层 teleport 到 body 不会被影响
+  --safe-area-bottom: max(env(safe-area-inset-bottom), var(--android-fullscreen-safe-bottom, 0px));
 }
 
 .android-capacitor {

--- a/src/utils/modal.ts
+++ b/src/utils/modal.ts
@@ -662,7 +662,8 @@ export const openScalingModal = async () => {
     size: "small",
     autoFocus: false,
     showMask: false,
-    style: { width: "400px" },
+    // Naive UI modal teleport 到 body，已脱离 #app 缩放上下文，直接用真实 viewport 宽度即可
+    style: { width: "min(400px, calc(100vw - 32px))" },
     title: "界面缩放",
     content: () => {
       return h(ScalingModal);

--- a/src/utils/style.ts
+++ b/src/utils/style.ts
@@ -6,7 +6,7 @@
  */
 export const getFontSize = (size: number, mode: string) => {
   if (mode === "adaptive") {
-    return `calc(${size} / 1080 * 100vh)`;
+    return `calc(${size} / 1080 * var(--page-zoom-100vh, 100vh))`;
   }
   return `${size}px`;
 };

--- a/src/views/Local/layout.vue
+++ b/src/views/Local/layout.vue
@@ -725,7 +725,10 @@ onUnmounted(() => {
   }
   @media (max-width: 767px) and (orientation: portrait) {
     height: 100%;
-    min-height: calc(100dvh - var(--app-header-height) - var(--phone-nav-total-height) - 16px);
+    min-height: calc(
+      var(--page-zoom-100dvh, 100dvh) - var(--app-header-height) - var(--phone-nav-total-height) -
+        16px
+    );
 
     .title {
       margin-top: 8px;


### PR DESCRIPTION
## 📌 变更类型

<!-- 勾选一项或多项 -->

- [x] ✨ feat — 新功能
- [x] 🐞 fix — Bug 修复
- [x] 🎨 style — 仅样式 / 格式,不影响逻辑
- [x] ♻️ refactor — 重构,不改变外部行为
- [ ] ⚡ perf — 性能优化
- [ ] 📝 docs — 仅文档
- [ ] 🧪 test — 新增 / 修改测试
- [ ] 🔧 chore — 构建 / 脚本 / 依赖
- [ ] 🚀 ci — 仅 CI 配置
- [ ] ⏪ revert — 回滚

## 📝 变更说明

本 PR 包含三个独立但相互衔接的改进,聚焦移动端播放器体验:

### 1. 评论页嵌入竖屏播放器(`7788731`)

- 为 `PlayerComment` 新增嵌入式布局,支持通过 props 控制显示与交互边界,可作为独立子页内嵌入
- 重构 `FullPlayerMobile` 的多页面管理逻辑,**评论 / 歌词 / 信息三个子页可自由切换**
- 根据当前子页类型动态调整手势拖拽高度与滑动响应区域,避免评论列表滚动与全屏关闭手势冲突
- 新增评论嵌入态专属样式

### 2. 页面缩放体系重构(`cf46ca23`)

- 把原先单一的 `pageZoom` 拆分为 `phonePortraitPageZoom` / `padPageZoom` 两个独立配置,**手机竖屏与平板 / 横屏各自独立缩放**
- 缩放实现从 `viewport` `meta initial-scale` 改为 `CSS transform` + `--page-zoom-*` 自定义属性,**移动端可独立切换缩放比而不影响布局栅格**
- 新增"安卓全面屏底部安全区优化"开关,自动注入 `--android-fullscreen-safe-bottom`,避免底部按钮被系统手势导航条/返回按钮遮挡
- 弹窗/弹出层 teleport 到 body 后不会被双重缩放(把缩放容器从 `body` 移到 `#app`,弹层维持原生比例)
- `useDevice` 改造为模块级单例 listener,**修复 21 个组件重复 mount 时各自注册 resize / orientationchange 监听导致的内存泄漏**
- 全局 vh/vw 硬编码统一替换为 `--page-zoom-100vh / --page-zoom-100vw` 缩放变量,保留视觉比例
- 设置页同步移除无 read path 的旧 `pageZoom` 写入分支;Settings schema 升至 18 → 19,迁移逻辑保证老用户升级后 UI 不会被等比缩到一半

### 3. 播放器快捷操作菜单(`d6008480`)

- 新增 `PlayerQuickActionsMenu` 组件,集成**音频频谱、动态封面、桌面歌词、逐词效果、在线 TTML、音量滑块**;以及独立的 **AMLL 效果分组**:逐词渲染、弹簧效果、AMLL 动态背景、隐藏已播放、歌词模糊
- 在 `FullPlayerMobile` 顶部信息行 & `PlayerControl` 控制栏(平板/桌面)分别接入,**变体样式自适应**
- 新增 `usePlayerMetaHold` 引用计数 hold 机制 + `PLAYER_META_HOLD_KEY` provide/inject:**popover 打开期间 acquire,关闭后 release**,期间跳过 FullPlayer 的 3 秒自动隐藏定时器,避免 trigger DOM 在弹层显示期间被卸载造成 popover 浮位
- `AMLL 动态背景`开关持久化记忆上次非 animation 背景类型(`lastNonAnimationPlayerBg`),关闭时回退到用户真正记忆中的偏好;**首次激活时默认开启"背景跳动效果"(低频脉动)**,后续切换尊重用户偏好(`amllAnimationBgEverActivated` 标志位)
- `AMLL 逐词渲染`开关 toggle 为 `true` 时弹出一次性 `n-message` warning:"使用此模式将增加发热与耗电"
- `AMLyric` 根节点 `:key` 改为 `${songId}|${yrc/lrc}` 复合 key:切歌仍重建保留 fade,**`showWordLyrics` 切换时(yrc↔lrc 词数变化)也重建**,规避 LyricPlayer 内部 word Animation 缓存对应不上新词数的潜在状态错乱
- Settings schema 升至 20,新增字段 `lastNonAnimationPlayerBg` / `amllAnimationBgEverActivated` 的迁移


## 📱 影响范围

<!-- 勾选此 PR 实际影响到的模块 -->

- [ ] 🎵 播放引擎 / 音频
- [x] 📝 歌词 / 桌面歌词
- [ ] 🔔 通知栏 / MediaSession
- [ ] 🌐 在线音乐 (网易云 / Jellyfin / Navidrome / Emby / Subsonic / Last.fm)
- [ ] 🧩 内置 API (nodejs-mobile)
- [x] 🎨 UI / 主题 / 布局
- [ ] 📦 构建 / 打包 / 签名
- [ ] 📱 Capacitor / 原生 Android 代码
- [ ] 📄 文档 / README

## ✅ 自检清单

- [x] 本 PR **目标分支为 `dev`**
- [x] 本地已执行 `pnpm lint` 且无 warning
- [x] 本地已执行 `pnpm typecheck` 且无报错
- [x] 已在 **至少一台真机** 上构建并验证关键路径
- [x] UI 改动已兼顾 **手机竖屏 + 平板横屏** 两种布局
- [x] 新增 / 修改的文案使用中文,与项目整体风格一致
- [x] 未引入不必要的依赖 / 大体积资源
- [x] 未修改签名密钥 / CI Secrets 相关文件

## 📸 截图 / 录屏 (UI 类 PR 必填)

<!-- 前后对比更佳,可直接拖拽图片或视频 -->
<img width="614" height="389" alt="屏幕截图 2026-05-25 092222" src="https://github.com/user-attachments/assets/53723d87-34dd-46f3-9460-567b0f1a44f7" />
<img width="2592" height="1728" alt="IMG_20260525_093906" src="https://github.com/user-attachments/assets/253df051-b998-4e77-b079-590930eb1cd6" />


## 🧪 测试方式

### A. 评论页嵌入

1. 真机/平板竖屏进入全屏播放器,顶部切到"评论",评论列表应**嵌入在原全屏页内**而非弹出新窗
2. 在评论页向下拖拽:仅在列表已滚到顶时才触发关闭手势,否则正常滚动列表
3. 切到"歌词"/"信息"页验证手势拖拽响应区与滑动区域不冲突

### B. 页面缩放

1. 设置 → 外观 → 页面缩放:**手机竖屏与平板/横屏各自独立调整**,互不影响
2. 安卓真机开启"全面屏优化"开关,确认底部按钮不再被系统手势条覆盖;关闭后回到默认行为
3. 切到 80% / 120% 缩放,**打开任意 Naive UI modal / popover**,弹层位置与字号保持原生比例(不被双重缩放)


## 💬 其他说明 (选填)

<!-- 兼容性风险、已知问题、后续计划等 -->

- **Settings schema 迁移**:本 PR 累计升级 17 → 18 → 19 → 20,新增 4 个字段(`phonePortraitPageZoom`、`padPageZoom`、`androidFullscreenSafeAreaOptimize`、`lastNonAnimationPlayerBg`、`amllAnimationBgEverActivated`)。老用户升级时旧 `pageZoom` **强制重置为 100%**(因 viewport 缩放 ≠ CSS 缩放,语义完全不同,直接迁移会让 UI 被等比缩小)
- **快捷菜单 hold 机制**:仅 `FullPlayer`(平板/桌面)路径 provide;`FullPlayerMobile` 无 autoHide 体系,inject 安全降级为 null,行为不受影响
- **AMLL `:key` 复合化**:`showWordLyrics` 切换时 LyricPlayer 会重新创建,带 ~200ms idle 期空白,这是规避 word Animation 缓存对应不上新词数潜在 bug 的取舍
