### PR TITLE
fix(Webview): 修复WebView文本缩放异常问题&全面屏顶部安全区问题

### DIFF
--- a/android/app/src/main/java/top/imsyy/splayer/android/MainActivity.java
+++ b/android/app/src/main/java/top/imsyy/splayer/android/MainActivity.java
@@ -7,6 +7,8 @@ import android.os.Handler;
 import android.os.Looper;
 import android.preference.PreferenceManager;
 import android.view.View;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
 import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
@@ -45,6 +47,7 @@ public class MainActivity extends BridgeActivity {
       }
     }
     applyImmersiveMode();
+    applyWebViewTextZoom();
     // 音频预载 TTL：推迟到首帧后再初始化（构造期会同步读 SharedPreferences，冷启动加密磁盘可能耗百毫秒）。
     // 这里 post 2s，startPeriodicSweep 内部再 postDelayed 5s，首次 sweep 实际 ≈7s 后开始；
     // 之后每 30min 周期清理；TTL=50min；期间用户重复播放该 url 会通过 PlaybackManager.load 续期。
@@ -140,5 +143,12 @@ public class MainActivity extends BridgeActivity {
       }
       decorView.setSystemUiVisibility(flags);
     }
+  }
+
+  private void applyWebViewTextZoom() {
+    WebView webView = getBridge().getWebView();
+    if (webView == null) return;
+    WebSettings settings = webView.getSettings();
+    settings.setTextZoom(100);
   }
 }

--- a/src/composables/usePageZoom.ts
+++ b/src/composables/usePageZoom.ts
@@ -23,6 +23,12 @@ export const usePageZoom = () => {
     return settingStore.androidFullscreenSafeAreaOptimize ? 32 : 0;
   });
 
+  const fullscreenSafeTop = computed(() => {
+    if (!isCapacitorAndroid) return 0;
+    if (settingStore.androidShowStatusBar) return 0;
+    return 24;
+  });
+
   // 节流：合并同一帧内的多次调用，避免连发 resize
   let resizePending = false;
   const notifyResize = () => {
@@ -37,7 +43,7 @@ export const usePageZoom = () => {
     setTimeout(fire, 150);
   };
 
-  const apply = (zoom: number, safeBottom: number) => {
+  const apply = (zoom: number, safeTop: number, safeBottom: number) => {
     const safe = Math.max(50, Math.min(200, Number(zoom) || 100));
     const ratio = safe / 100;
 
@@ -59,6 +65,7 @@ export const usePageZoom = () => {
     appEl.style.setProperty("--page-zoom-100vh", `${100 / ratio}vh`);
     appEl.style.setProperty("--page-zoom-100dvh", `${100 / ratio}dvh`);
     appEl.style.setProperty("--page-zoom-60vw", `${60 / ratio}vw`);
+    appEl.style.setProperty("--android-fullscreen-safe-top", `${safeTop / ratio}px`);
     appEl.style.setProperty("--android-fullscreen-safe-bottom", `${safeBottom / ratio}px`);
 
     // 仅在 ratio !== 1 时设置 transform：scale(1) 也会触发 stacking context 与
@@ -73,6 +80,8 @@ export const usePageZoom = () => {
     notifyResize();
   };
 
-  onMounted(() => apply(activeZoom.value, fullscreenSafeBottom.value));
-  watch([activeZoom, fullscreenSafeBottom], ([zoom, safeBottom]) => apply(zoom, safeBottom));
+  onMounted(() => apply(activeZoom.value, fullscreenSafeTop.value, fullscreenSafeBottom.value));
+  watch([activeZoom, fullscreenSafeTop, fullscreenSafeBottom], ([zoom, safeTop, safeBottom]) =>
+    apply(zoom, safeTop, safeBottom),
+  );
 };

--- a/src/layout/AppLayout.vue
+++ b/src/layout/AppLayout.vue
@@ -392,7 +392,7 @@ onBeforeUnmount(() => {
 
 <style lang="scss" scoped>
 #app-layout {
-  --safe-area-top: max(env(safe-area-inset-top), 0px);
+  --safe-area-top: max(env(safe-area-inset-top), var(--android-fullscreen-safe-top, 0px));
   --safe-area-bottom: max(env(safe-area-inset-bottom), var(--android-fullscreen-safe-bottom, 0px));
   --app-header-height: calc(72px + var(--safe-area-top));
   --phone-nav-height: 56px;

--- a/src/style/main.scss
+++ b/src/style/main.scss
@@ -12,7 +12,7 @@
 }
 
 :root {
-  --safe-area-top: max(env(safe-area-inset-top), 0px);
+  --safe-area-top: max(env(safe-area-inset-top), var(--android-fullscreen-safe-top, 0px));
   --safe-area-right: max(env(safe-area-inset-right), 0px);
   --safe-area-bottom: max(env(safe-area-inset-bottom), 0px);
   --safe-area-left: max(env(safe-area-inset-left), 0px);
@@ -166,6 +166,7 @@ audio {
   // transform 由 usePageZoom 在 ratio !== 1 时按需设置，避免 scale(1) 引入额外
   // stacking context / fixed containing block 切换；100% 缩放路径保持原生行为
   // 在缩放容器内补偿安卓全面屏底部，弹出层 teleport 到 body 不会被影响
+  --safe-area-top: max(env(safe-area-inset-top), var(--android-fullscreen-safe-top, 0px));
   --safe-area-bottom: max(env(safe-area-inset-bottom), var(--android-fullscreen-safe-bottom, 0px));
 }
 


### PR DESCRIPTION
## 📌 变更类型

<!-- 勾选一项或多项 -->

- [ ] ✨ feat — 新功能
- [x] 🐞 fix — Bug 修复
- [x] 🎨 style — 仅样式 / 格式，不影响逻辑
- [ ] ♻️ refactor — 重构，不改变外部行为
- [ ] ⚡ perf — 性能优化
- [ ] 📝 docs — 仅文档
- [ ] 🧪 test — 新增 / 修改测试
- [ ] 🔧 chore — 构建 / 脚本 / 依赖
- [ ] 🚀 ci — 仅 CI 配置
- [ ] ⏪ revert — 回滚

## 📝 变更说明

修复安卓端在用户调大系统字体后，WebView 页面文字被系统字体缩放影响，导致首页、发现页等 UI 元素被挤压、错位的问题。

同时补充安卓沉浸式状态栏下的顶部安全区兜底逻辑，避免部分设备在 `safe-area-inset-top` 返回异常或为 `0` 时，顶部导航栏与状态栏、挖孔区域发生遮挡。

本次改动主要包括：

- Android WebView 初始化后固定 `textZoom` 为 `100%`，避免系统字体缩放影响前端页面布局。
- 页面缩放逻辑中增加安卓顶部安全区兜底变量。
- 全局样式与布局层统一读取顶部安全区兜底值，保证顶部导航区域有稳定避让距离。
- 保留原有应用内页面缩放能力，不改变用户通过应用设置调整界面缩放的行为。

## 📱 影响范围

<!-- 勾选此 PR 实际影响到的模块 -->

- [ ] 🎵 播放引擎 / 音频
- [ ] 📝 歌词 / 桌面歌词
- [ ] 🔔 通知栏 / MediaSession
- [ ] 🌐 在线音乐 (网易云 / Jellyfin / Navidrome / Emby / Subsonic / Last.fm)
- [ ] 🧩 内置 API (nodejs-mobile)
- [x] 🎨 UI / 主题 / 布局
- [ ] 📦 构建 / 打包 / 签名
- [x] 📱 Capacitor / 原生 Android 代码
- [ ] 📄 文档 / README

## ✅ 自检清单

- [x] 本 PR **目标分支为 `dev`**
- [x] 本地已执行 `pnpm lint` 且无 warning
- [x] 本地已执行 `pnpm typecheck` 且无报错
- [x] 已在 **至少一台真机** 上构建并验证关键路径
- [x] UI 改动已兼顾 **手机竖屏 + 平板横屏** 两种布局
- [x] 新增 / 修改的文案使用中文，与项目整体风格一致
- [x] 未引入不必要的依赖 / 大体积资源
- [x] 未修改签名密钥 / CI Secrets 相关文件

## 📸 截图 / 录屏 (UI 类 PR 必填)

<!-- 前后对比更佳，可直接拖拽图片或视频 -->

| 改动前 | 改动后 |
| :----: | :----: |
| 系统字体放大后，首页 / 发现页顶部 UI 被挤压，顶部导航可能与状态栏区域重叠 | 系统字体放大后，页面字号保持稳定，顶部导航避让状态栏 / 挖孔区域 |
| 请在此处粘贴改动前截图 | 请在此处粘贴改动后截图 |

## 🧪 测试方式

<!-- 评审者如何验证这次改动 -->

1. 在安卓真机系统设置中调大系统字体大小，重新打开应用，确认首页、发现页、底部导航等页面文字不会被系统字体缩放异常放大。
2. 在手机竖屏下进入首页、发现页等主要页面，确认顶部 Logo、搜索框、设置按钮、菜单按钮不会被状态栏或挖孔区域遮挡。
3. 在平板横屏 / 平板模式下打开应用，确认主布局、顶部导航和页面缩放表现正常。
4. 切换应用内“界面缩放”设置，确认页面缩放仍按应用自身设置生效，不受系统字体缩放影响。
5. 执行本地检查：
   - `pnpm lint`
   - `pnpm typecheck`
   - `.\gradlew.bat :app:compileDebugJavaWithJavac`

## 💬 其他说明 (选填)

本次修复不引入新依赖，不修改签名、CI、构建脚本或密钥相关配置。

需要注意的是，顶部安全区兜底值用于处理部分安卓设备在沉浸式状态栏下安全区返回不稳定的问题。该逻辑只作为 `env(safe-area-inset-top)` 的兜底值参与计算，不会覆盖系统能够正确返回的安全区值。

## 🔁 变化前后可视化

```mermaid
flowchart LR
  subgraph Before[改动前]
    A[用户调大系统字体] --> B[Android WebView 跟随系统字体缩放]
    B --> C[前端文字异常放大]
    C --> D[卡片 / 搜索框 / 底栏被挤压]
    E[沉浸式状态栏] --> F[safe-area-top 可能为 0]
    F --> G[顶部 UI 可能遮挡]
  end

  subgraph After[改动后]
    H[用户调大系统字体] --> I[WebView textZoom 固定为 100%]
    I --> J[前端文字保持设计尺寸]
    K[沉浸式状态栏] --> L[顶部安全区使用系统值与兜底值较大者]
    L --> M[顶部 UI 稳定避让]
  end
```

## 🔗 请求链路变化

```mermaid
flowchart TD
  A[MainActivity.onCreate] --> B[初始化 Capacitor WebView]
  B --> C[applyWebViewTextZoom]
  C --> D[WebSettings.setTextZoom 100]

  E[App.vue 初始化] --> F[usePageZoom]
  F --> G[计算安卓顶部安全区兜底]
  G --> H[写入 --android-fullscreen-safe-top]
  H --> I[AppLayout / main.scss 读取 --safe-area-top]
  I --> J[Nav 顶部区域避让状态栏]
```

## 🧭 渲染路径变化

```mermaid
flowchart TD
  A[Android 系统字体设置] --> B[WebView 渲染层]
  B --> C{是否固定 textZoom}
  C -->|改动前| D[跟随系统字体缩放]
  D --> E[Vue 页面文字变大]
  E --> F[布局错位]

  C -->|改动后| G[textZoom 100%]
  G --> H[Vue 页面按 CSS 尺寸渲染]
  H --> I[布局稳定]

  J[状态栏 overlay WebView] --> K[顶部安全区变量]
  K --> L[顶部导航高度与 padding]
  L --> M[顶部 UI 避让]
```

## 👆 交互变化

```mermaid
flowchart LR
  A[用户调整系统字体] --> B[重新打开应用]
  B --> C[页面字号不被系统字体异常放大]
  C --> D[搜索 / 设置 / 菜单按钮位置稳定]

  E[用户进入沉浸式安卓页面] --> F[顶部导航自动保留安全距离]
  F --> D
```