### PR TITLE
feat(lyric/setting): 新增全局歌词时间轴偏移功能

### DIFF
--- a/src/components/Player/FullPlayerMobile.vue
+++ b/src/components/Player/FullPlayerMobile.vue
@@ -167,7 +167,18 @@ let savedPageType: MobilePageType = "info";
 
       <div v-if="hasLyric" class="page lyric-page">
         <div class="lyric-header">
-          <s-image :src="musicStore.getSongCover('s')" cache-type="covers" class="lyric-cover" />
+          <div
+            class="lyric-cover"
+            data-no-page-swipe
+            @pointerdown.stop
+            @pointerup="onLyricCoverPointerUp"
+          >
+            <s-image
+              :src="musicStore.getSongCover('s')"
+              cache-type="covers"
+              class="lyric-cover-image"
+            />
+          </div>
           <div class="lyric-info">
             <div class="name text-hidden">
               {{
@@ -301,6 +312,66 @@ const pageIndex = ref(resolveSavedPageIndex(savedPageType));
 const pageTransitionDisabled = ref(false);
 const pageSwipeBlocked = ref(false);
 let pageTransitionTimer = 0;
+let lastLyricCoverTapAt = 0;
+let lastLyricCoverTapX = 0;
+let lastLyricCoverTapY = 0;
+
+const LYRIC_COVER_DOUBLE_TAP_DELAY = 320;
+const LYRIC_COVER_DOUBLE_TAP_DISTANCE = 24;
+
+const applyGlobalLyricOffsetToCurrentSong = () => {
+  if (!settingStore.globalLyricOffsetEnabled || !settingStore.globalLyricOffsetDoubleClickApply) {
+    return;
+  }
+  const currentSongId = musicStore.playSong?.id;
+  if (!currentSongId) return;
+
+  const offsetValue = settingStore.globalLyricOffsetValue;
+  const currentOffset = statusStore.getSongOffset(currentSongId);
+  const sign = offsetValue > 0 ? "+" : "";
+
+  if (settingStore.globalLyricOffsetAlwaysApply) {
+    if (currentOffset === offsetValue) {
+      statusStore.setSongOffset(currentSongId, -offsetValue);
+      window.$message?.success("本歌曲将临时关闭偏移");
+    } else {
+      statusStore.resetSongOffset(currentSongId);
+      window.$message?.success(`已恢复全局偏移: ${sign}${offsetValue}ms`);
+    }
+  } else {
+    if (currentOffset === offsetValue) {
+      statusStore.resetSongOffset(currentSongId);
+      window.$message?.success(`已关闭单曲偏移: ${sign}${offsetValue}ms`);
+    } else {
+      statusStore.setSongOffset(currentSongId, offsetValue);
+      window.$message?.success(`已开启单曲偏移: ${sign}${offsetValue}ms`);
+    }
+  }
+};
+
+// 歌词页封面使用双点，避免和移动端下滑手势冲突
+const onLyricCoverPointerUp = (event: PointerEvent) => {
+  event.stopPropagation();
+  if (event.cancelable) event.preventDefault();
+  if (event.pointerType === "mouse" && event.button !== 0) return;
+
+  const now = Date.now();
+  const dx = event.clientX - lastLyricCoverTapX;
+  const dy = event.clientY - lastLyricCoverTapY;
+  const isDoubleTap =
+    now - lastLyricCoverTapAt <= LYRIC_COVER_DOUBLE_TAP_DELAY &&
+    Math.hypot(dx, dy) <= LYRIC_COVER_DOUBLE_TAP_DISTANCE;
+
+  if (isDoubleTap) {
+    lastLyricCoverTapAt = 0;
+    applyGlobalLyricOffsetToCurrentSong();
+    return;
+  }
+
+  lastLyricCoverTapAt = now;
+  lastLyricCoverTapX = event.clientX;
+  lastLyricCoverTapY = event.clientY;
+};
 
 const lyricHeaderHorizontalPadding = computed(() => {
   const padding = Math.max(0, settingStore.lyricHorizontalOffset);
@@ -337,7 +408,8 @@ const dragHandleStyle = computed(() => {
   if (currentPageType.value === "lyric") {
     return {
       top: "calc(52px + var(--mobile-safe-top))",
-      left: "16px",
+      // 歌词页保留下滑手势，但避开左侧封面区域，防止封面双点被捕获层吃掉
+      left: "calc(20px + var(--lyric-h-offset, 0px) + 72px)",
       right: "72px",
       height: "74px",
     };
@@ -926,11 +998,20 @@ const contentTransform = computed(() => {
       }
 
       .lyric-cover {
+        position: relative;
+        z-index: 11;
         width: 50px;
         height: 50px;
         flex-shrink: 0;
         border-radius: 6px;
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+        overflow: hidden;
+        touch-action: manipulation;
+
+        .lyric-cover-image {
+          width: 100%;
+          height: 100%;
+        }
 
         :deep(img) {
           width: 100%;
@@ -1238,6 +1319,11 @@ const contentTransform = computed(() => {
           width: 64px;
           height: 64px;
           border-radius: 10px;
+
+          .lyric-cover-image {
+            width: 100%;
+            height: 100%;
+          }
 
           :deep(img) {
             border-radius: 10px;

--- a/src/components/Player/PlayerLyric/index.vue
+++ b/src/components/Player/PlayerLyric/index.vue
@@ -163,7 +163,12 @@ const offsetMilliseconds = computed({
     return statusStore.getSongOffset(currentSongId.value);
   },
   set: (val: number | null) => {
-    statusStore.setSongOffset(currentSongId.value, val || 0);
+    const settingStore = useSettingStore();
+    const globalOffset = (settingStore.globalLyricOffsetEnabled && settingStore.globalLyricOffsetAlwaysApply)
+      ? settingStore.globalLyricOffsetValue
+      : 0;
+    const localOffset = (val || 0) - globalOffset;
+    statusStore.setSongOffset(currentSongId.value, localOffset);
   },
 });
 
@@ -179,7 +184,7 @@ const changeOffset = (delta: number) => {
  * 重置进度偏移
  */
 const resetOffset = () => {
-  statusStore.resetSongOffset(currentSongId.value);
+  offsetMilliseconds.value = 0;
 };
 
 onMounted(() => {

--- a/src/components/Player/PlayerMeta/PlayerCover.vue
+++ b/src/components/Player/PlayerMeta/PlayerCover.vue
@@ -4,6 +4,8 @@
     v-if="settingStore.playerType === 'fullscreen' && !isPhone"
     class="full-screen"
     :style="{ '--gradient-percent': settingStore.playerFullscreenGradient + '%' }"
+    @pointerdown.stop
+    @pointerup="onCoverPointerUp"
   >
     <s-image
       :src="getCoverUrl('xl')"
@@ -19,6 +21,8 @@
   <div
     v-else
     :class="['player-cover', settingStore.playerType, { playing: statusStore.playStatus }]"
+    @pointerdown.stop
+    @pointerup="onCoverPointerUp"
   >
     <!-- 指针 -->
     <img
@@ -186,6 +190,63 @@ const getCoverUrl = (size: "s" | "m" | "l" | "xl" = "l") => {
     return localCoverDataUrl.value;
   }
   return musicStore.getSongCover(size);
+};
+
+// 双击封面切换当前歌曲的偏移状态
+const onDoubleClickCover = () => {
+  if (settingStore.globalLyricOffsetEnabled && settingStore.globalLyricOffsetDoubleClickApply) {
+    const currentSongId = musicStore.playSong?.id;
+    if (!currentSongId) return;
+
+    const offsetValue = settingStore.globalLyricOffsetValue;
+    const currentOffset = statusStore.getSongOffset(currentSongId);
+    const sign = offsetValue > 0 ? "+" : "";
+
+    if (settingStore.globalLyricOffsetAlwaysApply) {
+      if (currentOffset === offsetValue) {
+        statusStore.setSongOffset(currentSongId, -offsetValue);
+        window.$message?.success("本歌曲将临时关闭偏移");
+      } else {
+        statusStore.resetSongOffset(currentSongId);
+        window.$message?.success(`已恢复全局偏移: ${sign}${offsetValue}ms`);
+      }
+    } else {
+      if (currentOffset === offsetValue) {
+        statusStore.resetSongOffset(currentSongId);
+        window.$message?.success(`已关闭单曲偏移: ${sign}${offsetValue}ms`);
+      } else {
+        statusStore.setSongOffset(currentSongId, offsetValue);
+        window.$message?.success(`已开启单曲偏移: ${sign}${offsetValue}ms`);
+      }
+    }
+  }
+};
+
+let lastCoverTapAt = 0;
+let lastCoverTapX = 0;
+let lastCoverTapY = 0;
+const COVER_DOUBLE_TAP_DELAY = 320;
+const COVER_DOUBLE_TAP_DISTANCE = 24;
+
+const onCoverPointerUp = (event: PointerEvent) => {
+  if (event.pointerType === "mouse" && event.button !== 0) return;
+
+  const now = Date.now();
+  const dx = event.clientX - lastCoverTapX;
+  const dy = event.clientY - lastCoverTapY;
+  const isDoubleTap =
+    now - lastCoverTapAt <= COVER_DOUBLE_TAP_DELAY &&
+    Math.hypot(dx, dy) <= COVER_DOUBLE_TAP_DISTANCE;
+
+  if (isDoubleTap) {
+    lastCoverTapAt = 0;
+    onDoubleClickCover();
+    return;
+  }
+
+  lastCoverTapAt = now;
+  lastCoverTapX = event.clientX;
+  lastCoverTapY = event.clientY;
 };
 
 watch(

--- a/src/components/Player/PlayerQuickActionsMenu.vue
+++ b/src/components/Player/PlayerQuickActionsMenu.vue
@@ -250,6 +250,104 @@
           </div>
           <n-switch v-model:value="settingStore.lyricsBlur" :round="false" size="small" />
         </div>
+
+        <!-- 全局偏移 -->
+        <div class="qa-item">
+          <div class="qa-item-label">
+            <SvgIcon name="Forward5" :size="18" />
+            <span class="qa-item-text">全局偏移</span>
+          </div>
+          <n-switch v-model:value="settingStore.globalLyricOffsetEnabled" :round="false" size="small" />
+        </div>
+        
+        <div class="qa-item qa-volume" v-if="settingStore.globalLyricOffsetEnabled">
+          <div class="qa-item-label">
+            <SvgIcon name="Forward5" :size="18" />
+            <span class="qa-item-text">偏移数值</span>
+            <span class="qa-volume-value">{{ settingStore.globalLyricOffsetValue > 0 ? '+' : '' }}{{ settingStore.globalLyricOffsetValue }}ms</span>
+          </div>
+          <div class="qa-stepper">
+            <n-button
+              block
+              secondary
+              size="tiny"
+              :disabled="settingStore.globalLyricOffsetValue <= -10000"
+              @click="adjustGlobalLyricOffset(-50)"
+            >
+              -
+            </n-button>
+            <n-button
+              block
+              secondary
+              size="tiny"
+              :disabled="settingStore.globalLyricOffsetValue >= 10000"
+              @click="adjustGlobalLyricOffset(50)"
+            >
+              +
+            </n-button>
+          </div>
+        </div>
+
+        <div class="qa-item qa-volume" v-if="settingStore.globalLyricOffsetEnabled">
+          <div class="qa-presets" style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; width: 100%;">
+            <n-button block secondary size="tiny" @click="applyGlobalLyricOffsetPreset(0)">
+              0ms
+            </n-button>
+            <n-button block secondary size="tiny" @click="applyGlobalLyricOffsetPreset(250)">
+              {{ settingStore.globalLyricOffsetPresetSign === '-' ? '-250ms' : '+250ms' }}
+            </n-button>
+            <n-button block secondary size="tiny" @click="applyGlobalLyricOffsetPreset(500)">
+              {{ settingStore.globalLyricOffsetPresetSign === '-' ? '-500ms' : '+500ms' }}
+            </n-button>
+            <n-button block secondary size="tiny" @click="applyGlobalLyricOffsetPreset(850)">
+              {{ settingStore.globalLyricOffsetPresetSign === '-' ? '-850ms' : '+850ms' }}
+            </n-button>
+          </div>
+        </div>
+
+        <div class="qa-item qa-volume" v-if="settingStore.globalLyricOffsetEnabled">
+          <div class="qa-item-label">
+            <SvgIcon name="LibraryMusic" :size="18" />
+            <span class="qa-item-text">快捷预设单位</span>
+            <span class="qa-volume-value">{{ settingStore.globalLyricOffsetPresetSign }}</span>
+          </div>
+          <div class="qa-stepper">
+            <n-button
+              block
+              size="tiny"
+              :type="settingStore.globalLyricOffsetPresetSign === '+' ? 'primary' : 'default'"
+              :secondary="settingStore.globalLyricOffsetPresetSign === '+'"
+              @click="settingStore.globalLyricOffsetPresetSign = '+'"
+            >
+              +
+            </n-button>
+            <n-button
+              block
+              size="tiny"
+              :type="settingStore.globalLyricOffsetPresetSign === '-' ? 'primary' : 'default'"
+              :secondary="settingStore.globalLyricOffsetPresetSign === '-'"
+              @click="settingStore.globalLyricOffsetPresetSign = '-'"
+            >
+              -
+            </n-button>
+          </div>
+        </div>
+
+        <div class="qa-item" v-if="settingStore.globalLyricOffsetEnabled">
+          <div class="qa-item-label">
+            <SvgIcon name="Forward5" :size="18" />
+            <span class="qa-item-text">始终启用偏移</span>
+          </div>
+          <n-switch v-model:value="settingStore.globalLyricOffsetAlwaysApply" :round="false" size="small" />
+        </div>
+
+        <div class="qa-item" v-if="settingStore.globalLyricOffsetEnabled">
+          <div class="qa-item-label">
+            <SvgIcon name="Album" :size="18" />
+            <span class="qa-item-text">双击封面开关</span>
+          </div>
+          <n-switch v-model:value="settingStore.globalLyricOffsetDoubleClickApply" :round="false" size="small" />
+        </div>
       </div>
     </div>
   </n-popover>
@@ -324,6 +422,19 @@ const adjustLandscapeCoverOffset = (delta: number) => {
     LANDSCAPE_COVER_OFFSET_MIN,
     LANDSCAPE_COVER_OFFSET_MAX,
   );
+};
+
+const adjustGlobalLyricOffset = (delta: number) => {
+  settingStore.globalLyricOffsetValue = clampValue(
+    settingStore.globalLyricOffsetValue + delta,
+    -10000,
+    10000,
+  );
+};
+
+const applyGlobalLyricOffsetPreset = (value: number) => {
+  const signMultiplier = settingStore.globalLyricOffsetPresetSign === "-" ? -1 : 1;
+  settingStore.globalLyricOffsetValue = value * signMultiplier;
 };
 
 const adjustLandscapeLyricPadding = (delta: number) => {

--- a/src/components/Setting/config/lyric.ts
+++ b/src/components/Setting/config/lyric.ts
@@ -463,6 +463,66 @@ export const useLyricSettings = (): SettingConfig => {
             }),
           },
           {
+            key: "globalLyricOffsetEnabled",
+            label: "全局歌词偏移",
+            type: "switch",
+            description: "是否启用全局歌词时间轴偏移",
+            value: computed({
+              get: () => settingStore.globalLyricOffsetEnabled,
+              set: (v) => (settingStore.globalLyricOffsetEnabled = v),
+            }),
+            children: [
+              {
+                key: "globalLyricOffsetValue",
+                label: "偏移数值",
+                type: "input-number",
+                description: "全局歌词偏移数值 (+ -)，单位毫秒",
+                min: -10000,
+                max: 10000,
+                step: 10,
+                suffix: "ms",
+                value: computed({
+                  get: () => settingStore.globalLyricOffsetValue,
+                  set: (v) => (settingStore.globalLyricOffsetValue = v || 0),
+                }),
+              },
+              {
+                key: "globalLyricOffsetPresetSign",
+                label: "快捷预设单位",
+                type: "select",
+                description: "快捷开关中的预设数值符号 (+ 或 -)",
+                options: [
+                  { label: "+", value: "+" },
+                  { label: "-", value: "-" },
+                ],
+                value: computed({
+                  get: () => settingStore.globalLyricOffsetPresetSign,
+                  set: (v) => (settingStore.globalLyricOffsetPresetSign = v),
+                }),
+              },
+              {
+                key: "globalLyricOffsetAlwaysApply",
+                label: "始终启用偏移",
+                type: "switch",
+                description: "开启后，任何歌曲播放时都将默认应用该偏移数值",
+                value: computed({
+                  get: () => settingStore.globalLyricOffsetAlwaysApply,
+                  set: (v) => (settingStore.globalLyricOffsetAlwaysApply = v),
+                }),
+              },
+              {
+                key: "globalLyricOffsetDoubleClickApply",
+                label: "双击歌词页封面应用偏移",
+                type: "switch",
+                description: "开启后，双击歌词页封面可应用当前全局偏移",
+                value: computed({
+                  get: () => settingStore.globalLyricOffsetDoubleClickApply,
+                  set: (v) => (settingStore.globalLyricOffsetDoubleClickApply = v),
+                }),
+              },
+            ],
+          },
+          {
             key: "lyricOffsetStep",
             label: "歌词时延调节步长",
             type: "input-number",

--- a/src/stores/setting.ts
+++ b/src/stores/setting.ts
@@ -425,6 +425,16 @@ export interface SettingState {
     time: boolean;
     description: boolean;
   };
+  /** 全局歌词时间轴偏移开关 */
+  globalLyricOffsetEnabled: boolean;
+  /** 全局歌词时间轴偏移数值 (ms) */
+  globalLyricOffsetValue: number;
+  /** 全局歌词时间轴快捷预设单位符号 */
+  globalLyricOffsetPresetSign: "+" | "-";
+  /** 双击歌词页封面应用全局偏移 */
+  globalLyricOffsetDoubleClickApply: boolean;
+  /** 始终启用全局偏移 */
+  globalLyricOffsetAlwaysApply: boolean;
   /** 全屏播放器界面元素显示配置 */
   fullscreenPlayerElements: {
     like: boolean;
@@ -758,6 +768,11 @@ export const useSettingStore = defineStore("setting", {
       time: true,
       description: true,
     },
+    globalLyricOffsetEnabled: false,
+    globalLyricOffsetValue: 0,
+    globalLyricOffsetPresetSign: "+",
+    globalLyricOffsetDoubleClickApply: false,
+    globalLyricOffsetAlwaysApply: false,
     fullscreenPlayerElements: {
       like: true,
       addToPlaylist: true,

--- a/src/stores/status.ts
+++ b/src/stores/status.ts
@@ -11,6 +11,7 @@ import type {
 import type { RepeatModeType, ShuffleModeType } from "@/types/shared/play-mode";
 import { isDevBuild } from "@/utils/env";
 import { defineStore } from "pinia";
+import { useSettingStore } from "./setting";
 
 interface StatusState {
   /** 菜单折叠状态 */
@@ -335,7 +336,14 @@ export const useStatusStore = defineStore("status", {
     getSongOffset(songId?: number): number {
       if (!songId) return 0;
       const offsetTime = this.currentTimeOffsetMap?.[songId] ?? 0;
-      return Math.floor(offsetTime * 1000);
+      const baseOffset = Math.floor(offsetTime * 1000);
+      
+      // 注意：这里需要动态导入 settingStore 避免循环依赖
+      const settingStore = useSettingStore();
+      if (settingStore.globalLyricOffsetEnabled && settingStore.globalLyricOffsetAlwaysApply) {
+        return baseOffset + settingStore.globalLyricOffsetValue;
+      }
+      return baseOffset;
     },
     /**
      * 设置指定歌曲的偏移
@@ -362,12 +370,13 @@ export const useStatusStore = defineStore("status", {
      */
     incSongOffset(songId?: number, delta: number = 500) {
       if (!songId) return;
-      const current = this.getSongOffset(songId);
-      const next = current + delta;
-      if (next === 0) {
+      const offsetTime = this.currentTimeOffsetMap?.[songId] ?? 0;
+      const currentLocal = Math.floor(offsetTime * 1000);
+      const nextLocal = currentLocal + delta;
+      if (nextLocal === 0) {
         delete this.currentTimeOffsetMap[songId];
       } else {
-        this.setSongOffset(songId, next);
+        this.setSongOffset(songId, nextLocal);
       }
     },
     /** 重置指定歌曲的偏移为 0 */


### PR DESCRIPTION
- 新增全局歌词偏移相关的状态配置到设置存储 
- 在设置页面添加全局歌词偏移的完整配置选项 
- 在播放器快捷菜单中集成全局歌词偏移的快速调节控件 
- 为桌面端与移动端播放器封面添加双击应用全局偏移的交互 
- 优化移动端歌词页封面的手势交互避免冲突 
 
## 📌 变更类型 
 
<!-- 勾选一项或多项 --> 
 
- [x] ✨ feat — 新功能 
- [ ] 🐞 fix — Bug 修复 
- [ ] 🎨 style — 仅样式 / 格式，不影响逻辑 
- [ ] ♻️ refactor — 重构，不改变外部行为 
- [ ] ⚡ perf — 性能优化 
- [ ] 📝 docs — 仅文档 
- [ ] 🧪 test — 新增 / 修改测试 
- [ ] 🔧 chore — 构建 / 脚本 / 依赖 
- [ ] 🚀 ci — 仅 CI 配置 
- [ ] ⏪ revert — 回滚 
 
## 📝 变更说明 
 
<!-- 清晰说明 **改了什么** 与 **为什么改**，而不是逐行复述 diff --> 

**改了什么：**
1. **状态与设置**：在 `settingStore` 中新增了全局歌词偏移相关的状态（开关、数值、快捷预设符号、双击应用、始终应用等），并在全局设置页面中添加了对应的配置选项。
2. **快捷控件**：在播放器快捷动作菜单（`PlayerQuickActionsMenu`）中集成了全局歌词偏移的快速调节面板与快捷预设按钮。
3. **交互扩展**：在桌面端和移动端播放器封面（`PlayerCover`）及歌词页封面中加入了双击手势逻辑，用于快速开启或临时关闭单曲/全局偏移，并伴有全局的提示消息（Message）。
4. **状态计算**：重构了 `statusStore` 中的时间轴偏移获取和设置逻辑，将全局偏移与单曲偏移的计算结合在一起。
5. **手势优化**：自定义了基于 `pointerup` 的双击判断逻辑（通过计算延迟与距离判断 `isDoubleTap`），以避免与移动端歌词页面的原生下拉滑动事件产生冲突。

**为什么改：**
- 提升了在遇到多首歌曲歌词时间轴不准时的调节效率，用户无需再逐首调整。
- 引入双击封面应用偏移的快捷操作，进一步增强了听歌时的沉浸感与交互便捷度。
- 解决移动端封面双击事件和原生滑动事件之间的冲突问题，保证交互流畅性。
 
## 🔗 关联 Issue 
 
<!-- 用 Closes / Fixes 关键字关联，会在合并时自动关闭对应 Issue --> 
 
Closes # 
 
## 📱 影响范围 
 
<!-- 勾选此 PR 实际影响到的模块 --> 
 
- [ ] 🎵 播放引擎 / 音频 
- [x] 📝 歌词 / 桌面歌词 
- [ ] 🔔 通知栏 / MediaSession 
- [ ] 🌐 在线音乐 (网易云 / Jellyfin / Navidrome / Emby / Subsonic / Last.fm) 
- [ ] 🧩 内置 API (nodejs-mobile) 
- [x] 🎨 UI / 主题 / 布局 
- [ ] 📦 构建 / 打包 / 签名 
- [ ] 📱 Capacitor / 原生 Android 代码 
- [ ] 📄 文档 / README 
 
## ✅ 自检清单 
 
- [x] 本 PR **目标分支为 `dev`** 
- [x] 本地已执行 `pnpm lint` 且无 warning 
- [x] 本地已执行 `pnpm typecheck` 且无报错 
- [x] 已在 **至少一台真机** 上构建并验证关键路径 
- [x] UI 改动已兼顾 **手机竖屏 + 平板横屏** 两种布局 
- [x] 新增 / 修改的文案使用中文，与项目整体风格一致 
- [x] 未引入不必要的依赖 / 大体积资源 
- [x] 未修改签名密钥 / CI Secrets 相关文件 
 
## 🧪 测试方式 
 
<!-- 评审者如何验证这次改动 --> 
 
1. 在“设置-歌词”或播放器快捷菜单中，开启“全局歌词偏移”并调整偏移数值。
2. 播放一首歌曲，双击播放器封面或移动端歌词页封面，观察是否成功应用或关闭当前歌曲的偏移（应有 Message 提示）。
3. 检查移动端歌词页面，测试页面的下拉滑动是否正常工作，且双击封面不会引发滑动冲突。
4. 开启“始终启用偏移”选项，切换下一首歌曲，验证全局偏移量是否默认生效。
 