### PR TITLE
refactor(audio cache): 修复安卓后台播放缓存阻塞与封面异步竞态问题&诊断接口

### DIFF
--- a/android/app/src/main/java/top/imsyy/splayer/android/cache/AudioCacheProvider.java
+++ b/android/app/src/main/java/top/imsyy/splayer/android/cache/AudioCacheProvider.java
@@ -72,8 +72,25 @@ public final class AudioCacheProvider {
   private static volatile SimpleCache simpleCache;
 
   private static final Object lock = new Object();
+  @Nullable private static volatile DiagnosticListener diagnosticListener;
 
   private AudioCacheProvider() {}
+
+  public interface DiagnosticListener {
+    void onDiagnosticLog(@NonNull String tag, @NonNull String message);
+  }
+
+  public static void setDiagnosticListener(@Nullable DiagnosticListener listener) {
+    diagnosticListener = listener;
+  }
+
+  private static void emitDiagnosticLog(@NonNull String tag, @NonNull String message) {
+    Log.d(TAG, tag + " " + message);
+    DiagnosticListener listener = diagnosticListener;
+    if (listener != null) {
+      listener.onDiagnosticLog(tag, message);
+    }
+  }
 
   /** 懒初始化 SimpleCache 单例（同进程多次构造同目录会抛 IllegalStateException）。 */
   @NonNull
@@ -139,7 +156,7 @@ public final class AudioCacheProvider {
 
     // http(s) 走 CacheDataSource；本地 file:// / content:// 直接 DefaultDataSource，
     // 避免本地文件被复制一份到 cacheDir/exo/。
-    DataSource.Factory httpCacheFactory = buildHttpCacheFactory(appContext, httpFactory, cache);
+    DataSource.Factory httpCacheFactory = buildHttpCacheFactory(appContext, httpFactory, cache, false);
     DataSource.Factory localFactory = new DefaultDataSource.Factory(appContext);
 
     return () -> new SchemeRoutingDataSource(httpCacheFactory, localFactory);
@@ -153,7 +170,8 @@ public final class AudioCacheProvider {
   private static DataSource.Factory buildHttpCacheFactory(
       @NonNull Context appContext,
       @NonNull DataSource.Factory httpFactory,
-      @NonNull SimpleCache cache) {
+      @NonNull SimpleCache cache,
+      boolean blockOnCache) {
     CacheDataSink.Factory cacheSinkFactory =
         new CacheDataSink.Factory().setCache(cache).setFragmentSize(Long.MAX_VALUE);
     return () -> {
@@ -163,8 +181,10 @@ public final class AudioCacheProvider {
               .setUpstreamDataSourceFactory(httpFactory)
               .setCacheKeyFactory(spec -> resolveCacheKey(spec.uri))
               .setFlags(
-                  CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR
-                      | CacheDataSource.FLAG_BLOCK_ON_CACHE);
+                  blockOnCache
+                      ? CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR
+                          | CacheDataSource.FLAG_BLOCK_ON_CACHE
+                      : CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR);
       if (!isLowDiskSpace(appContext)) {
         cf.setCacheWriteDataSinkFactory(cacheSinkFactory);
       } else {
@@ -186,7 +206,7 @@ public final class AudioCacheProvider {
             .setAllowCrossProtocolRedirects(true)
             .setConnectTimeoutMs(15_000)
             .setReadTimeoutMs(15_000);
-    return buildHttpCacheFactory(appContext, httpFactory, cache);
+    return buildHttpCacheFactory(appContext, httpFactory, cache, true);
   }
 
   /**
@@ -242,7 +262,15 @@ public final class AudioCacheProvider {
         pendingListeners.clear();
         current = ds;
       }
-      return ds.open(dataSpec);
+      long startedAt = android.os.SystemClock.elapsedRealtime();
+      try {
+        return ds.open(dataSpec);
+      } finally {
+        long costMs = android.os.SystemClock.elapsedRealtime() - startedAt;
+        if (isHttp && costMs > 1000L) {
+          emitDiagnosticLog("DIAG-AudioOpen", "slow open " + costMs + "ms key=" + resolveCacheKey(dataSpec.uri));
+        }
+      }
     }
 
     @Override
@@ -495,8 +523,13 @@ public final class AudioCacheProvider {
     chosen.execute(() -> {
       // 取每个 cacheKey 自己的 monitor：跨 executor 时同 cacheKey 串行，避免并发 CacheWriter 写同一组 span
       final Object writerLock = cacheKeyWriterLocks.computeIfAbsent(cacheKey, k -> new Object());
+      long lockWaitStartedAt = android.os.SystemClock.elapsedRealtime();
       try {
         synchronized (writerLock) {
+          long lockWaitMs = android.os.SystemClock.elapsedRealtime() - lockWaitStartedAt;
+          if (lockWaitMs > 500L) {
+            emitDiagnosticLog("DIAG-CacheWriter", "lock wait " + lockWaitMs + "ms key=" + cacheKey);
+          }
           DataSource.Factory factory = buildHttpCacheFactoryForPrefetch(appContext);
           DataSource ds = factory.createDataSource();
           DataSpec.Builder specBuilder =

--- a/android/app/src/main/java/top/imsyy/splayer/android/playback/PlaybackManager.java
+++ b/android/app/src/main/java/top/imsyy/splayer/android/playback/PlaybackManager.java
@@ -68,6 +68,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicLong;
 import top.imsyy.splayer.android.MainActivity;
 import top.imsyy.splayer.android.R;
 import top.imsyy.splayer.android.cache.AudioCacheProvider;
@@ -102,6 +103,7 @@ public final class PlaybackManager {
    */
   private final java.util.concurrent.atomic.AtomicLong resolveTokenCounter =
       new java.util.concurrent.atomic.AtomicLong();
+  private final AtomicLong artworkTokenCounter = new AtomicLong();
 
   private ExoPlayer player;
   /** 暴露给 MediaSession 的包装 Player：覆写 availableCommands，让系统媒体面板始终展示上一/下一首。 */
@@ -287,6 +289,8 @@ public final class PlaybackManager {
 
   private PlaybackManager(Context context) {
     this.appContext = context.getApplicationContext();
+    AudioCacheProvider.setDiagnosticListener(
+        (tag, message) -> mainHandler.post(() -> emitDiagnosticLog(tag, message)));
   }
 
   public static PlaybackManager getInstance(Context context) {
@@ -1438,6 +1442,15 @@ public final class PlaybackManager {
     currentPlugin.emitEvent("customAction", payload, true);
   }
 
+  private void emitDiagnosticLog(String tag, String message) {
+    AndroidNativePlaybackPlugin currentPlugin = plugin;
+    if (currentPlugin == null) return;
+    JSObject payload = new JSObject();
+    payload.put("tag", tag);
+    payload.put("message", message);
+    currentPlugin.emitEvent("diagnosticLog", payload, false);
+  }
+
   private void startTrackFromState(
       String source, TrackMetadata metadata, boolean likedState, boolean emitProgressImmediately) {
     if (player == null) {
@@ -2002,6 +2015,7 @@ public final class PlaybackManager {
       };
 
   private void loadCoverBitmapAsync(String coverUrl) {
+    final long artworkToken = artworkTokenCounter.incrementAndGet();
     if (coverUrl == null || coverUrl.isEmpty() || coverUrl.startsWith("blob:")) {
       coverBitmap = BitmapFactory.decodeResource(appContext.getResources(), R.mipmap.ic_launcher);
       coverArtworkBytes = encodeArtworkBytes(coverBitmap);
@@ -2072,6 +2086,10 @@ public final class PlaybackManager {
           final byte[] encodedBytes = encodeArtworkBytes(resolvedBitmap);
           mainHandler.post(
               () -> {
+                if (artworkToken != artworkTokenCounter.get()) {
+                  emitDiagnosticLog("DIAG-Artwork", "stale cover ignored");
+                  return;
+                }
                 coverBitmap = resolvedBitmap;
                 coverArtworkBytes = encodedBytes;
                 refreshCurrentMediaItemMetadata();

--- a/src/core/audio-player/AndroidNativeAudioPlayer.ts
+++ b/src/core/audio-player/AndroidNativeAudioPlayer.ts
@@ -402,6 +402,12 @@ export class AndroidNativeAudioPlayer extends EventTarget implements IPlaybackEn
         }
       }),
     );
+
+    this.listenerHandles.push(
+      await AndroidNativePlayback.addListener("diagnosticLog", (event) => {
+        console.debug(`[AndroidNativePlayback] [${event.tag}] ${event.message}`);
+      }),
+    );
   }
 
   private async releaseListeners() {

--- a/src/plugins/androidNativePlayback.ts
+++ b/src/plugins/androidNativePlayback.ts
@@ -168,6 +168,11 @@ export interface AndroidNativeVisualizerDataEvent {
   lowFreq: number;
 }
 
+export interface AndroidNativeDiagnosticLogEvent {
+  tag: string;
+  message: string;
+}
+
 export interface AndroidNativeFloatingLyricDataPayload {
   lrcData: string;
   yrcData: string;
@@ -269,6 +274,10 @@ export interface AndroidNativePlaybackPlugin {
   addListener(
     eventName: "visualizerData",
     listenerFunc: (event: AndroidNativeVisualizerDataEvent) => void,
+  ): Promise<PluginListenerHandle>;
+  addListener(
+    eventName: "diagnosticLog",
+    listenerFunc: (event: AndroidNativeDiagnosticLogEvent) => void,
   ): Promise<PluginListenerHandle>;
   removeAllListeners(): Promise<void>;
 }


### PR DESCRIPTION
- 新增诊断监听器接口，用于输出缓存相关日志
- 为Http缓存工厂添加blockOnCache参数，动态控制缓存标志
- 为音频数据源打开操作添加慢操作日志上报
- 为缓存写入锁等待添加超时日志上报
- 优化缓存构建逻辑，修复缓存标志配置问

## 📌 变更类型

<!-- 勾选一项或多项 -->

- [ ] ✨ feat — 新功能
- [x] 🐞 fix — Bug 修复
- [ ] 🎨 style — 仅样式 / 格式，不影响逻辑
- [x] ♻️ refactor — 重构，不改变外部行为
- [x] ⚡ perf — 性能优化
- [ ] 📝 docs — 仅文档
- [ ] 🧪 test — 新增 / 修改测试
- [ ] 🔧 chore — 构建 / 脚本 / 依赖
- [ ] 🚀 ci — 仅 CI 配置
- [ ] ⏪ revert — 回滚


Closes #

## 📱 影响范围

<!-- 勾选此 PR 实际影响到的模块 -->

- [x] 🎵 播放引擎 / 音频
- [ ] 📝 歌词 / 桌面歌词
- [ ] 🔔 通知栏 / MediaSession
- [ ] 🌐 在线音乐 (网易云 / Jellyfin / Navidrome / Emby / Subsonic / Last.fm)
- [ ] 🧩 内置 API (nodejs-mobile)
- [ ] 🎨 UI / 主题 / 布局
- [ ] 📦 构建 / 打包 / 签名
- [x] 📱 Capacitor / 原生 Android 代码
- [ ] 📄 文档 / README

## ✅ 自检清单

- [x] 本 PR **目标分支为 `dev`**
- [x] 本地已执行 `pnpm lint` 且无 warning
- [x] 本地已执行 `pnpm typecheck` 且无报错
- [x] 已在 **至少一台真机** 上构建并验证关键路径
- [x] UI 改动已兼顾 **手机竖屏 + 平板横屏** 两种布局
- [x] 新增 / 修改的文案使用中文，与项目整体风格一致
- [x] 未引入不必要的依赖 / 大体积资源
- [x] 未修改签名密钥 / CI Secrets 相关文件