### PR TITLE
refactor(androidLyricScheduler): 重构歌词调度逻辑，统一优先级处理流程

### DIFF
--- a/src/core/player/androidLyricScheduler.test.ts
+++ b/src/core/player/androidLyricScheduler.test.ts
@@ -14,40 +14,56 @@ interface TestResult {
 
 const result = (id: ResultId, hasLyric = id !== "empty"): TestResult => ({ id, hasLyric });
 
+const deferredResult = () => {
+  let resolve!: (value: TestResult) => void;
+  const promise = new Promise<TestResult>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+};
+
+const deferredRejectedResult = () => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<TestResult>((_, fail) => {
+    reject = fail;
+  });
+  return { promise, reject };
+};
+
 const createFetchers = (
-  values: Partial<Record<Exclude<ResultId, "empty">, TestResult>>,
+  values: Partial<Record<Exclude<ResultId, "empty">, TestResult | Promise<TestResult>>>,
   calls: string[],
 ): AndroidLyricFetchers<TestResult> => ({
   hasResult: (value) => value.hasLyric,
   emptyResult: () => result("empty", false),
   fetchSidecar: async () => {
     calls.push("sidecar");
-    return values.sidecar ?? result("empty", false);
+    return values.sidecar ? await values.sidecar : result("empty", false);
   },
   fetchDirectory: async (preferMetadata) => {
     calls.push(`directory:${preferMetadata ? "metadata" : "index"}`);
-    return values.directory ?? result("empty", false);
+    return values.directory ? await values.directory : result("empty", false);
   },
   fetchOnline: async () => {
     calls.push("online");
-    return values.online ?? result("empty", false);
+    return values.online ? await values.online : result("empty", false);
   },
   fetchAmlTtml: async () => {
     calls.push("amll");
-    return values.amll ?? result("empty", false);
+    return values.amll ? await values.amll : result("empty", false);
   },
   fetchLegacyQm: async () => {
     calls.push("qm");
-    return values.qm ?? result("empty", false);
+    return values.qm ? await values.qm : result("empty", false);
   },
   fetchOfficial: async () => {
     calls.push("official");
-    return values.official ?? result("empty", false);
+    return values.official ? await values.official : result("empty", false);
   },
 });
 
 describe("androidLyricScheduler", () => {
-  it("在线歌曲先查 Android 扫描目录，命中后不请求在线歌词", async () => {
+  it("在线歌曲直接请求在线歌词", async () => {
     const calls: string[] = [];
 
     const lyric = await fetchAndroidPrioritizedLyricResult({
@@ -56,11 +72,11 @@ describe("androidLyricScheduler", () => {
       fetchers: createFetchers({ directory: result("directory"), online: result("online") }, calls),
     });
 
-    assert.equal(lyric.id, "directory");
-    assert.deepEqual(calls, ["directory:index"]);
+    assert.equal(lyric.id, "online");
+    assert.deepEqual(calls, ["online"]);
   });
 
-  it("在线歌曲扫描目录未命中时回退在线歌词", async () => {
+  it("在线歌曲不等待扫描目录未命中", async () => {
     const calls: string[] = [];
 
     const lyric = await fetchAndroidPrioritizedLyricResult({
@@ -70,7 +86,7 @@ describe("androidLyricScheduler", () => {
     });
 
     assert.equal(lyric.id, "online");
-    assert.deepEqual(calls, ["directory:index", "online"]);
+    assert.deepEqual(calls, ["online"]);
   });
 
   it("本地歌曲同目录歌词优先于扫描目录", async () => {
@@ -89,7 +105,7 @@ describe("androidLyricScheduler", () => {
     assert.deepEqual(calls, ["sidecar"]);
   });
 
-  it("本地歌曲无同目录歌词时优先使用扫描目录", async () => {
+  it("本地歌曲无同目录歌词时按 auto 优先级查找", async () => {
     const calls: string[] = [];
 
     const lyric = await fetchAndroidPrioritizedLyricResult({
@@ -98,8 +114,8 @@ describe("androidLyricScheduler", () => {
       fetchers: createFetchers({ directory: result("directory"), amll: result("amll") }, calls),
     });
 
-    assert.equal(lyric.id, "directory");
-    assert.deepEqual(calls, ["sidecar", "directory:metadata"]);
+    assert.equal(lyric.id, "amll");
+    assert.deepEqual(calls, ["sidecar", "amll", "directory:metadata", "qm", "official"]);
   });
 
   it("本地歌曲扫描目录未命中时按歌词优先级回退", async () => {
@@ -112,6 +128,77 @@ describe("androidLyricScheduler", () => {
     });
 
     assert.equal(lyric.id, "qm");
-    assert.deepEqual(calls, ["sidecar", "directory:metadata", "qm"]);
+    assert.deepEqual(calls, ["sidecar", "qm", "directory:metadata", "amll", "official"]);
+  });
+
+  it("本地歌曲 local 优先级优先使用扫描目录", async () => {
+    const calls: string[] = [];
+
+    const lyric = await fetchAndroidPrioritizedLyricResult({
+      isLocalSong: true,
+      priority: "local",
+      fetchers: createFetchers({ directory: result("directory"), amll: result("amll") }, calls),
+    });
+
+    assert.equal(lyric.id, "directory");
+    assert.deepEqual(calls, ["sidecar", "directory:metadata"]);
+  });
+
+  it("本地歌曲同目录未命中后并发查询 YRC 和 TTML 来源", async () => {
+    const calls: string[] = [];
+    const amll = deferredResult();
+    const directory = deferredResult();
+    const qm = deferredResult();
+
+    const lyricPromise = fetchAndroidPrioritizedLyricResult({
+      isLocalSong: true,
+      priority: "ttml",
+      fetchers: createFetchers(
+        { amll: amll.promise, directory: directory.promise, qm: qm.promise },
+        calls,
+      ),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.deepEqual(calls, ["sidecar", "amll", "directory:metadata", "qm", "official"]);
+
+    directory.resolve(result("empty", false));
+    qm.resolve(result("qm"));
+    amll.resolve(result("empty", false));
+
+    const lyric = await lyricPromise;
+
+    assert.equal(lyric.id, "qm");
+  });
+
+  it("高优先级命中后消费低优先级失败请求", async () => {
+    const calls: string[] = [];
+    const directory = deferredRejectedResult();
+    const unhandledReasons: unknown[] = [];
+    const handleUnhandledRejection = (reason: unknown) => {
+      unhandledReasons.push(reason);
+    };
+
+    process.on("unhandledRejection", handleUnhandledRejection);
+
+    try {
+      const lyric = await fetchAndroidPrioritizedLyricResult({
+        isLocalSong: true,
+        priority: "auto",
+        fetchers: createFetchers(
+          { amll: result("amll"), directory: directory.promise },
+          calls,
+        ),
+      });
+
+      directory.reject(new Error("directory failed"));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      assert.equal(lyric.id, "amll");
+      assert.deepEqual(calls, ["sidecar", "amll", "directory:metadata", "qm", "official"]);
+      assert.deepEqual(unhandledReasons, []);
+    } finally {
+      process.off("unhandledRejection", handleUnhandledRejection);
+    }
   });
 });

--- a/src/core/player/androidLyricScheduler.ts
+++ b/src/core/player/androidLyricScheduler.ts
@@ -19,6 +19,34 @@ export interface AndroidLyricSchedulerOptions<TResult> {
 
 type LyricSource<TResult> = () => Promise<TResult>;
 
+type LyricRequestResult<TResult> =
+  | { fulfilled: true; result: TResult }
+  | { fulfilled: false };
+
+const settleLyricRequest = async <TResult>(
+  fetchSource: LyricSource<TResult>,
+): Promise<LyricRequestResult<TResult>> => {
+  try {
+    return { fulfilled: true, result: await fetchSource() };
+  } catch {
+    return { fulfilled: false };
+  }
+};
+
+const fetchFirstByPriority = async <TResult>(
+  sources: Array<LyricSource<TResult>>,
+  fetchers: AndroidLyricFetchers<TResult>,
+): Promise<TResult> => {
+  const requests = sources.map((fetchSource) => settleLyricRequest(fetchSource));
+
+  for (const request of requests) {
+    const settled = await request;
+    if (settled.fulfilled && fetchers.hasResult(settled.result)) return settled.result;
+  }
+
+  return fetchers.emptyResult();
+};
+
 export const fetchAndroidPrioritizedLyricResult = async <TResult>({
   isLocalSong,
   priority,
@@ -29,26 +57,28 @@ export const fetchAndroidPrioritizedLyricResult = async <TResult>({
     if (fetchers.hasResult(sidecarResult)) return sidecarResult;
   }
 
-  const directoryResult = await fetchers.fetchDirectory(isLocalSong);
-  if (fetchers.hasResult(directoryResult)) return directoryResult;
-
   if (!isLocalSong) {
     return fetchers.fetchOnline();
   }
 
+  const localDirectory = () => fetchers.fetchDirectory(true);
+
+  if (priority === "local") {
+    const directoryResult = await localDirectory();
+    if (fetchers.hasResult(directoryResult)) return directoryResult;
+    return fetchFirstByPriority(
+      [fetchers.fetchAmlTtml, fetchers.fetchLegacyQm, fetchers.fetchOfficial],
+      fetchers,
+    );
+  }
+
   const sourceOrders: Partial<Record<AndroidLyricPriority, Array<LyricSource<TResult>>>> = {
-    local: [fetchers.fetchAmlTtml, fetchers.fetchLegacyQm, fetchers.fetchOfficial],
-    ttml: [fetchers.fetchAmlTtml, fetchers.fetchLegacyQm, fetchers.fetchOfficial],
-    qm: [fetchers.fetchLegacyQm, fetchers.fetchAmlTtml, fetchers.fetchOfficial],
-    official: [fetchers.fetchOfficial],
-    auto: [fetchers.fetchAmlTtml, fetchers.fetchLegacyQm, fetchers.fetchOfficial],
+    ttml: [fetchers.fetchAmlTtml, localDirectory, fetchers.fetchLegacyQm, fetchers.fetchOfficial],
+    qm: [fetchers.fetchLegacyQm, localDirectory, fetchers.fetchAmlTtml, fetchers.fetchOfficial],
+    official: [fetchers.fetchOfficial, localDirectory],
+    auto: [fetchers.fetchAmlTtml, localDirectory, fetchers.fetchLegacyQm, fetchers.fetchOfficial],
   };
 
   const sources = sourceOrders[priority] || sourceOrders.auto || [];
-  for (const fetchSource of sources) {
-    const result = await fetchSource();
-    if (fetchers.hasResult(result)) return result;
-  }
-
-  return fetchers.emptyResult();
+  return fetchFirstByPriority(sources, fetchers);
 };


### PR DESCRIPTION
- 提取通用的请求处理工具函数settleLyricRequest和fetchFirstByPriority
- 重构fetchAndroidPrioritizedLyricResult，复用通用调度逻辑
- 调整本地歌曲优先级处理顺序，将本地目录扫描加入各优先级队列
- 修复在线歌曲逻辑，不再提前请求扫描目录
- 新增单元测试覆盖并发请求、错误处理和local优先级场景
- 优化测试用例，适配新的调度逻辑


## 📌 变更类型

<!-- 勾选一项或多项 -->

- [ ] ✨ feat — 新功能
- [x] 🐞 fix — Bug 修复
- [ ] 🎨 style — 仅样式 / 格式，不影响逻辑
- [ ] ♻️ refactor — 重构，不改变外部行为
- [x] ⚡ perf — 性能优化
- [ ] 📝 docs — 仅文档
- [ ] 🧪 test — 新增 / 修改测试
- [ ] 🔧 chore — 构建 / 脚本 / 依赖
- [ ] 🚀 ci — 仅 CI 配置
- [ ] ⏪ revert — 回滚


## 📱 影响范围

- [x] 🎵 播放引擎 / 音频
- [x] 📝 歌词 / 桌面歌词
- [x] 🔔 通知栏 / MediaSession
- [ ] 🌐 在线音乐 (网易云 / Jellyfin / Navidrome / Emby / Subsonic / Last.fm)
- [ ] 🧩 内置 API (nodejs-mobile)
- [ ] 🎨 UI / 主题 / 布局
- [ ] 📦 构建 / 打包 / 签名
- [ ] 📱 Capacitor / 原生 Android 代码
- [ ] 📄 文档 / README

## ✅ 自检清单

- [x] 本 PR **目标分支为 `dev`**
- [x] 本地已执行 `pnpm lint` 且无 warning
- [x] 本地已执行 `pnpm typecheck` 且无报错
- [x] 已在 **至少一台真机** 上构建并验证关键路径
- [x] UI 改动已兼顾 **手机竖屏 + 平板横屏** 两种布局
- [x] 新增 / 修改的文案使用中文，与项目整体风格一致
- [x] 未引入不必要的依赖 / 大体积资源
- [x] 未修改签名密钥 / CI Secrets 相关文件
