### PR TITLE
fix: 全屏播放器显示时出现穿透事件

### DIFF
--- a/src/components/Layout/Nav.vue
+++ b/src/components/Layout/Nav.vue
@@ -173,6 +173,16 @@ const isMax = ref(false);
 const showAside = ref(false);
 useBackClosable(showAside);
 
+watch(
+  () => statusStore.showFullPlayer,
+  (show) => {
+    if (show) {
+      showAside.value = false;
+      showCloseModal.value = false;
+    }
+  },
+);
+
 // 最小化
 const min = () => window.electron.ipcRenderer.send("win-min");
 

--- a/src/components/List/SongList.vue
+++ b/src/components/List/SongList.vue
@@ -155,7 +155,7 @@
       <!-- 列表操作 -->
       <Teleport to="body">
         <Transition name="fade" mode="out-in">
-          <div v-if="floatToolShow" class="list-menu">
+          <div v-if="floatToolShow && !statusStore.showFullPlayer" class="list-menu">
             <n-float-button-group position="relative">
               <n-float-button v-if="hasPlaySong >= 0" width="42" @click="scrollToCurrentSong">
                 <SvgIcon :size="22" name="Location" />
@@ -171,7 +171,7 @@
       <Teleport to="body">
         <Transition name="fade">
           <div
-            v-if="isDragging && draggable && dragLabelData"
+            v-if="isDragging && draggable && dragLabelData && !statusStore.showFullPlayer"
             class="drag-label"
             :style="{
               top: `${dragLabelPosition.top}px`,

--- a/src/layout/AppLayout.vue
+++ b/src/layout/AppLayout.vue
@@ -103,7 +103,7 @@
                 <component v-else :is="Component" class="router-view" />
               </Transition>
             </RouterView>
-            <n-back-top :right="40" :bottom="120">
+            <n-back-top v-if="!statusStore.showFullPlayer" :right="40" :bottom="120">
               <SvgIcon :size="22" name="Up" />
             </n-back-top>
           </n-layout>
@@ -121,7 +121,7 @@
               <component v-else :is="Component" class="router-view" />
             </Transition>
           </RouterView>
-          <n-back-top :right="16" :bottom="phoneBackTopBottom">
+          <n-back-top v-if="!statusStore.showFullPlayer" :right="16" :bottom="phoneBackTopBottom">
             <SvgIcon :size="22" name="Up" />
           </n-back-top>
         </main>
@@ -458,6 +458,7 @@ onBeforeUnmount(() => {
 
   &.show-full-player {
     opacity: 0;
+    pointer-events: none;
     transform: scale(0.9);
 
     #main-header {


### PR DESCRIPTION
- 新增监听全局全屏播放器状态的侦听器，全屏时自动关闭侧边栏
- 为歌曲列表菜单、拖拽标签和两个场景的返回顶部按钮添加全屏播放器状态判断，仅在非全屏播放器时显示
- 为全屏播放器容器添加pointer-events: none，避免遮挡交互

## 📌 变更类型

<!-- 勾选一项或多项 -->

- [ ] ✨ feat — 新功能
- [x] 🐞 fix — Bug 修复
- [ ] 🎨 style — 仅样式 / 格式，不影响逻辑
- [ ] ♻️ refactor — 重构，不改变外部行为
- [ ] ⚡ perf — 性能优化
- [ ] 📝 docs — 仅文档
- [ ] 🧪 test — 新增 / 修改测试
- [ ] 🔧 chore — 构建 / 脚本 / 依赖
- [ ] 🚀 ci — 仅 CI 配置
- [ ] ⏪ revert — 回滚

## 📝 变更说明

<!-- 清晰说明 **改了什么** 与 **为什么改**，而不是逐行复述 diff -->

## 🔗 关联 Issue

<!-- 用 Closes / Fixes 关键字关联，会在合并时自动关闭对应 Issue -->

Closes #36 

## 📱 影响范围

<!-- 勾选此 PR 实际影响到的模块 -->

- [ ] 🎵 播放引擎 / 音频
- [ ] 📝 歌词 / 桌面歌词
- [ ] 🔔 通知栏 / MediaSession
- [ ] 🌐 在线音乐 (网易云 / Jellyfin / Navidrome / Emby / Subsonic / Last.fm)
- [ ] 🧩 内置 API (nodejs-mobile)
- [x] 🎨 UI / 主题 / 布局
- [ ] 📦 构建 / 打包 / 签名
- [ ] 📱 Capacitor / 原生 Android 代码
- [ ] 📄 文档 / README

## ✅ 自检清单

- [x] 本 PR **目标分支为 `dev`**
- [x] 本地已执行 `pnpm lint` 且无 warning
- [x] 本地已执行 `pnpm typecheck` 且无报错
- [x] 已在 **至少一台真机** 上构建并验证关键路径
- [x] UI 改动已兼顾 **手机竖屏 + 平板横屏** 两种布局
- [x] 新增 / 修改的文案使用中文，与项目整体风格一致
- [x] 未引入不必要的依赖 / 大体积资源
- [x] 未修改签名密钥 / CI Secrets 相关文件

## 📸 截图 / 录屏 (UI 类 PR 必填)

<!-- 前后对比更佳，可直接拖拽图片或视频 -->

| 改动前 | 改动后 |
| :----: | :----: |
|    
<img width="1224" height="2688" alt="image" src="https://github.com/user-attachments/assets/ba692049-6726-4df7-a1d4-558925045765" />
    |        |
    
    
## 以上问题在改动后修复
