### PR TITLE
feat: 完善安卓端返回键处理与退出逻辑

### DIFF
--- a/android/app/src/main/java/top/imsyy/splayer/android/playback/AndroidNativePlaybackPlugin.java
+++ b/android/app/src/main/java/top/imsyy/splayer/android/playback/AndroidNativePlaybackPlugin.java
@@ -75,6 +75,31 @@ public class AndroidNativePlaybackPlugin extends Plugin {
     resolveOnMainThread(call, () -> PlaybackManager.getInstance(getContext()).cleanup());
   }
 
+  /** 用户确认退出：停服务 + finishAndRemoveTask + System.exit */
+  @PluginMethod
+  public void shutdownApp(PluginCall call) {
+    Activity activity = getActivity();
+    runOnMainThread(
+        call,
+        () -> {
+          PlaybackManager.getInstance(getContext()).shutdownAll();
+          call.resolve();
+          // 等桥消息送达 JS 后再退，给 100ms 余量
+          new android.os.Handler(android.os.Looper.getMainLooper())
+              .postDelayed(
+                  () -> {
+                    if (activity != null) {
+                      try {
+                        activity.finishAndRemoveTask();
+                      } catch (Exception ignored) {
+                      }
+                    }
+                    System.exit(0);
+                  },
+                  100L);
+        });
+  }
+
   @PluginMethod
   public void seek(PluginCall call) {
     // Capacitor 从 JS 传 number 时底层是 Double，getLong 会取不到默认返回 0L 导致 seek-to-zero

--- a/android/app/src/main/java/top/imsyy/splayer/android/playback/PlaybackManager.java
+++ b/android/app/src/main/java/top/imsyy/splayer/android/playback/PlaybackManager.java
@@ -463,6 +463,29 @@ public final class PlaybackManager {
     }
   }
 
+  /** 用户确认退出 App：清播放、停前台服务、停桌面歌词服务 */
+  public synchronized void shutdownAll() {
+    try {
+      cleanup();
+    } catch (Exception e) {
+      Log.w(TAG, "shutdownAll cleanup failed", e);
+    }
+    try {
+      Intent floating = new Intent(appContext, FloatingLyricService.class);
+      appContext.stopService(floating);
+      floatingLyricService = null;
+    } catch (Exception e) {
+      Log.w(TAG, "shutdownAll stop floating lyric failed", e);
+    }
+    try {
+      Intent playback = new Intent(appContext, PlaybackService.class);
+      appContext.stopService(playback);
+      serviceStarted = false;
+    } catch (Exception e) {
+      Log.w(TAG, "shutdownAll stop playback service failed", e);
+    }
+  }
+
   /** 硬清理：清播放列表 / 登入登出等场景，清空 MediaItem、通知栏、queuedNext 及快路径锁。 */
   public synchronized JSObject cleanup() {
     ensureInitialized();

--- a/src/components/Global/Provider.vue
+++ b/src/components/Global/Provider.vue
@@ -41,6 +41,7 @@ import {
 import { useSettingStore, useStatusStore } from "@/stores";
 import { setColorSchemes, MONOTONOUS_THEME } from "@/utils/color";
 import { useCustomCode } from "@/composables/useCustomCode";
+import { pushBackHandler } from "@/composables/useAndroidBack";
 // import { rgbToHex } from "@imsyy/color-utils";
 import themeColor from "@/assets/data/themeColor.json";
 
@@ -266,8 +267,38 @@ const setupNaiveTools = () => {
   window.$message = useMessage();
   // 对话框
   window.$dialog = useDialog();
-  // 模态框
-  window.$modal = useModal();
+  // 模态框包装：默认可被 back 关闭，_backable: false 隐式 opt-out（吞不关）
+  const modalApi = useModal();
+  const originalCreate = modalApi.create.bind(modalApi);
+  modalApi.create = ((options: Record<string, unknown>) => {
+    const { _backable, ...rest } = options;
+    const isBackable = _backable !== false;
+
+    let off: (() => void) | null = null;
+    const userAfterLeave = rest.onAfterLeave as ((...a: unknown[]) => void) | undefined;
+    const cleanupOff = () => {
+      off?.();
+      off = null;
+    };
+    const wrappedAfterLeave = (...args: unknown[]) => {
+      cleanupOff();
+      userAfterLeave?.(...args);
+    };
+    const modal = originalCreate({
+      ...rest,
+      onAfterLeave: wrappedAfterLeave,
+    } as Parameters<typeof originalCreate>[0]);
+    // 防御调用方后续重赋 modal.onAfterLeave
+    modal.onAfterLeave = wrappedAfterLeave;
+    off = pushBackHandler(() => {
+      // self-cleanup 防连按 race
+      cleanupOff();
+      if (isBackable) modal.destroy();
+      return true;
+    });
+    return modal;
+  }) as typeof modalApi.create;
+  window.$modal = modalApi;
 };
 
 // 挂载工具

--- a/src/components/Layout/Nav.vue
+++ b/src/components/Layout/Nav.vue
@@ -138,6 +138,7 @@ import { useSettingStore, useStatusStore } from "@/stores";
 import { useDevice } from "@/composables/useDevice";
 import { renderIcon } from "@/utils/helper";
 import { openSetting, openThemeConfig, openScalingModal, openUpdateApp } from "@/utils/modal";
+import { useBackClosable } from "@/composables/useAndroidBack";
 import { isDev, isElectron } from "@/utils/env";
 
 const router = useRouter();
@@ -170,6 +171,7 @@ const useBorderless = ref(true);
 const isMax = ref(false);
 // 是否显示侧边栏
 const showAside = ref(false);
+useBackClosable(showAside);
 
 // 最小化
 const min = () => window.electron.ipcRenderer.send("win-min");

--- a/src/components/Menu/CoverMenu.vue
+++ b/src/components/Menu/CoverMenu.vue
@@ -18,6 +18,7 @@ import type { DropdownOption } from "naive-ui";
 import type { CoverType } from "@/types/main";
 import { renderIcon, copyData, getShareUrl } from "@/utils/helper";
 import { useMusicStore, useStatusStore } from "@/stores";
+import { useBackClosable } from "@/composables/useAndroidBack";
 
 const emit = defineEmits<{
   // 直接搜索
@@ -32,6 +33,7 @@ const statusStore = useStatusStore();
 const dropdownX = ref<number>(0);
 const dropdownY = ref<number>(0);
 const dropdownShow = ref<boolean>(false);
+useBackClosable(dropdownShow);
 const dropdownOptions = ref<DropdownOption[]>([]);
 // 开启右键菜单
 const openDropdown = async (

--- a/src/components/Menu/MobileSongMenu.vue
+++ b/src/components/Menu/MobileSongMenu.vue
@@ -36,6 +36,7 @@
 <script setup lang="ts">
 import { SongType } from "@/types/main";
 import { useSongMenu } from "@/composables/useSongMenu";
+import { useBackClosable } from "@/composables/useAndroidBack";
 import { getPlayerInfoObj } from "@/utils/format";
 import SImage from "../UI/s-image.vue";
 import { NMenu, type MenuOption, type DropdownOption } from "naive-ui";
@@ -45,6 +46,7 @@ const emit = defineEmits<{ removeSong: [index: number[]] }>();
 const { getMenuOptions } = useSongMenu();
 
 const showDrawer = ref(false);
+useBackClosable(showDrawer);
 const currentSong = ref<SongType | null>(null);
 const menuOptions = ref<DropdownOption[]>([]);
 

--- a/src/components/Menu/SearchInpMenu.vue
+++ b/src/components/Menu/SearchInpMenu.vue
@@ -17,6 +17,7 @@
 import type { DropdownOption } from "naive-ui";
 import { renderIcon, copyData, getClipboardData } from "@/utils/helper";
 import { useStatusStore } from "@/stores";
+import { useBackClosable } from "@/composables/useAndroidBack";
 
 const emit = defineEmits<{
   // 直接搜索
@@ -29,6 +30,7 @@ const statusStore = useStatusStore();
 const dropdownX = ref<number>(0);
 const dropdownY = ref<number>(0);
 const dropdownShow = ref<boolean>(false);
+useBackClosable(dropdownShow);
 const dropdownOptions = ref<DropdownOption[]>([]);
 
 // 开启右键菜单

--- a/src/components/Menu/SongListMenu.vue
+++ b/src/components/Menu/SongListMenu.vue
@@ -19,6 +19,7 @@ import { NFlex, NText, type DropdownOption } from "naive-ui";
 import { getPlayerInfoObj } from "@/utils/format";
 import SImage from "../UI/s-image.vue";
 import { useSongMenu } from "@/composables/useSongMenu";
+import { useBackClosable } from "@/composables/useAndroidBack";
 
 const props = defineProps<{ hiddenCover?: boolean }>();
 const emit = defineEmits<{ removeSong: [index: number[]] }>();
@@ -29,6 +30,18 @@ const { getMenuOptions } = useSongMenu();
 const dropdownX = ref<number>(0);
 const dropdownY = ref<number>(0);
 const dropdownShow = ref<boolean>(false);
+// 子菜单展开时先折叠（派发 ArrowLeft 给 naive 内部 keyboard 处理），再按才关 dropdown
+useBackClosable(dropdownShow, {
+  onBack: () => {
+    if (document.querySelectorAll(".n-dropdown-menu").length > 1) {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }),
+      );
+      return true;
+    }
+    return false;
+  },
+});
 const dropdownOptions = ref<DropdownOption[]>([]);
 
 // 开启右键菜单

--- a/src/components/Player/PlayerQuickActionsMenu.vue
+++ b/src/components/Player/PlayerQuickActionsMenu.vue
@@ -1,5 +1,6 @@
 <template>
   <n-popover
+    v-model:show="popoverShow"
     placement="bottom-end"
     trigger="click"
     :show-arrow="false"
@@ -260,6 +261,10 @@ import { useSettingStore, useStatusStore } from "@/stores";
 import { usePlayerController } from "@/core/player/PlayerController";
 import { isElectron, isCapacitorAndroid } from "@/utils/env";
 import { PLAYER_META_HOLD_KEY } from "@/composables/usePlayerMetaHold";
+import { useBackClosable } from "@/composables/useAndroidBack";
+
+const popoverShow = ref(false);
+useBackClosable(popoverShow);
 
 // 触发器外观：mobile 用 40px 圆形，control 与 PlayerControl 其他 menu-icon 一致
 const props = withDefaults(defineProps<{ variant?: "mobile" | "control" }>(), {

--- a/src/components/Player/PlayerRightMenu.vue
+++ b/src/components/Player/PlayerRightMenu.vue
@@ -108,6 +108,7 @@ import { openAutoClose, openChangeRate, openEqualizer, openABLoop } from "@/util
 import { useAudioManager } from "@/core/player/AudioManager";
 import type { DropdownOption } from "naive-ui";
 import { useQualityControl } from "@/composables/useQualityControl";
+import { useBackClosable } from "@/composables/useAndroidBack";
 
 const dataStore = useDataStore();
 const statusStore = useStatusStore();
@@ -125,6 +126,7 @@ const {
 } = useQualityControl();
 
 const showQualityPopover = ref(false);
+useBackClosable(showQualityPopover);
 const qualityTagRef = ref<HTMLElement | null>(null);
 
 const handleQualityClick = async () => {

--- a/src/composables/useAndroidBack.ts
+++ b/src/composables/useAndroidBack.ts
@@ -1,31 +1,211 @@
-import { onMounted, onUnmounted } from "vue";
-import { App as CapacitorApp, type PluginListenerHandle } from "@capacitor/app";
-import { Capacitor } from "@capacitor/core";
+import { onBeforeUnmount, onMounted, onUnmounted, watch, type Ref } from "vue";
+import { App as CapacitorApp } from "@capacitor/app";
+import { Capacitor, type PluginListenerHandle } from "@capacitor/core";
 import { useRouter } from "vue-router";
+import { useMusicStore, useStatusStore } from "@/stores";
+import { useOrientationTransition } from "@/composables/useOrientationTransition";
+import { AndroidNativePlayback } from "@/plugins/androidNativePlayback";
 
 const ROOT_PATHS = new Set(["/", "/home"]);
 
+/**
+ * 安卓返回键处理栈
+ *
+ * 子级 UI（n-modal / n-drawer / 自定义弹层）在打开时注册自己的 back 处理函数，
+ * useAndroidBack 在分发返回事件时优先消费栈顶处理器。
+ * - 处理函数返回 true：表示已消化本次 back，停止后续分发
+ * - 返回 false / undefined：放行，继续走下一层
+ */
+export type BackHandler = () => boolean | void | Promise<boolean | void>;
+
+const backHandlerStack: BackHandler[] = [];
+
+/** 注册 back 处理器，返回反注册函数 */
+export const pushBackHandler = (handler: BackHandler): (() => void) => {
+  backHandlerStack.push(handler);
+  return () => {
+    const idx = backHandlerStack.lastIndexOf(handler);
+    if (idx !== -1) backHandlerStack.splice(idx, 1);
+  };
+};
+
+/** setup 内自动绑定，onMounted 推栈、onBeforeUnmount 出栈 */
+export const useBackHandler = (handler: BackHandler): void => {
+  let off: (() => void) | null = null;
+  onMounted(() => {
+    off = pushBackHandler(handler);
+  });
+  onBeforeUnmount(() => {
+    off?.();
+    off = null;
+  });
+};
+
+/**
+ * v-model:show ref 接入返回键
+ * options.onBack 返回 true 表示已消费但不关闭，用于多层级逐层折叠
+ */
+export const useBackClosable = (
+  showRef: Ref<boolean>,
+  options?: { onBack?: () => boolean | void },
+): void => {
+  let off: (() => void) | null = null;
+  const detach = () => {
+    off?.();
+    off = null;
+  };
+  const stop = watch(
+    showRef,
+    (visible) => {
+      if (visible) {
+        if (off) return;
+        off = pushBackHandler(() => {
+          // 给上层消费机会
+          if (options?.onBack?.() === true) return true;
+          // self-cleanup 防连按 race
+          detach();
+          showRef.value = false;
+          return true;
+        });
+      } else {
+        detach();
+      }
+    },
+    { immediate: true },
+  );
+  onBeforeUnmount(() => {
+    stop();
+    detach();
+  });
+};
+
+/** 从栈顶向下分发，handler 抛错视为已处理 */
+const dispatchBackStack = async (): Promise<boolean> => {
+  for (let i = backHandlerStack.length - 1; i >= 0; i--) {
+    const handler = backHandlerStack[i];
+    try {
+      const handled = await handler();
+      if (handled === true) return true;
+    } catch (e) {
+      console.warn("[useAndroidBack] back handler threw, treated as handled", e);
+      return true;
+    }
+  }
+  return false;
+};
+
+/** 能否 router.back：看 history.state.back，比 history.length 可靠 */
+const canRouterBack = (currentPath: string): boolean => {
+  if (ROOT_PATHS.has(currentPath)) return false;
+  const state = window.history.state as { back?: string | null } | null;
+  return !!state && typeof state.back === "string" && state.back.length > 0;
+};
+
 export const useAndroidBack = () => {
   const router = useRouter();
+  const statusStore = useStatusStore();
+  const musicStore = useMusicStore();
+  const orientationTransition = useOrientationTransition();
   let listener: PluginListenerHandle | null = null;
+  // 防 addListener race：resolve 前组件卸载则后续移除新 handle
+  let cancelled = false;
+  // 沉浸式退出期间防重入（覆盖整个 ~670ms 动画）
+  let immersiveExiting = false;
+  // 退出确认弹窗单例标志
+  let exitConfirmShown = false;
+
+  /** 退出确认弹窗：back 可关闭，不走全局 modal 包装器所以手动接栈 */
+  const showExitConfirm = () => {
+    if (exitConfirmShown) return;
+    exitConfirmShown = true;
+    let off: (() => void) | null = null;
+    const dialog = window.$dialog.warning({
+      title: "退出 SPlayer",
+      content: "确定要退出吗？",
+      positiveText: "退出",
+      negativeText: "取消",
+      autoFocus: false,
+      onPositiveClick: async () => {
+        // 优先走原生 shutdownApp：停前台服务再强杀进程；失败兜底 exitApp
+        try {
+          await AndroidNativePlayback.shutdownApp();
+        } catch (e) {
+          console.warn("[useAndroidBack] shutdownApp failed, fallback to exitApp", e);
+          await CapacitorApp.exitApp();
+        }
+      },
+      onAfterLeave: () => {
+        off?.();
+        off = null;
+        exitConfirmShown = false;
+      },
+    });
+    off = pushBackHandler(() => {
+      // self-cleanup 防连按 race
+      off?.();
+      off = null;
+      dialog.destroy();
+      return true;
+    });
+  };
 
   onMounted(async () => {
     if (Capacitor.getPlatform() !== "android") return;
 
-    listener = await CapacitorApp.addListener("backButton", async () => {
-      const currentPath = router.currentRoute.value.path;
-      const hasBackHistory = window.history.length > 1 && !ROOT_PATHS.has(currentPath);
-
-      if (hasBackHistory) {
+    const handle = await CapacitorApp.addListener("backButton", async () => {
+      // 0) 子级弹层
+      if (await dispatchBackStack()) return;
+      // 1) 搜索遮罩
+      if (statusStore.searchFocus) {
+        statusStore.searchFocus = false;
+        return;
+      }
+      // 2) 播放列表面板
+      if (statusStore.playListShow) {
+        statusStore.playListShow = false;
+        return;
+      }
+      // 3) 播放器评论面板
+      if (statusStore.showPlayerComment) {
+        statusStore.showPlayerComment = false;
+        return;
+      }
+      // 4) 沉浸式横屏
+      if (statusStore.isImmersiveFullscreen) {
+        // 其他入口已在 exit，本次吞即可
+        if (orientationTransition.isTransitioning.value) return;
+        if (immersiveExiting) return;
+        immersiveExiting = true;
+        try {
+          await orientationTransition.exit(musicStore.songCover);
+        } finally {
+          immersiveExiting = false;
+        }
+        return;
+      }
+      // 5) 全屏播放器
+      if (statusStore.showFullPlayer) {
+        statusStore.showFullPlayer = false;
+        return;
+      }
+      // 6) 路由回退
+      if (canRouterBack(router.currentRoute.value.path)) {
         await router.back();
         return;
       }
-
-      await CapacitorApp.exitApp();
+      // 7) 已到根，弹确认框
+      showExitConfirm();
     });
+
+    if (cancelled) {
+      handle.remove();
+      return;
+    }
+    listener = handle;
   });
 
   onUnmounted(() => {
+    cancelled = true;
     listener?.remove();
     listener = null;
   });

--- a/src/composables/useOrientationTransition.ts
+++ b/src/composables/useOrientationTransition.ts
@@ -226,6 +226,8 @@ export const useOrientationTransition = () => {
       return true;
     } catch (e) {
       console.warn("[orientationTransition] exit unexpected error", e);
+      // 异常路径同步状态，防 back 残留
+      statusStore.isImmersiveFullscreen = false;
       cleanup();
       return false;
     }

--- a/src/plugins/androidNativePlayback.ts
+++ b/src/plugins/androidNativePlayback.ts
@@ -207,6 +207,8 @@ export interface AndroidNativePlaybackPlugin {
   stop(): Promise<AndroidNativePlaybackState>;
   /** 硬清理：清 MediaItem / 通知栏 / 播放队列窗口。仅用于清场场景，切歌仍用 stop()。 */
   cleanup(): Promise<AndroidNativePlaybackState>;
+  /** 退出 App：停所有前台服务后强杀进程 */
+  shutdownApp(): Promise<void>;
   seek(options: { positionMs: number }): Promise<AndroidNativePlaybackState>;
   setVolume(options: { volume: number }): Promise<void>;
   setRate(options: { rate: number }): Promise<void>;

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,4 +1,19 @@
-import { DialogApi, LoadingBarApi, MessageApi, ModalApi, NotificationApi } from "naive-ui";
+import {
+  DialogApi,
+  LoadingBarApi,
+  MessageApi,
+  ModalApi,
+  ModalOptions,
+  ModalReactive,
+  NotificationApi,
+} from "naive-ui";
+
+// 扩展 ModalApi.create 支持 _backable：false 表示安卓返回键吞但不关闭
+type ExtendedModalOptions = ModalOptions & { _backable?: boolean };
+
+interface ExtendedModalApi extends Omit<ModalApi, "create"> {
+  create(options: ExtendedModalOptions): ModalReactive;
+}
 
 declare global {
   interface Window {
@@ -7,7 +22,7 @@ declare global {
     $dialog: DialogApi;
     $notification: NotificationApi;
     $loadingBar: LoadingBarApi;
-    $modal: ModalApi;
+    $modal: ExtendedModalApi;
     // electron
     api: {
       store: {

--- a/src/utils/modal.ts
+++ b/src/utils/modal.ts
@@ -52,6 +52,8 @@ export const openUserAgreement = async () => {
     maskClosable: false,
     closeOnEsc: false,
     closable: false,
+    // 用户协议必须显式同意，禁止安卓返回键关闭
+    _backable: false,
     style: {
       maxWidth: "70vw",
     },
@@ -132,6 +134,8 @@ export const openUserLogin = async (
     maskClosable: false,
     closeOnEsc: false,
     closable: false,
+    // 强制登录场景下禁止安卓返回键关闭
+    _backable: !force,
     style: { width: "400px" },
     content: () => {
       return h(Login, {

--- a/src/views/Discover/playlists.vue
+++ b/src/views/Discover/playlists.vue
@@ -98,12 +98,14 @@ import type { CoverType } from "@/types/main";
 import { useDataStore, useSettingStore } from "@/stores";
 import { allCatlistPlaylist } from "@/api/playlist";
 import { formatCoverList } from "@/utils/format";
+import { useBackClosable } from "@/composables/useAndroidBack";
 
 const router = useRouter();
 const dataStore = useDataStore();
 const settingStore = useSettingStore();
 
 const catChangeShow = ref<boolean>(false);
+useBackClosable(catChangeShow);
 
 // 歌单分类
 const catName = ref<string>((router.currentRoute.value.query?.cat as string) || "全部歌单");


### PR DESCRIPTION
## 📌 变更类型

- [ ] ✨ feat — 新功能
- [x] 🐞 fix — Bug 修复
- [ ] 🎨 style — 仅样式 / 格式，不影响逻辑
- [x] ♻️ refactor — 重构，不改变外部行为
- [ ] ⚡ perf — 性能优化
- [ ] 📝 docs — 仅文档
- [ ] 🧪 test — 新增 / 修改测试
- [ ] 🔧 chore — 构建 / 脚本 / 依赖
- [ ] 🚀 ci — 仅 CI 配置
- [ ] ⏪ revert — 回滚

## 📝 变更说明

### 背景

安卓物理返回键此前直接走 `CapacitorApp.exitApp()`，存在两个体验断层：

1. **多层 UI 无层级回退**：modal、drawer、全屏播放器、右键菜单子级等弹层，按 back 不会逐层关闭，而是直接退出 App
2. **退出粗暴**：`exitApp` 仅 finish Activity，**前台服务（PlaybackService、FloatingLyricService）继续存活**，通知栏与桌面歌词残留；缺乏二次确认，误触退出体验差

### 解决方案

#### 1. 全局 Back 处理栈（[useAndroidBack](cci:1://file:///d:/a/SPlayer-for-Android/src/composables/useAndroidBack.ts:103:0-211:2)）

- 新增 [pushBackHandler](cci:1://file:///d:/a/SPlayer-for-Android/src/composables/useAndroidBack.ts:21:0-28:2) / [useBackHandler](cci:1://file:///d:/a/SPlayer-for-Android/src/composables/useAndroidBack.ts:31:0-41:2) / [useBackClosable](cci:1://file:///d:/a/SPlayer-for-Android/src/composables/useAndroidBack.ts:42:0-78:2) 三层 API
- back 触发时**从栈顶向下分发**，handler 返回 `true` 则消费本次按键
- 异常被 swallow 视为已处理，避免穿透到下层 UI 触发误关 / 误退
- [useBackClosable(showRef, { onBack })](cci:1://file:///d:/a/SPlayer-for-Android/src/composables/useAndroidBack.ts:42:0-78:2)：v-model:show 风格弹层一行接入；[onBack](cci:1://file:///d:/a/SPlayer-for-Android/src/components/Menu/SongListMenu.vue:34:2-42:3) 钩子支持"消费但不关闭"语义，用于多层级逐层折叠

#### 2. 弹层 / 菜单接入

- `n-modal` 全局包装器：[Provider.vue](cci:7://file:///d:/a/SPlayer-for-Android/src/components/Global/Provider.vue:0:0-0:0) 劫持 `useModal().create`，默认所有 modal 可被 back 关闭，显式 `_backable: false` 可禁用（如用户协议、登录强制流程）
- `n-drawer` / `n-dropdown` / 自定义弹窗（`SongListMenu` / `CoverMenu` / `SearchInpMenu`）接入 [useBackClosable](cci:1://file:///d:/a/SPlayer-for-Android/src/composables/useAndroidBack.ts:42:0-78:2)
- **n-dropdown 子菜单两步折叠**：按 back 时若检测 `.n-dropdown-menu` 多于一层，向 document 派发 `ArrowLeft` 让 naive UI 内部折叠子菜单，第二次 back 才关整个 dropdown

#### 3. 原生退出能力

- [PlaybackManager.shutdownAll()](cci:1://file:///d:/a/SPlayer-for-Android/android/app/src/main/java/top/imsyy/splayer/android/playback/PlaybackManager.java:465:2-486:3)：[cleanup()](cci:1://file:///d:/a/SPlayer-for-Android/src/composables/useOrientationTransition.ts:69:0-73:2) → `stopService(FloatingLyricService)` → `stopService(PlaybackService)`，每段独立 try/catch
- [AndroidNativePlaybackPlugin.shutdownApp()](cci:1://file:///d:/a/SPlayer-for-Android/src/plugins/androidNativePlayback.ts:209:2-210:30)：调 [shutdownAll](cci:1://file:///d:/a/SPlayer-for-Android/android/app/src/main/java/top/imsyy/splayer/android/playback/PlaybackManager.java:465:2-486:3) → 100ms 后 [finishAndRemoveTask + System.exit(0)](cci:1://file:///d:/a/SPlayer-for-Android/src/composables/useOrientationTransition.ts:169:2-233:4)，从最近任务列表移除并强杀进程
- TS 侧 [androidNativePlayback.ts](cci:7://file:///d:/a/SPlayer-for-Android/src/plugins/androidNativePlayback.ts:0:0-0:0) 暴露 [shutdownApp(): Promise<void>](cci:1://file:///d:/a/SPlayer-for-Android/src/plugins/androidNativePlayback.ts:209:2-210:30)

#### 4. 退出确认弹窗

- 根路由按 back 不再直接退出，弹 `$dialog.warning` 二次确认
- 单例标志 + [onAfterLeave](cci:1://file:///d:/a/SPlayer-for-Android/src/utils/modal.ts:354:4-356:5) 兜底，连按 back 不重复弹
- 弹窗自身也接 back 栈（关 dialog 而非退 App）
- 点【退出】走原生 [shutdownApp](cci:1://file:///d:/a/SPlayer-for-Android/src/plugins/androidNativePlayback.ts:209:2-210:30)，失败兜底 `CapacitorApp.exitApp`

#### 5. 边界修复

- [useOrientationTransition.exit](cci:1://file:///d:/a/SPlayer-for-Android/src/composables/useOrientationTransition.ts:169:2-233:4) catch 分支强制把 `statusStore.isImmersiveFullscreen` 置 false，避免异常路径下沉浸式状态残留导致 back 死循环

#### 6. 类型扩展

- [types/global.d.ts](cci:7://file:///d:/a/SPlayer-for-Android/src/types/global.d.ts:0:0-0:0) 扩展 [ExtendedModalOptions](cci:2://file:///d:/a/SPlayer-for-Android/src/types/global.d.ts:11:0-11:67) 加 `_backable?: boolean`

## 🔗 关联 Issue

Closes #

## 📱 影响范围

- [x] 🎵 播放引擎 / 音频
- [x] 📝 歌词 / 桌面歌词
- [x] 🔔 通知栏 / MediaSession
- [ ] 🌐 在线音乐 (网易云 / Jellyfin / Navidrome / Emby / Subsonic / Last.fm)
- [ ] 🧩 内置 API (nodejs-mobile)
- [x] 🎨 UI / 主题 / 布局
- [ ] 📦 构建 / 打包 / 签名
- [x] 📱 Capacitor / 原生 Android 代码
- [ ] 📄 文档 / README

## ✅ 自检清单

- [x] 本 PR **目标分支为 `dev`**
- [x] 本地已执行 `pnpm lint` 且无 warning
- [x] 本地已执行 `pnpm typecheck` 且无报错
- [x] 已在 **至少一台真机** 上构建并验证关键路径
- [x] UI 改动已兼顾 **手机竖屏 + 平板横屏** 两种布局
- [x] 新增 / 修改的文案使用中文，与项目整体风格一致
- [x] 未引入不必要的依赖 / 大体积资源
- [x] 未修改签名密钥 / CI Secrets 相关文件

## 🧪 测试方式

### A. Back 多层关闭

1. 进入二级页（如歌单详情）→ 长按歌曲打开右键菜单
2. 点【更多操作 →】展开子菜单 → 按 **back** → 子菜单折叠（dropdown 仍开）→ 再按 **back** → dropdown 整体关闭
3. 持续按 **back** 路由逐级回退

### B. 退出确认

4. 根路由（`/` 或 `/home`）按 **back** → 弹"退出 SPlayer / 确定要退出吗？"
5. 按 **back** → 弹窗关闭，App 不退出
6. 再次根路由按 **back** → 弹框 → 点【取消】→ 弹窗关，App 不退出

### C. 原生退出彻底性（关键）

7. 重新弹框 → 点【退出】，立刻检查：
   - 通知栏媒体播放通知 ✅ 消失
   - 桌面歌词浮窗（如开启）✅ 消失
   - 最近任务列表 ✅ 无 SPlayer 卡片
   - 系统设置 → 应用 → SPlayer → 运行中服务 ✅ 空

### D. 强制弹窗不被 back 误关

8. 首次启动触发用户协议弹窗 → 按 **back** → 弹窗保持，提示"请先阅读并同意用户协议"

### E. 沉浸式横屏 back

9. 进入沉浸式横屏播放 → 按 **back** → 完整 exit 动画回到竖屏，无沉浸式状态残留

## 💬 其他说明

### 兼容性风险

- n-dropdown 子菜单折叠依赖 naive UI 内部 `keyboard: true` + ArrowLeft 行为，若升级 naive UI 改了快捷键实现需回归
- `finishAndRemoveTask` 需 Android 5.0+，项目 minSdk 已满足
- [System.exit(0)](cci:1://file:///d:/a/SPlayer-for-Android/src/composables/useOrientationTransition.ts:169:2-233:4) 是兜底强杀，第三方 SDK 注册的 cleanup hook 不会执行，目前无相关依赖

### 已知边界

- 退出确认弹窗关闭动画（~200ms）期间连按 back 会被静默吞掉，下一次才能再弹，实测无视觉异常
- `_backable: false` 的 modal 仍会消费 back 防止穿透，但 modal 本身不关