### PR TITLE
fix: 适配我喜欢的歌单获取，统一歌单列表渲染

### DIFF
--- a/src/api/playlist.ts
+++ b/src/api/playlist.ts
@@ -4,13 +4,13 @@ import request from "@/utils/request";
  * 获取歌单详情
  * @param {number} id - 歌单 id
  */
-export const playlistDetail = (id: number) => {
+export const playlistDetail = (id: number, noCookie: boolean = true) => {
   return request({
     url: "/playlist/detail",
     params: {
       id,
       s: 0, // 去除返回收藏者
-      noCookie: true, // 去除返回 privileges
+      ...(noCookie ? { noCookie: true } : {}), // 去除返回 privileges
       timestamp: Date.now(),
     },
   });

--- a/src/views/List/liked.vue
+++ b/src/views/List/liked.vue
@@ -16,18 +16,8 @@
       @play-all="playAllSongs"
     />
     <Transition name="fade" mode="out-in">
-      <div v-if="(!searchValue || searchData?.length) && isPhone" class="mobile-liked-song-list">
-        <SongCard
-          v-for="(song, index) in displayData"
-          :key="song.id"
-          :song="song"
-          :index="index"
-          hidden-size
-          @click.stop="playMobileSong(song)"
-        />
-      </div>
       <SongList
-        v-else-if="!searchValue || searchData?.length"
+        v-if="!searchValue || searchData?.length"
         :data="displayData"
         :loading="loading"
         :height="songListHeight"
@@ -67,14 +57,9 @@ import { useListDetail } from "@/composables/List/useListDetail";
 import { useListSearch } from "@/composables/List/useListSearch";
 import { useListScroll } from "@/composables/List/useListScroll";
 import { useListActions } from "@/composables/List/useListActions";
-import { useDevice } from "@/composables/useDevice";
-import { usePlayerController } from "@/core/player/PlayerController";
-import SongCard from "@/components/Card/SongCard.vue";
 
 const dataStore = useDataStore();
 const statusStore = useStatusStore();
-const { isPhone } = useDevice();
-const player = usePlayerController();
 
 // 是否激活
 const isActivated = ref<boolean>(false);
@@ -202,7 +187,7 @@ const loadPlaylistData = async (id: number, forceRefresh: boolean = false) => {
     resetScroll();
   }
   try {
-    const detail = await playlistDetail(id);
+    const detail = await playlistDetail(id, false);
     if (currentRequestId.value !== id) return;
     // 更新歌单详情
     setDetailData(formatCoverList(detail.playlist)[0]);
@@ -323,7 +308,7 @@ const syncSongList = async (serverIds: number[], requestId: number) => {
   if (currentRequestId.value !== requestId) return;
   setListData(newList);
   // 更新详情
-  const detail = await playlistDetail(playlistId.value);
+  const detail = await playlistDetail(playlistId.value, false);
   if (currentRequestId.value === requestId) {
     setDetailData(formatCoverList(detail.playlist)[0]);
   }
@@ -356,11 +341,6 @@ const playAllSongs = useDebounceFn(() => {
   if (!detailData.value || !displayData.value?.length) return;
   playAllSongsAction(displayData.value, playlistId.value);
 }, 300);
-
-const playMobileSong = (song: SongType) => {
-  if (!displayData.value?.length) return;
-  player.updatePlayList(displayData.value, song, playlistId.value);
-};
 
 // 删除指定索引歌曲
 const removeSong = (ids: number[]) => {
@@ -438,13 +418,3 @@ onMounted(async () => {
   }
 });
 </script>
-
-<style lang="scss" scoped>
-.mobile-liked-song-list {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  padding-top: 236px;
-  padding-bottom: 12px;
-}
-</style>


### PR DESCRIPTION
- 为歌单详情接口新增可选 `noCookie` 参数，支持动态控制请求是否携带登录态
- 在获取“我喜欢的音乐”歌单详情时关闭 `noCookie`，确保私有歌单可正确获取详情与歌曲权限数据
- 移除“我喜欢的音乐”页面手机端单独的全量 `SongCard` 渲染逻辑，统一使用 `SongList` 虚拟列表组件渲染
- 清理无用导入、方法和样式代码，降低页面维护成本

## 📌 变更类型

- [ ] ✨ feat — 新功能
- [x] 🐞 fix — Bug 修复
- [ ] 🎨 style — 仅样式 / 格式，不影响逻辑
- [x] ♻️ refactor — 重构，不改变外部行为
- [x] ⚡ perf — 性能优化
- [ ] 📝 docs — 仅文档
- [ ] 🧪 test — 新增 / 修改测试
- [ ] 🔧 chore — 构建 / 脚本 / 依赖
- [ ] 🚀 ci — 仅 CI 配置
- [ ] ⏪ revert — 回滚

## 📝 变更说明

本次修复主要解决用户从首页进入“我喜欢的音乐”时出现卡顿、空白，以及刷新缓存时私有歌单详情请求返回 `401 Unauthorized` 的问题。

此前“我喜欢的音乐”页面在手机端使用单独的 `SongCard` 分支渲染歌曲列表，会一次性渲染完整歌曲数据。当用户喜欢的歌曲数量较多，或页面正在刷新缓存时，容易造成 WebView 主线程压力过大，出现明显卡顿甚至页面空白。现在该页面统一使用已有的 `SongList` 虚拟列表组件，仅渲染可视区域内的歌曲项，从而降低首次进入和刷新缓存时的渲染压力。

同时，歌单详情接口原先固定传入 `noCookie: true`，导致获取“我喜欢的音乐”这类私有歌单详情时不会携带登录态，在 Android 内置 API 链路下会触发 `401 Unauthorized`。本次为 `playlistDetail` 新增可选 `noCookie` 参数，默认仍保持原有行为；仅在“我喜欢的音乐”页面显式关闭 `noCookie`，使请求通过 `X-SPlayer-Cookie` 携带登录态，并由内置 API 转换为接口需要的标准 Cookie 请求。

该调整保留了 `SongList` 在手机端的单击播放能力，同时保留默认排序、非搜索状态下的拖拽排序能力，避免因性能修复引入播放交互回归。

## 🔗 关联 Issue

Closes #33

## 📱 影响范围

- [ ] 🎵 播放引擎 / 音频
- [ ] 📝 歌词 / 桌面歌词
- [ ] 🔔 通知栏 / MediaSession
- [x] 🌐 在线音乐 (网易云 / Jellyfin / Navidrome / Emby / Subsonic / Last.fm)
- [ ] 🧩 内置 API (nodejs-mobile)
- [ ] 🎨 UI / 主题 / 布局
- [ ] 📦 构建 / 打包 / 签名
- [ ] 📱 Capacitor / 原生 Android 代码
- [ ] 📄 文档 / README

## ✅ 自检清单

- [x] 本 PR **目标分支为 `dev`**
- [x] 本地已执行 `pnpm lint` 且无 warning
- [x] 本地已执行 `pnpm typecheck` 且无报错
- [x] 已在 **至少一台真机** 上构建并验证关键路径
- [x] UI 改动已兼顾 **手机竖屏 + 平板横屏** 两种布局
- [x] 新增 / 修改的文案使用中文，与项目整体风格一致
- [x] 未引入不必要的依赖 / 大体积资源
- [x] 未修改签名密钥 / CI Secrets 相关文件

## 📸 截图 / 录屏 (UI 类 PR 必填)

| 改动前 | 改动后 |
| :----: | :----: |
| 用户进入“我喜欢的音乐”时可能出现空白或长时间卡顿；刷新缓存时可能出现 `401 Unauthorized` | 页面统一使用虚拟列表渲染，进入与刷新缓存更稳定；私有歌单详情可正常请求 |

## 🧪 测试方式

1. 从首页进入“我喜欢的音乐”，确认页面不再出现长时间空白，歌曲列表可正常展示。
2. 在“我喜欢的音乐”页面点击“刷新缓存”，确认控制台不再出现 `/playlist/detail` 的 `401 Unauthorized`，缓存刷新后歌曲数量与内容正常。
3. 在手机竖屏环境下点击歌曲，确认可单击播放；在默认排序、非搜索状态下长按歌曲，确认仍可进行拖拽排序。
4. 在歌曲数量较多的账号下重复进入“我喜欢的音乐”，确认页面滚动、播放、搜索和批量操作入口表现正常。
5. 执行 `pnpm lint` 和 `pnpm typecheck`，确认无 warning、无类型错误。

## 💬 其他说明 (选填)

- `playlistDetail` 新增的 `noCookie` 参数默认值仍为 `true`，其他调用方不受影响。
- `X-SPlayer-Cookie` 仅用于前端到 SPlayer API 的本地/代理请求链路，不会以该自定义 Header 名称直接转发到服务器；其值会在 SPlayer API 层转换为接口需要的标准 Cookie。
- “我喜欢的音乐”页面改为统一使用 `SongList` 后，手机端也会保留 `SongList` 的单击播放与长按拖拽排序能力。